### PR TITLE
[fix] OSS restore state to proper device

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -149,7 +149,7 @@ class OSS(Optimizer):
 
         # Restore the global param_groups
         self.param_groups = recursive_copy_to_device(
-            state_dict["param_groups"], non_blocking=False, device=self._device
+            state_dict["param_groups"], non_blocking=True, device=self._device
         )
 
     def add_param_group(self, param_group: dict) -> None:

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -148,9 +148,7 @@ class OSS(Optimizer):
         self.load_local_state_dict(state_dict["state"][self.rank])
 
         # Restore the global param_groups
-        self.param_groups = recursive_copy_to_device(
-            state_dict["param_groups"], non_blocking=True, device=self._device
-        )
+        self.param_groups = recursive_copy_to_device(state_dict["param_groups"], non_blocking=True, device=self._device)
 
     def add_param_group(self, param_group: dict) -> None:
         super().add_param_group(param_group)

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -148,7 +148,9 @@ class OSS(Optimizer):
         self.load_local_state_dict(state_dict["state"][self.rank])
 
         # Restore the global param_groups
-        self.param_groups = state_dict["param_groups"]
+        self.param_groups = recursive_copy_to_device(
+            state_dict["param_groups"], non_blocking=False, device=self._device
+        )
 
     def add_param_group(self, param_group: dict) -> None:
         super().add_param_group(param_group)

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -63,7 +63,7 @@ def test_state_dict():
     assert x == torch.tensor([0.9], device=DEVICE)
 
     # Check that the exposed param_groups are on the proper device
-    assert o.param_groups[0]["params"][0].device == DEVICE
+    assert o.param_groups[0]["params"][0].device == x.device
 
 
 def test_local_state_dict():

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -62,6 +62,9 @@ def test_state_dict():
     o.step()
     assert x == torch.tensor([0.9], device=DEVICE)
 
+    # Check that the exposed param_groups are on the proper device
+    assert o.param_groups[0]["params"][0].device == DEVICE
+
 
 def test_local_state_dict():
     x = torch.tensor([1.0], device=DEVICE, requires_grad=True)


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes the state pull and push behavior to being something more easily predictable, when a state is pulled it gets moved to CPU (failsafe if this is a reasonably big model). Upon restore the `param_groups` were not restored to the proper device. It looks like there are still probable duplicates in that field though

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
