### PR TITLE
Use PyTorch v1.5 for circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,6 +42,7 @@ install_dep: &install_dep
   - run:
       name: Install Dependencies
       command: |
+        pip install --progress-bar off torch==1.5.1+cu101 -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off -r requirements-test.txt
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,6 +4,6 @@ isort == 4.3.21
 mypy == 0.770
 pytest == 5.4.1
 torchtext == 0.6.0
-torch == 1.4.0
-# NOTE(msb) not a dependency but needed by torch == 1.4.0
+torch == 1.5.1
+# NOTE(msb) not a dependency but needed by torch
 numpy == 1.17.4


### PR DESCRIPTION
We need PyTorch v1.5 in order to test with GradScaler.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
