### PR TITLE
[fix] CircleCI vs pip hotfix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,8 @@ install_dep_17: &install_dep_17
       name: Install Dependencies
       command: |
         sudo apt-get install -y libopenmpi-dev
-        pip install --progress-bar off torch==1.7.1+cu110 torchvision==0.8.2+cu110 -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off -r requirements-test.txt
+        pip install --progress-bar off torch==1.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off git+https://github.com/msbaines/torch_pg.git@c85c96f#egg=torch-pg
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env
@@ -82,7 +82,7 @@ install_repo_gpu: &install_repo_gpu
   - run:
       name: Install Repository
       command: |
-        export CUDA_HOME=/usr/local/cuda-11.0
+        export CUDA_HOME=/usr/local/cuda-10.1
         pip install -e .
 
 run_coverage: &run_coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,7 @@ install_dep_16: &install_dep_16
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env
 
-install_dep_17: &install_dep_17
+install_dep_17_cpu: &install_dep_17_cpu
   - run:
       name: Install Dependencies
       command: |
@@ -70,7 +70,7 @@ install_dep_17: &install_dep_17
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env
 
-install_dep_17_benchmarks: &install_dep_17_benchmarks
+install_dep_17_gpu: &install_dep_17_gpu
   # FIXME: need to be removed when properly handling torch 1.7.1
   # short term fix is to override the default pip installed torch
   - run:
@@ -170,7 +170,7 @@ jobs:
           keys:
             - cache-key-cpu-{{ checksum "setup.py"}}-{{ checksum "requirements-test.txt"}}
 
-      - <<: *install_dep_17
+      - <<: *install_dep_17_cpu
 
       - save_cache:
           paths:
@@ -290,7 +290,7 @@ jobs:
           keys:
             - cache-key-gpu17-{{ checksum "setup.py"}}-{{ checksum "requirements-test.txt"}}
 
-      - <<: *install_dep_17
+      - <<: *install_dep_17_gpu
 
       - save_cache:
           paths:
@@ -327,7 +327,7 @@ jobs:
           keys:
             - cache-key-benchmarks-{{ checksum "setup.py"}}-{{ checksum "requirements-test.txt"}}
 
-      - <<: *install_dep_17_benchmarks
+      - <<: *install_dep_17_gpu
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,7 +82,7 @@ install_repo_gpu: &install_repo_gpu
   - run:
       name: Install Repository
       command: |
-        export CUDA_HOME=/usr/local/cuda-10.1
+        export CUDA_HOME=/usr/local/cuda-11.0
         pip install -e .
 
 run_coverage: &run_coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -70,7 +70,7 @@ install_dep_17: &install_dep_17
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env
 
-install_dep_17: &install_dep_17_benchmarks
+install_dep_17_benchmarks: &install_dep_17_benchmarks
   # FIXME: need to be removed when properly handling torch 1.7.1
   # short term fix is to override the default pip installed torch
   - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,11 +64,25 @@ install_dep_17: &install_dep_17
       name: Install Dependencies
       command: |
         sudo apt-get install -y libopenmpi-dev
+        pip install --progress-bar off torch==1.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
+        pip install --progress-bar off -r requirements-test.txt
+        pip install --progress-bar off git+https://github.com/msbaines/torch_pg.git@c85c96f#egg=torch-pg
+        python -c 'import torch; print("Torch version:", torch.__version__)'
+        python -m torch.utils.collect_env
+
+install_dep_17: &install_dep_17_benchmarks
+  # FIXME: need to be removed when properly handling torch 1.7.1
+  # short term fix is to override the default pip installed torch
+  - run:
+      name: Install Dependencies
+      command: |
+        sudo apt-get install -y libopenmpi-dev
         pip install --progress-bar off -r requirements-test.txt
         pip install --progress-bar off torch==1.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off git+https://github.com/msbaines/torch_pg.git@c85c96f#egg=torch-pg
         python -c 'import torch; print("Torch version:", torch.__version__)'
         python -m torch.utils.collect_env
+
 
 install_repo_cpu: &install_repo_cpu
   - run:
@@ -313,7 +327,7 @@ jobs:
           keys:
             - cache-key-benchmarks-{{ checksum "setup.py"}}-{{ checksum "requirements-test.txt"}}
 
-      - <<: *install_dep_17
+      - <<: *install_dep_17_benchmarks
 
       - save_cache:
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ install_dep_17: &install_dep_17
       name: Install Dependencies
       command: |
         sudo apt-get install -y libopenmpi-dev
-        pip install --progress-bar off torch==1.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
+        pip install --progress-bar off torch==1.7.1+cu110 torchvision==0.8.2+cu110 -f https://download.pytorch.org/whl/torch_stable.html
         pip install --progress-bar off -r requirements-test.txt
         pip install --progress-bar off git+https://github.com/msbaines/torch_pg.git@c85c96f#egg=torch-pg
         python -c 'import torch; print("Torch version:", torch.__version__)'


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Not very nice because one duplicated install preset, but short term fix to make sure that master is not broken, https://github.com/facebookresearch/fairscale/pull/251 will be the real deal. In short, the default pip install torch recently changed to cuda11, and our circleci presets are around cuda 10.1 (which is probably a sane decision given torch 1.5 and 1.6 compatibility). `pip install -r requirements` thus nukes pre-installed torch with a version incompatible with the available cuda, which breaks all of our gpu-related tests (unit tests silently fail, and benchmark dies with some noise).
 
This adds a new install profile which overrides the default pip install with the required torch 1.7 cu101 for the gpu-related tests (but not the cpu ones, since they require some mpi dark magic which breaks in that case). Best of both worlds (everything works as it should I think), elegance set aside.

## PR review
**Please merge this if acceptable to you, master should not stay broken IMHO.**

## Did you have fun?
Make sure you had fun coding 🙃
