### PR TITLE
[fix][Pipe] fallback for Pipe tests on internal pytorch numbering

### DIFF
--- a/tests/nn/pipe_process/test_pipe.py
+++ b/tests/nn/pipe_process/test_pipe.py
@@ -374,7 +374,6 @@ def checkpoint_eval(pipeline_style):
 
 
 def torch_version() -> Tuple[int, ...]:
-    test_version = "1.8.0a0fb"
     result = version.parse(torch.__version__).release
 
     # Catch torch version if run against internal pre-releases, like `1.8.0a0fb`, for which version.parse() will None
@@ -382,7 +381,7 @@ def torch_version() -> Tuple[int, ...]:
         # Two options here: either skip this version, or check that Pipe is not broken by this ongoing
         # development.
         # Assuming that we're interested in the second usecase more than the first, return the pre-release or dev numbering
-        numbering = test_version.split(".")
+        numbering = torch.__version__.split(".")
         result = (int(numbering[0]), int(numbering[1]), 0)
     assert result
     return result

--- a/tests/nn/pipe_process/test_pipe.py
+++ b/tests/nn/pipe_process/test_pipe.py
@@ -374,7 +374,16 @@ def checkpoint_eval(pipeline_style):
 
 
 def torch_version() -> Tuple[int, ...]:
+    test_version = "1.8.0a0fb"
     result = version.parse(torch.__version__).release
+
+    # Catch torch version if run against internal pre-releases, like `1.8.0a0fb`, for which version.parse() will None
+    if result is None:
+        # Two options here: either skip this version, or check that Pipe is not broken by this ongoing
+        # development.
+        # Assuming that we're interested in the second usecase more than the first, return the pre-release or dev numbering
+        numbering = test_version.split(".")
+        result = (int(numbering[0]), int(numbering[1]), 0)
     assert result
     return result
 

--- a/tests/nn/pipe_process/test_pipe.py
+++ b/tests/nn/pipe_process/test_pipe.py
@@ -376,11 +376,15 @@ def checkpoint_eval(pipeline_style):
 def torch_version() -> Tuple[int, ...]:
     result = version.parse(torch.__version__).release
 
-    # Catch torch version if run against internal pre-releases, like `1.8.0a0fb`, for which version.parse() will None
+    # Catch torch version if run against internal pre-releases, like `1.8.0a0fb`,
+    # for which version.parse().release will return None (version becomes of LegacyVersion type)
     if result is None:
-        # Two options here: either skip this version, or check that Pipe is not broken by this ongoing
-        # development.
-        # Assuming that we're interested in the second usecase more than the first, return the pre-release or dev numbering
+        # Two options here:
+        # - either skip this version,
+        # - or check that Pipe is not broken by this ongoing development.
+
+        # Assuming that we're interested in the second usecase more than the first,
+        # return the pre-release or dev numbering
         numbering = torch.__version__.split(".")
         result = (int(numbering[0]), int(numbering[1]), 0)
     assert result


### PR DESCRIPTION
# Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #215 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃

cc @mrshenli, not sure why Pytorch is not following PEP440 but there's probably a reason 