### PR TITLE
Support optimizer state sharding for megatron

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -376,7 +376,7 @@ class OSS(Optimizer):
                 logging.debug(
                     "Sending the sharded optimizer state to the reference replica from rank %s", rank,
                 )
-                broadcast_object(empty_buffer, src_rank=self.global_rank, group=self.group, dist_device=self._device)
+                broadcast_object(self.local_state_dict(), src_rank=self.global_rank, group=self.group, dist_device=self._device)
             else:
                 global_rank = self.get_global_rank(self.group, rank)
                 # Discard this tensor/rank, broadcast necessary for syncing

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -72,6 +72,8 @@ class OSS(Optimizer):
         self.world_size = dist.get_world_size(self.group)
 
         self.rank = dist.get_rank(self.group)
+        self.global_rank = self.get_global_rank(self.group, self.rank)
+
         self.optim = optim(self.partition_parameters()[self.rank], **default)
 
         #  Optional consolidated optimizer state
@@ -88,7 +90,7 @@ class OSS(Optimizer):
 
     # Partition helpers
     def partition_parameters(self) -> List[List[dict]]:
-        """Partitions parameters across distributed ranks.
+        """Partitions parameters across distributed data parallel ranks.
 
         Returns a list of param_groups (which is a list of dict) where each
         element of the list contains the param_groups for a rank. Element 0
@@ -135,12 +137,20 @@ class OSS(Optimizer):
 
     @property
     def param_to_rank(self) -> Dict[torch.Tensor, int]:
+        '''param to data parallel rank'''
         if len(self._param_rank) == 0:
             for rank, param_groups in enumerate(self.partition_parameters()):
                 for param_group in param_groups:
                     for param in param_group["params"]:
                         self._param_rank[param] = rank
         return self._param_rank
+
+    def get_global_rank(self, group, rank):
+        if group is dist.group.WORLD:
+            return rank
+        else:
+            global_rank = dist.distributed_c10d._get_global_rank(group, rank)
+        return global_rank
 
     # NOTE(msb) We add a kwargs in order to support Optimizer sub-classes that support extra kwargs.
     # For example, the apex library contains fused optimizers with a step that supports extra kwargs.
@@ -172,14 +182,15 @@ class OSS(Optimizer):
                     # Gloo will rightly assert on this operation for any tensor that requires grad.
                     # We save and restore the grad requirement state to work around that, in our case
                     # the grad is only useful on the source rank.
+                    global_rank = self.get_global_rank(self.group, rank)
+
                     requires_grad.append((param, param.requires_grad))
                     param.requires_grad = False
-                    requests.append(dist.broadcast(tensor=param, src=rank, group=self.group, async_op=True))
+                    requests.append(dist.broadcast(tensor=param, src=global_rank, group=self.group, async_op=True))
 
         for fut, req_grad in zip(requests, requires_grad):
             fut.wait()
             req_grad[0].requires_grad = req_grad[1]
-
         return loss
 
     def local_state_dict(self) -> dict:
@@ -328,7 +339,7 @@ class OSS(Optimizer):
         empty_buffer = torch.tensor([0], dtype=torch.uint8, device=self._device)
         all_states: List[Dict[str, Any]] = []
 
-        for rank in range(dist.get_world_size(group=self.group)):
+        for rank in range(self.world_size):
             if rank == self.rank:
                 logging.debug("Saving self state")
                 all_states.append(
@@ -336,12 +347,13 @@ class OSS(Optimizer):
                 )
 
                 # Sync with other replicas
-                broadcast_object(empty_buffer, src_rank=rank, group=self.group, dist_device=self._device)
+                broadcast_object(empty_buffer, src_rank=self.global_rank, group=self.group, dist_device=self._device)
             else:
                 # Fetch the optim state from the other replicas
-                logging.debug("Receiving state from rank %s ", rank)
+                global_rank = self.get_global_rank(self.group, rank)
+                logging.debug("Receiving state from rank %s ", global_rank)
                 replica_state = broadcast_object(
-                    empty_buffer, src_rank=rank, group=self.group, dist_device=self._device
+                    empty_buffer, src_rank=global_rank, group=self.group, dist_device=self._device
                 )
 
                 all_states.append(
@@ -356,14 +368,15 @@ class OSS(Optimizer):
         """Broadcast this rank's state shard, discard others"""
         empty_buffer = torch.tensor([0], dtype=torch.uint8, device=self._device)
 
-        for rank in range(dist.get_world_size(group=self.group)):
+        for rank in range(self.world_size):
             if rank == self.rank:
                 # Send the state to the reference replica
                 logging.debug(
                     "Sending the sharded optimizer state to the reference replica from rank %s", rank,
                 )
-                broadcast_object(self.local_state_dict(), src_rank=rank, group=self.group, dist_device=self._device)
+                broadcast_object(empty_buffer, src_rank=self.global_rank, group=self.group, dist_device=self._device)
             else:
+                global_rank = self.get_global_rank(self.group, rank)
                 # Discard this tensor/rank, broadcast necessary for syncing
-                logging.debug("Discarding broadcast from rank %s", rank)
-                broadcast_object(empty_buffer, src_rank=rank, group=self.group, dist_device=self._device)
+                logging.debug("Discarding broadcast from rank %s", global_rank)
+                broadcast_object(empty_buffer, src_rank=global_rank, group=self.group, dist_device=self._device)

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -393,3 +393,4 @@ class OSS(Optimizer):
             for p in partition:
                 for t in p["params"]:
                     t.grad = None
+                    


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #115.  Previously, optimizer state sharding was causing incorrect results when used with model parallel. This resolves the issue. In order to use this with Fairseq, you'll also need to use the [version of Fairseq from the PR I opened there](https://github.com/fairinternal/fairseq-py/pull/1326).

## Test Plan
I confirmed that zero-sharding gives the same results in the model parallel case:
```
python fairseq_train.py --task masked_lm /checkpoint/bioseq_nonsecure/model-parallel-data/tiny_sample_valid_ur50-bin  --dataset-impl fasta  --save-dir checkpoints/zero-0-mp-1    --dropout 0.1   --optimizer adam --adam-betas '(0.9, 0.98)' --weight-decay 0.01 --clip-norm 0.0   --lr 0.0005 --lr-scheduler inverse_sqrt --warmup-updates 4000 --warmup-init-lr 1e-07   --tokens-per-sample 128 --sample-break-mode none   --max-tokens 128 --memory-efficient-fp16 --no-progress-bar --log-interval 1 --seed 4 --max-epoch 1 --max-update 50 --encoder-layers 4 --no-save  --arch model_parallel_roberta_large --model-parallel-size 2 --update-freq 2 --zero-sharding os

2020-09-30 20:06:34 | INFO | train_inner | epoch 001:      2 / 78 loss_scale=32, train_wall=2, wall=24
2020-09-30 20:06:36 | INFO | fairseq.trainer | NOTE: overflow detected, setting loss scale to: 16.0
2020-09-30 20:06:36 | INFO | train_inner | epoch 001:      3 / 78 loss_scale=16, train_wall=2, wall=26
2020-09-30 20:06:39 | INFO | train_inner | epoch 001:      4 / 78 loss=1.006, ppl=2.01, wps=0, ups=0, wpb=1024, bsz=8, num_updates=1, lr=2.24975e-07, gnorm=0.056, loss_scale=16, train_wall=3, wall=29
2020-09-30 20:06:42 | INFO | train_inner | epoch 001:      5 / 78 loss=0.97, ppl=1.96, wps=324.5, ups=0.32, wpb=1024, bsz=8, num_updates=2, lr=3.4995e-07, gnorm=0.053, loss_scale=16, train_wall=3, wall=33
2020-09-30 20:06:45 | INFO | train_inner | epoch 001:      6 / 78 loss=0.959, ppl=1.94, wps=358.7, ups=0.35, wpb=1024, bsz=8, num_updates=3, lr=4.74925e-07, gnorm=0.057, loss_scale=16, train_wall=3, wall=35
2020-09-30 20:06:49 | INFO | train_inner | epoch 001:      7 / 78 loss=0.966, ppl=1.95, wps=316.2, ups=0.31, wpb=1024, bsz=8, num_updates=4, lr=5.999e-07, gnorm=0.057, loss_scale=16, train_wall=3, wall=39
2020-09-30 20:06:51 | INFO | fairseq.trainer | NOTE: overflow detected, setting loss scale to: 8.0
2020-09-30 20:06:51 | INFO | train_inner | epoch 001:      8 / 78 loss=None, ppl=0, wps=0, ups=0, wpb=None, bsz=None, num_updates=None, lr=None, gnorm=None, loss_scale=8, train_wall=2, wall=41
2020-09-30 20:06:54 | INFO | train_inner | epoch 001:      9 / 78 loss=1.022, ppl=2.03, wps=347.4, ups=0.34, wpb=1024, bsz=8, num_updates=5, lr=7.24875e-07, gnorm=0.066, loss_scale=8, train_wall=3, wall=44
2020-09-30 20:06:57 | INFO | train_inner | epoch 001:     10 / 78 loss=1.008, ppl=2.01, wps=301.4, ups=0.29, wpb=1024, bsz=8, num_updates=6, lr=8.4985e-07, gnorm=0.074, loss_scale=8, train_wall=3, wall=47

python fairseq_train.py --task masked_lm /checkpoint/bioseq_nonsecure/model-parallel-data/tiny_sample_valid_ur50-bin  --dataset-impl fasta  --save-dir checkpoints/zero-0-mp-1    --dropout 0.1   --optimizer adam --adam-betas '(0.9, 0.98)' --weight-decay 0.01 --clip-norm 0.0   --lr 0.0005 --lr-scheduler inverse_sqrt --warmup-updates 4000 --warmup-init-lr 1e-07   --tokens-per-sample 128 --sample-break-mode none   --max-tokens 128 --memory-efficient-fp16 --no-progress-bar --log-interval 1 --seed 4 --max-epoch 1 --max-update 50 --encoder-layers 4 --no-save  --arch model_parallel_roberta_large --model-parallel-size 2 --update-freq 2
2020-09-30 20:08:50 | INFO | train_inner | epoch 001:      2 / 78 loss_scale=32, train_wall=2, wall=25
2020-09-30 20:08:52 | INFO | fairseq.trainer | NOTE: overflow detected, setting loss scale to: 16.0
2020-09-30 20:08:52 | INFO | train_inner | epoch 001:      3 / 78 loss_scale=16, train_wall=2, wall=27
2020-09-30 20:08:55 | INFO | train_inner | epoch 001:      4 / 78 loss=1.006, ppl=2.01, wps=0, ups=0, wpb=1024, bsz=8, num_updates=1, lr=2.24975e-07, gnorm=0.056, loss_scale=16, train_wall=3, wall=30
2020-09-30 20:08:58 | INFO | train_inner | epoch 001:      5 / 78 loss=0.97, ppl=1.96, wps=290.5, ups=0.28, wpb=1024, bsz=8, num_updates=2, lr=3.4995e-07, gnorm=0.053, loss_scale=16, train_wall=3, wall=34
2020-09-30 20:09:02 | INFO | train_inner | epoch 001:      6 / 78 loss=0.959, ppl=1.94, wps=294.5, ups=0.29, wpb=1024, bsz=8, num_updates=3, lr=4.74925e-07, gnorm=0.057, loss_scale=16, train_wall=3, wall=38
2020-09-30 20:09:05 | INFO | train_inner | epoch 001:      7 / 78 loss=0.966, ppl=1.95, wps=295.1, ups=0.29, wpb=1024, bsz=8, num_updates=4, lr=5.999e-07, gnorm=0.057, loss_scale=16, train_wall=3, wall=41
2020-09-30 20:09:07 | INFO | fairseq.trainer | NOTE: overflow detected, setting loss scale to: 8.0
2020-09-30 20:09:07 | INFO | train_inner | epoch 001:      8 / 78 loss=None, ppl=0, wps=0, ups=0, wpb=None, bsz=None, num_updates=None, lr=None, gnorm=None, loss_scale=8, train_wall=2, wall=43
2020-09-30 20:09:10 | INFO | train_inner | epoch 001:      9 / 78 loss=1.022, ppl=2.03, wps=382.3, ups=0.37, wpb=1024, bsz=8, num_updates=5, lr=7.24875e-07, gnorm=0.066, loss_scale=8, train_wall=3, wall=46
2020-09-30 20:09:14 | INFO | train_inner | epoch 001:     10 / 78 loss=1.008, ppl=2.01, wps=289.3, ups=0.28, wpb=1024, bsz=8, num_updates=6, lr=8.4985e-07, gnorm=0.074, loss_scale=8, train_wall=3, wall=49
```

And also in the data parallel only case:
```
python fairseq_train.py --task masked_lm /checkpoint/bioseq_nonsecure/model-parallel-data/tiny_sample_valid_ur50-bin  --dataset-impl fasta  --save-dir checkpoints/zero-0-mp-1    --dropout 0.1   --optimizer adam --adam-betas '(0.9, 0.98)' --weight-decay 0.01 --clip-norm 0.0   --lr 0.0005 --lr-scheduler inverse_sqrt --warmup-updates 4000 --warmup-init-lr 1e-07   --tokens-per-sample 128 --sample-break-mode none   --max-tokens 128 --memory-efficient-fp16 --no-progress-bar --log-interval 1 --seed 4 --max-epoch 1 --max-update 50 --encoder-layers 4 --no-save  --arch roberta_large --update-freq 2  --zero-sharding os

2020-09-30 21:42:51 | INFO | train_inner | epoch 001:      1 / 39 loss=0.932, ppl=1.91, wps=0, ups=0, wpb=2048, bsz=16, num_updates=1, lr=2.24975e-07, gnorm=0.046, loss_scale=128, train_wall=6, wall=12
2020-09-30 21:42:54 | INFO | train_inner | epoch 001:      2 / 39 loss=0.941, ppl=1.92, wps=793.3, ups=0.39, wpb=2048, bsz=16, num_updates=2, lr=3.4995e-07, gnorm=0.056, loss_scale=128, train_wall=3, wall=15
2020-09-30 21:42:56 | INFO | train_inner | epoch 001:      3 / 39 loss=0.933, ppl=1.91, wps=769.6, ups=0.37, wpb=2048, bsz=16, num_updates=3, lr=4.74925e-07, gnorm=0.052, loss_scale=128, train_wall=3, wall=18
2020-09-30 21:42:59 | INFO | train_inner | epoch 001:      4 / 39 loss=0.957, ppl=1.94, wps=777.1, ups=0.38, wpb=2048, bsz=16, num_updates=4, lr=5.999e-07, gnorm=0.057, loss_scale=128, train_wall=3, wall=20
2020-09-30 21:43:02 | INFO | train_inner | epoch 001:      5 / 39 loss=0.92, ppl=1.89, wps=769.5, ups=0.37, wpb=2048, bsz=16, num_updates=5, lr=7.24875e-07, gnorm=0.057, loss_scale=128, train_wall=3, wall=23
2020-09-30 21:43:04 | INFO | train_inner | epoch 001:      6 / 39 loss=0.935, ppl=1.91, wps=788.5, ups=0.38, wpb=2048, bsz=16, num_updates=6, lr=8.4985e-07, gnorm=0.047, loss_scale=128, train_wall=3, wall=26
2020-09-30 21:43:07 | INFO | train_inner | epoch 001:      7 / 39 loss=0.944, ppl=1.92, wps=793, ups=0.39, wpb=2048, bsz=16, num_updates=7, lr=9.74825e-07, gnorm=0.075, loss_scale=128, train_wall=3, wall=28
2020-09-30 21:43:10 | INFO | train_inner | epoch 001:      8 / 39 loss=0.95, ppl=1.93, wps=789, ups=0.38, wpb=2048, bsz=16, num_updates=8, lr=1.0998e-06, gnorm=0.061, loss_scale=128, train_wall=3, wall=31
2020-09-30 21:43:12 | INFO | train_inner | epoch 001:      9 / 39 loss=0.946, ppl=1.93, wps=777.1, ups=0.38, wpb=2048, bsz=16, num_updates=9, lr=1.22478e-06, gnorm=0.044, loss_scale=128, train_wall=3, wall=34
2020-09-30 21:43:15 | INFO | train_inner | epoch 001:     10 / 39 loss=0.93, ppl=1.91, wps=781.2, ups=0.38, wpb=2048, bsz=16, num_updates=10, lr=1.34975e-06, gnorm=0.045, loss_scale=128, train_wall=3, wall=36

python fairseq_train.py --task masked_lm /checkpoint/bioseq_nonsecure/model-parallel-data/tiny_sample_valid_ur50-bin  --dataset-impl fasta  --save-dir checkpoints/zero-0-mp-1    --dropout 0.1   --optimizer adam --adam-betas '(0.9, 0.98)' --weight-decay 0.01 --clip-norm 0.0   --lr 0.0005 --lr-scheduler inverse_sqrt --warmup-updates 4000 --warmup-init-lr 1e-07   --tokens-per-sample 128 --sample-break-mode none   --max-tokens 128 --memory-efficient-fp16 --no-progress-bar --log-interval 1 --seed 4 --max-epoch 1 --max-update 50 --encoder-layers 4 --no-save  --arch roberta_large --update-freq 2  --zero-sharding os

2020-09-30 21:44:19 | INFO | train_inner | epoch 001:      1 / 39 loss=0.932, ppl=1.91, wps=0, ups=0, wpb=2048, bsz=16, num_updates=1, lr=2.24975e-07, gnorm=0.046, loss_scale=128, train_wall=8, wall=13
2020-09-30 21:44:22 | INFO | train_inner | epoch 001:      2 / 39 loss=0.941, ppl=1.92, wps=605, ups=0.29, wpb=2048, bsz=16, num_updates=2, lr=3.4995e-07, gnorm=0.056, loss_scale=128, train_wall=3, wall=17
2020-09-30 21:44:26 | INFO | train_inner | epoch 001:      3 / 39 loss=0.933, ppl=1.91, wps=555.2, ups=0.27, wpb=2048, bsz=16, num_updates=3, lr=4.74925e-07, gnorm=0.052, loss_scale=128, train_wall=4, wall=21
2020-09-30 21:44:29 | INFO | train_inner | epoch 001:      4 / 39 loss=0.957, ppl=1.94, wps=614.4, ups=0.3, wpb=2048, bsz=16, num_updates=4, lr=5.999e-07, gnorm=0.057, loss_scale=128, train_wall=3, wall=24
2020-09-30 21:44:33 | INFO | train_inner | epoch 001:      5 / 39 loss=0.92, ppl=1.89, wps=559.2, ups=0.27, wpb=2048, bsz=16, num_updates=5, lr=7.24875e-07, gnorm=0.057, loss_scale=128, train_wall=4, wall=28
2020-09-30 21:44:37 | INFO | train_inner | epoch 001:      6 / 39 loss=0.935, ppl=1.91, wps=518.1, ups=0.25, wpb=2048, bsz=16, num_updates=6, lr=8.4985e-07, gnorm=0.047, loss_scale=128, train_wall=4, wall=32
2020-09-30 21:44:41 | INFO | train_inner | epoch 001:      7 / 39 loss=0.944, ppl=1.92, wps=562.9, ups=0.27, wpb=2048, bsz=16, num_updates=7, lr=9.74825e-07, gnorm=0.075, loss_scale=128, train_wall=4, wall=35
2020-09-30 21:44:45 | INFO | train_inner | epoch 001:      8 / 39 loss=0.95, ppl=1.93, wps=532.1, ups=0.26, wpb=2048, bsz=16, num_updates=8, lr=1.0998e-06, gnorm=0.061, loss_scale=128, train_wall=4, wall=39
2020-09-30 21:44:48 | INFO | train_inner | epoch 001:      9 / 39 loss=0.946, ppl=1.93, wps=604.8, ups=0.29, wpb=2048, bsz=16, num_updates=9, lr=1.22478e-06, gnorm=0.044, loss_scale=128, train_wall=3, wall=43
2020-09-30 21:44:52 | INFO | train_inner | epoch 001:     10 / 39 loss=0.93, ppl=1.91, wps=547.2, ups=0.27, wpb=2048, bsz=16, num_updates=10, lr=1.34975e-06, gnorm=0.045, loss_scale=128, train_wall=4, wall=47
```

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
