### PR TITLE
[OSS] Getting rid of the "should bucket" hash table, just use a list + robustness related fixes

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -634,7 +634,7 @@ class OSS(Optimizer):
                 for param in params:
                     # Criteria to decide whether this parameter is to be bucketed or not:
                     # - enough room in the bucket
-                    if (offset + param.numel()) < self.buckets[device][dst_rank].max_size:
+                    if param.requires_grad and (offset + param.numel()) < self.buckets[device][dst_rank].max_size:
                         self.should_bucket_param.append(True)
 
                         if offset == 0:

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -120,7 +120,6 @@ class OSS(Optimizer):
         self.work_handles: Deque[Workhandle] = deque()
         self._max_work_handles = -1
         self._setup_bucket_strategy()
-        print(f"Optimizer set up: {self.rank} - {self._device}")
 
     # Partition helpers
     def partition_parameters(self) -> List[List[dict]]:
@@ -196,8 +195,6 @@ class OSS(Optimizer):
                 returns the loss. Optional for most optimizers.
 
         .. note: Any extra parameter is passed to the base optimizer as-is"""
-
-        print(f"Optimizer step: {self.rank} - {list(self.per_device_params.keys())[0]}")
 
         # Sync oss param_groups attributes in case they've been updated by a scheduler.
         self._sync_param_groups()
@@ -403,8 +400,6 @@ class OSS(Optimizer):
             state_dict (dict): optimizer state. Should be an object returned
                 from a call to :meth:`state_dict`
         """
-
-        print("loading state dict")
 
         # Check whether we got a local or global dict
         if state_dict["local_state_dict"]:

--- a/tests/nn/data_parallel/test_sharded_ddp.py
+++ b/tests/nn/data_parallel/test_sharded_ddp.py
@@ -44,6 +44,7 @@ def run_one_step(rank, world_size, backend, device, temp_file_name):
         model.register_buffer("test_buffer", torch.ones((1)) * rank)
         model.to(device)
 
+        next(model.parameters()).requires_grad = False
         optimizer = OSS(params=model.parameters(), optim=torch.optim.SGD, lr=0.01, momentum=0.99)
         ddp_model = ShardedDataParallel(model, optimizer, broadcast_buffers=broadcast_buffers)
 

--- a/tests/nn/data_parallel/test_sharded_ddp.py
+++ b/tests/nn/data_parallel/test_sharded_ddp.py
@@ -7,6 +7,7 @@
 Testing OssDdp class.
 """
 
+from contextlib import suppress
 import copy
 import tempfile
 from typing import List
@@ -21,12 +22,10 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 from fairscale.nn.data_parallel import ShardedDataParallel
 from fairscale.optim import OSS
+from fairscale.utils.testing import GPT2
 
 skip_if_no_cuda = pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda required")
 skip_if_single_gpu = pytest.mark.skipif(torch.cuda.device_count() < 2, reason="multiple GPUs required")
-from contextlib import suppress
-
-from fairscale.utils.testing import GPT2
 
 
 def run_one_step(rank, world_size, backend, device, temp_file_name):
@@ -44,7 +43,8 @@ def run_one_step(rank, world_size, backend, device, temp_file_name):
         model.register_buffer("test_buffer", torch.ones((1)) * rank)
         model.to(device)
 
-        next(model.parameters()).requires_grad = False
+        next(model.parameters()).requires_grad = False  # Test non-trainable parameters
+
         optimizer = OSS(params=model.parameters(), optim=torch.optim.SGD, lr=0.01, momentum=0.99)
         ddp_model = ShardedDataParallel(model, optimizer, broadcast_buffers=broadcast_buffers)
 


### PR DESCRIPTION
Properly handle all params, with or without requires_grad, HuggingFace has triggered a bug which was always there. Remove the hash table to store the strategy (a bit risky if the tensors are moved around) and replace with a simple list. Make sure that we update the strategy if a new parameter group is added

# Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes https://github.com/huggingface/transformers/issues/9156 for the multi-node case, ie: with bucketing involved, tested locally by commenting out the no-bucketing statement.
Fixes #258 
Makes sure that this case is caught by the unit test, I'm really surprised that this was not covered before, but I did check that master fails on this

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Well, yes 🙃 the fp16 issue is not solved though

cc @stas00 
