### PR TITLE
cpu support for benchmarks/oss.py

### DIFF
--- a/benchmarks/oss.py
+++ b/benchmarks/oss.py
@@ -105,9 +105,10 @@ def train(
 
     else:
         if args.cpu:
-            model = DDP(model, device_ids=None, find_unused_parameters=False)  # type: ignore
+            device_ids = None
         else:
-            model = DDP(model, device_ids=[rank], find_unused_parameters=False)  # type: ignore
+            device_ids = [rank]
+        model = DDP(model, device_ids=device_ids, find_unused_parameters=False)  # type: ignore
         optimizer = (
             OSS(params=model.parameters(), optim=OPTIM, lr=1e-4, momentum=0.9)
             if optim_type == OptimType.oss_ddp


### PR DESCRIPTION
# Before submitting

- [X] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fix issues of benchmark/oss.py when trying to run it from cpu. Make two changes:
1. set device_ids to None when calling DDP as required by [PyTorch DDP](https://pytorch.org/docs/stable/generated/torch.nn.parallel.DistributedDataParallel.html?highlight=distributeddataparallel#torch.nn.parallel.DistributedDataParallel)
2. remove max_allocated_memory when cpu is in use. For cuda, if not args.cpu will be true and max_allocated_memory will still be displayed

## PR review
Talked with @blefaudeux on the issue.

## Did you have fun?
Make sure you had fun coding 🙃
