### PR TITLE
Aligning OSS state dict with `https://pytorch.org/docs/stable/_module…

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -127,7 +127,7 @@ class OSS(Optimizer):
             len(self._all_states) > 0
         ), "The optimizer state is not materialized, please call consolidate_state_dict on every replica beforehand"
 
-        return {"states": self._all_states}
+        return {"state": self._all_states, "param_groups": self.param_groups}
 
     def load_local_state_dict(self, state_dict: dict) -> None:
         """ Loads this rank's state_dict. """
@@ -140,7 +140,7 @@ class OSS(Optimizer):
     def load_state_dict(self, state_dict: Dict[str, Any]) -> None:
         """ Loads this rank's optimizer state_dict, given the global optimizer state. """
         # Dispatch this rank's state dictionary to the local load
-        self.load_local_state_dict(state_dict["states"][self.rank])
+        self.load_local_state_dict(state_dict["state"][self.rank])
 
     def add_param_group(self, param_group: dict) -> None:
         super().add_param_group(param_group)

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -222,7 +222,7 @@ def run_test_collect_shards(rank, world_size, reference_rank):
     # - load it again
     if rank == reference_rank:
         optimizer_state_dict = optimizer.state_dict()
-        assert len(optimizer_state_dict["states"]) == world_size
+        assert len(optimizer_state_dict["state"]) == world_size
     else:
         optimizer_state_dict = {}
 


### PR DESCRIPTION
Align the state dictionary reported by OSS to what the default torch optimizer holds 
See https://pytorch.org/docs/stable/_modules/torch/optim/optimizer.html#Optimizer

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [0] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Partial fix of #28 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
