### PR TITLE
workaround device location problem

### DIFF
--- a/fairscale/nn/pipe/pipeline.py
+++ b/fairscale/nn/pipe/pipeline.py
@@ -181,8 +181,11 @@ def create_task(
         ) -> TensorOrTensors:
             with use_skip_tracker(skip_tracker), record_function("chunk%d-part%d" % (chunk_id, part_id)):
                 # XXX:
-                partition.to(input.device)
-                return partition(input)
+                #partition.to(input.device)
+                ret = partition(input)
+                if type(ret) is list:
+                    ret = tuple(ret)
+                return ret
 
         chk = Checkpointing(function, batch)
         if style is PipelineStyle.SingleProcess:

--- a/fairscale/nn/pipe/pipeline.py
+++ b/fairscale/nn/pipe/pipeline.py
@@ -180,6 +180,8 @@ def create_task(
             part_id: int = j,
         ) -> TensorOrTensors:
             with use_skip_tracker(skip_tracker), record_function("chunk%d-part%d" % (chunk_id, part_id)):
+                # XXX:
+                partition.to(input.device)
                 return partition(input)
 
         chk = Checkpointing(function, batch)


### PR DESCRIPTION
I ran into a problem where the second partition is not in the right GPU device when running pipe. I was using a resnet50 model, 2 partitions. In the constructor of the Pipeline class, I verified that the partitions are in the right device. However, when the call is make inside the checkpointed block, it seems in the wrong device again?

I looked through the unit tests in tests/nn/pipe/test_pipe.py, which seems to use mostly cpu devices. when I have time, I may add a unit test to try to recreate this problem. For not, just put the PR here to track.