### PR TITLE
[feat] sync adascale from internal repo, support add_param_group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [next rel] - TBD
 ### Added
-- AdaScale: Added gradient accumulation feature (#202)
-- AdaScale: Added support of torch.lr_scheduler (#229)
+- AdaScale:
+  . Added gradient accumulation feature (#202)
+  . Added support of torch.lr_scheduler (#229)
+  . Added support for add_param_groups (#266)
+  . Added support for scale != world_size (#266)
 
 ### Fixed
 - AdaScale: smoothing factor value fixed when using gradient accumulation (#235)

--- a/fairscale/optim/adascale.py
+++ b/fairscale/optim/adascale.py
@@ -104,25 +104,27 @@ class AdaScale(Optimizer):
         optimizer (torch.optim.Optimizer):
             Optimizer to apply AdaScale to.
         world_size (int):
-            Number of world_size for distributed training. If
-            None, defaults to ``dist.get_world_size()``.
+            Number of world_size for distributed training.
+            If None, defaults to ``dist.get_world_size()``.
         scale (float):
             Scaling factor of the batch size from scale equals 1, e.g. using a 10x
             larger batch size (summed across all ranks with gradient accumulation)
-            means a scale of 10. If None, defaults to
-            ``world_size * num_gradients_to_accumulate``.
+            means a scale of 10.
+            If None, defaults to ``world_size * num_gradients_to_accumulate``.
         smoothing (float):
-            Smoothing factor for moving average. If None, it defaults to
-            ``max(1 - (world_size * num_gradients_to_accumulate)/1000, 0)``.
+            Smoothing factor for moving average.
+            If None, it defaults to ``max(1 - (world_size * num_gradients_to_accumulate)/1000, 0)``.
         num_gradients_to_accumulate (int):
             Number of passes that we accumulate gradients locally
-            between each optimizer step.
+            between each optimizer step. This can be changed during
+            training as long as the train loop changes gradient accumulation
+            accordingly.
             Default to 1, which does not accumulate gradients.
         debias_ewma (bool):
             (experimental) Use debias exponential moving average
             for smoothing and mu and sigma variables. False will
-            use the method in the paper Appendix B.3.
-            Default: True.
+            use the method in the paper's Appendix B.3.
+            Default: True, which is what have been validated so far.
     """
 
     def __init__(

--- a/fairscale/optim/adascale.py
+++ b/fairscale/optim/adascale.py
@@ -454,9 +454,8 @@ class AdaScale(Optimizer):
         grad_sqr = total_grad_sqr - grad_var / S
         grad_var = np.maximum(grad_var, 1e-6)
         grad_sqr = np.maximum(grad_sqr, 0.0)
-        theta = self.smoothing
-        self._update_avg("grad_sqr_avg", grad_sqr, theta)
-        self._update_avg("grad_var_avg", grad_var, theta)
+        self._update_avg("grad_sqr_avg", grad_sqr, self.smoothing)
+        self._update_avg("grad_var_avg", grad_var, self.smoothing)
         self._last_final_backward_call = self._num_backward_calls
         # Indicating backward is done.
         self._local_grad_sqr = None

--- a/fairscale/optim/adascale.py
+++ b/fairscale/optim/adascale.py
@@ -490,9 +490,14 @@ class AdaScale(Optimizer):
         """Set the number of gradients to accumulate to a new value.
 
         This is experimental. This could be called while training so that
-        we can gradually increasing the steps between updates.
+        we can gradually increasing the steps between updates. Almost always
+        `set_scale` needs to be called to update the scale as well.
 
         TODO (min): need a way of determine how much to increase the step size?
+        TODO (min): have both `set_scale` and `set_num_gradients_to_accumulate`
+                    is hard to use and easy to make mistake. I think it is better
+                    to specific a specify a `base_scale`. But more discussion is
+                    needed here.
 
         Args:
             num_gradients_to_accumulate (int):

--- a/tests/optim/test_single_node_adascale.py
+++ b/tests/optim/test_single_node_adascale.py
@@ -201,6 +201,7 @@ def test_lr_scheduler():
                 loss.backward()
             assert optim.gain() <= 3, optim.gain()
             optim.step()
+            optim.zero_grad()
             # asserting LR is right
             assert np.allclose(optim.param_groups[0]["lr"], 0.1 / 10 ** epoch), optim.param_groups[0]["lr"]
         scheduler.step()

--- a/tests/optim/test_single_node_adascale.py
+++ b/tests/optim/test_single_node_adascale.py
@@ -139,7 +139,6 @@ def test_state_checkpointing():
 
     # Run a bit.
     def run_a_bit(replay_data=None):
-        print("running")
         data = []
         replay_data_idx = 0
         for _ in range(6):  # run some steps
@@ -152,8 +151,6 @@ def test_state_checkpointing():
                     replay_data_idx += 1
                 out = model(in_data)
                 out.sum().backward()
-                # print(out.sum().item())
-                print(model.weight.grad)
                 if i == accum_steps - 1:
                     optim.step()
                     optim.zero_grad()
@@ -396,7 +393,6 @@ def test_unhook():
                 if "torch.nn.parameter.Parameter" not in str(type(obj)):
                     continue
                 if torch.is_tensor(obj) or (hasattr(obj, "data") and torch.is_tensor(obj.data)):
-                    print(obj.shape)
                     if obj.shape == (456, 123):
                         return True
             except Exception as e:

--- a/tests/optim/test_single_node_adascale.py
+++ b/tests/optim/test_single_node_adascale.py
@@ -372,7 +372,7 @@ def test_scale_not_equal_default(test_case):
     for i in range(4):
         out = model(Tensor(data[i]))
         out.sum().backward()
-    # Since the input are perfect orthogonal, the gain should be at the scale.
+    # Since the inputs are perfect orthogonal, the gain should be at the scale.
     assert np.allclose(optim.gain(), exp_gain), optim.gain()
 
 

--- a/tests/optim/test_single_node_adascale.py
+++ b/tests/optim/test_single_node_adascale.py
@@ -305,3 +305,17 @@ def test_set_num_gradients_to_accumulate(test_case):
 
     assert np.allclose(optim.gain(), exp_gain), optim.gain()
     optim.step()
+
+
+def test_debias_ewma():
+    """Test debias_ewma experimental feature"""
+    model = Linear(2, 2, bias=False)
+    optim = AdaScale(SGD(model.parameters(), lr=0.1), num_gradients_to_accumulate=2, debias_ewma=True)
+    for _ in range(4):
+        optim.zero_grad()
+        out = model(Tensor([0.0, 1.0]))
+        out.sum().backward()
+        out = model(Tensor([1.0, 0.0]))
+        out.sum().backward()
+        assert np.allclose(optim.gain(), 2.0), optim.gain()
+        optim.step()

--- a/tests/optim/test_single_node_adascale.py
+++ b/tests/optim/test_single_node_adascale.py
@@ -41,7 +41,7 @@ def test_loss_accum_cpu():
     """
     model = Linear(2, 2, bias=False)
     # num_gradients_to_accumulate value doesn't matter in this negative test.
-    optim = AdaScale(SGD(model.parameters(), lr=0.1), num_gradients_to_accumulate=123)
+    optim = AdaScale(SGD(model.parameters(), lr=0.1), num_gradients_to_accumulate=3)
     # data 1
     in_data = Tensor([0.0, 1.0])
     loss = model(in_data).sum()
@@ -53,9 +53,9 @@ def test_loss_accum_cpu():
     loss += model(in_data).sum()
     # backward, but gradient is only produced once by the autograd engine.
     loss.backward()
-    # therefore, the gain will always be 1, which renders adascale as noop.
-    optim.step()
+    # The gain will always be 1, which renders adascale as noop.
     assert np.allclose(optim.gain(), 1.0), optim.gain()
+    # We don't call optim.step(), since it will detect that backward is not yet done.
 
 
 # IMPORTANT: make sure these test_cases values are sync'ed with the DDP

--- a/tests/optim/test_single_node_adascale.py
+++ b/tests/optim/test_single_node_adascale.py
@@ -278,9 +278,9 @@ def test_add_param_group(debias_ewma):
 @pytest.mark.parametrize(
     "test_case",
     [
-        {"new_accum": 3, "exp_gain": 1.1190662277452972},
-        {"new_accum": 6, "exp_gain": 1.0619749887486511},
-        {"new_accum": 9, "exp_gain": 1.0339000994448166},
+        {"new_accum": 3, "exp_gain": 1.2573902104603087},
+        {"new_accum": 6, "exp_gain": 1.0903738977361481},
+        {"new_accum": 9, "exp_gain": 1.0432658660558123},
     ],
 )
 def test_set_num_gradients_to_accumulate(test_case):
@@ -297,6 +297,7 @@ def test_set_num_gradients_to_accumulate(test_case):
     assert np.allclose(optim.gain(), 2.0)
     optim.step()
 
+    optim.zero_grad()
     optim.set_scale(float(new_accum))
     optim.set_num_gradients_to_accumulate(new_accum)
     for _ in range(new_accum):


### PR DESCRIPTION
- [x] added add_param_group API, unit test added
- [x] added code to support scale != world_size, unit test added
- [x] added code to unhook the hooks, unit test added
- [x] removed `scale` param from the gain() function since it is not correct to do it there.
- [x] changed to not mutate the gradient in-place in the grad-accumulation case, unit test updated
- [x] added experimental feature for debias_ewma or not, unit test added
- [x] added experimental code to adjust gradient accumulation steps during the training (`set_num_gradients_to_accumulate`), unit test added
- [x] added checking code for proper API calling places
- [x] rename internal APIs to make them internal
- [x] update changelog

testing: unit tests

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes #269.
Fixes #224.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
