### PR TITLE
Workaround sporadic crash on shutdown in test_python_autograd_function[PipelineStyle.MultiProcess]

### DIFF
--- a/tests/nn/pipe_process/test_bugs.py
+++ b/tests/nn/pipe_process/test_bugs.py
@@ -65,6 +65,7 @@ def python_autograd_function(pipeline_style):
     if model.group.rank() == 1:
         assert torch.allclose(x, y)
 
+    torch.distributed.rpc.shutdown()
     torch.distributed.barrier()
 
 


### PR DESCRIPTION
Works around https://github.com/pytorch/pytorch/issues/47161 by calling rpc.shutdown() before exiting. My theory is that the race condition occurs when an rpc thread runs during shutdown, so I assume that calling rpc.shutdown() will prevent that. Local testing seems to indicate that it works. 