### PR TITLE
[fix] solutions to recent pip's isolation failing to build from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ pip install -r requirements.txt
 pip install -e .
 ```
 
+If either of the above fails, add `--no-build-isolation` to the `pip install` command (this could be a problem with recent versions of pip).
+
+
 ## Getting Started
 The full documentation (https://fairscale.readthedocs.io/) contains instructions for getting started and extending fairscale.
 


### PR DESCRIPTION
`pip install fairscale` doesn't work with recent pip - I am not sure if it has to do with the particular pytorch version the user has installed or whether it affects everybody who has the recent versions of it. Currently I have `pip==20.3.3`.

So the new pip started building binary packages in a special isolation where it fetches all the dependencies and then builds a mini site-packages under /tmp/pip-install-xyz and then builds the package.

The failure is a long long trace, and the middle of it is what we want:

```
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 351, in __init__                                   
      if not is_ninja_available():                                                                                                                               
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 1310, in is_ninja_available                        
      subprocess.check_call('ninja --version'.split(), stdout=devnull)                                                                                           
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/subprocess.py", line 364, in check_call                                                                
      raise CalledProcessError(retcode, cmd)                                                                                                                     
  subprocess.CalledProcessError: Command '['ninja', '--version']' returned non-zero exit status 1. 
```
<details>
<summary>Full log</summary>
<pre>
pip install fairscale
Collecting fairscale
  Downloading fairscale-0.1.1.tar.gz (83 kB)
     |████████████████████████████████| 83 kB 562 kB/s 
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  ERROR: Command errored out with exit status 1:
   command: /home/stas/anaconda3/envs/main-38/bin/python /home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpjvw00c7v                                                                                                                            
       cwd: /tmp/pip-install-1wq9f8fp/fairscale_347f218384a64f24b8d5ce846641213e                                                                                 
  Complete output (55 lines):                                                                                                                                    
  running egg_info                                                                                                                                               
  writing fairscale.egg-info/PKG-INFO                                                                                                                            
  writing dependency_links to fairscale.egg-info/dependency_links.txt                                                                                            
  writing requirements to fairscale.egg-info/requires.txt                                                                                                        
  writing top-level names to fairscale.egg-info/top_level.txt                                                                                                    
  Traceback (most recent call last):                                                                                                                             
    File "/home/stas/anaconda3/envs/main-38/bin/ninja", line 5, in <module>                                                                                      
      from ninja import ninja                                                                                                                                    
  ModuleNotFoundError: No module named 'ninja'                                                                                                                   
  Traceback (most recent call last):                                                                                                                             
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 280, in <module>                                
      main()                                                                                                                                                     
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 263, in main                                    
      json_out['return_val'] = hook(**hook_input['kwargs'])                                                                                                      
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py", line 114, in get_requires_for_build_wheel            
      return hook(config_settings)                                                                                                                               
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 149, in get_requires_for_build_wheel                   
      return self._get_build_requires(                                                                                                                           
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 130, in _get_build_requires                            
      self.run_setup()                                                                                                                                           
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 145, in run_setup                                      
      exec(compile(code, __file__, 'exec'), locals())                                                                                                            
    File "setup.py", line 56, in <module>                                                                                                                        
      setuptools.setup(                                                                                                                                          
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup                                            
      return distutils.core.setup(**attrs)                                                                                                                       
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/core.py", line 148, in setup                                                                 
      dist.run_commands()                                                                                                                                        
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/dist.py", line 966, in run_commands                                                          
      self.run_command(cmd)                                                                                                                                      
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/dist.py", line 985, in run_command                                                           
      cmd_obj.run()                                                                                                                                              
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 298, in run                                      
      self.find_sources()                                                                                                                                        
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 305, in find_sources                             
      mm.run()                                                                                                                                                   
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 536, in run                                      
      self.add_defaults()                                                                                                                                        
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 572, in add_defaults                             
      sdist.add_defaults(self)                                                                                                                                   
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/command/sdist.py", line 228, in add_defaults                                                 
      self._add_defaults_ext()                                                                                                                                   
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/command/sdist.py", line 311, in _add_defaults_ext                                            
      build_ext = self.get_finalized_command('build_ext')                                                                                                        
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/cmd.py", line 298, in get_finalized_command                                                  
      cmd_obj = self.distribution.get_command_obj(command, create)                                                                                               
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/distutils/dist.py", line 858, in get_command_obj                                                       
      cmd_obj = self.command_obj[command] = klass(self)                                                                                                          
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 351, in __init__                                   
      if not is_ninja_available():                                                                                                                               
    File "/tmp/pip-build-env-a5x2icen/overlay/lib/python3.8/site-packages/torch/utils/cpp_extension.py", line 1310, in is_ninja_available                        
      subprocess.check_call('ninja --version'.split(), stdout=devnull)                                                                                           
    File "/home/stas/anaconda3/envs/main-38/lib/python3.8/subprocess.py", line 364, in check_call                                                                
      raise CalledProcessError(retcode, cmd)                                                                                                                     
  subprocess.CalledProcessError: Command '['ninja', '--version']' returned non-zero exit status 1.                                                               
  ----------------------------------------                                                                                                                       
ERROR: Command errored out with exit status 1: /home/stas/anaconda3/envs/main-38/bin/python /home/stas/anaconda3/envs/main-38/lib/python3.8/site-packages/pip/_vendor/pep517/_in_process.py get_requires_for_build_wheel /tmp/tmpjvw00c7v Check the logs for full command output.
</pre>

</details>
actually for some reason pytorch fails to run this simple code:

```
# torch/utils/cpp_extension.py
def is_ninja_available():
    r'''
    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
    available on the system, ``False`` otherwise.
    '''
    with open(os.devnull, 'wb') as devnull:
        try:
            subprocess.check_call('ninja --version'.split(), stdout=devnull)
        except OSError:
            return False
        else:
            return True
```

I suspect that pip does something to `os.devnull` and that's why it fails.

Probably a simpler code would be:

```
def is_ninja_available():
    r'''
    Returns ``True`` if the `ninja <https://ninja-build.org/>`_ build system is
    available on the system, ``False`` otherwise.
    '''
    try:
        subprocess.check_output('ninja --version'.split())
    except:
        return False
    else:
        return True 
```

which doesn't use `os.devnull` and does the same function.

Back to the issue at hand, here are 2 workarounds that solve this problem:

1. Add `--no-build-isolation` - which relies on all dependencies to be installed already
```
pip install fairscale --no-build-isolation
```
or for develop build
```
git clone https://github.com/facebookresearch/fairscale/
cd fairscale
pip install --no-build-isolation -e .
```

2. don't use pip to build this package, instead use setup tools directly:

```
git clone https://github.com/facebookresearch/fairscale/
cd fairscale
python setup.py bdist_wheel
pip install dist/fairscale-0.1.1-cp38-cp38-linux_x86_64.whl
```
(note: as you read this later the version will change so adjust it)

---------------

I have a fix PR for pytorch - https://github.com/pytorch/pytorch/pull/49443
