### PR TITLE
Resolve issue where grad norms because inf with OSS / fp16

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -259,7 +259,7 @@ class OSS(Optimizer):
             dist.all_reduce(total_norm, op=torch.distributed.ReduceOp.MAX, group=self.group)
         else:
             local_norm = torch.norm(
-                input=torch.stack([torch.norm(input=p.grad.detach(), p=norm_type).to(self._device) for p in local_params]),  # type: ignore
+                input=torch.stack([torch.norm(input=p.grad.detach(), p=norm_type, dtype=torch.float32).to(self._device) for p in local_params]),  # type: ignore
                 p=norm_type,
             )
 


### PR DESCRIPTION
Discussed with @blefaudeux over chat. For large transformer models where grad norm is high (~5000 per device), the OSS clip norm code causes clip norm to become inf. This is because the logic is done in fp16 and 5000 ** 2 causes overflow in fp16.

The solution is to cast everything to fp32 before squaring/reducing. The return norm is also in fp32, as a result.