### PR TITLE
[fix] Regression testing oss+sharded_ddp only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,7 +135,8 @@ run_oss_benchmark: &run_oss_benchmark
   - run:
       name: Run OSS Benchmark
       command: |
-        python benchmarks/oss.py --check_regression --world_size 4 --reference_speed 660 --reference_memory 1120 --reference_loss 0.023
+        python benchmarks/oss.py --world_size 4 --epochs 2
+        python benchmarks/oss.py --check_regression --world_size 4 --optim_type oss_sharded_ddp --reference_speed 660 --reference_memory 930 --reference_loss 0.023
 
 run_oss_gloo: &run_oss_gloo
   - run:


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
The regression detection, which triggers following https://github.com/facebookresearch/fairscale/pull/276. The gist of it is that with the current config, oss+DDP is part of the regression test, while we're really interested in OSS+ShardedDDP (and the threshold is much lower for this one actually, so the current setting was not very good).

3 changes then:
- regression test oss+sharded_ddp only
- much tighter threshold (900MB vs 1100MB) which actually reflects this solution's real perf
- keep pytorch+oss/ddp+oss/sharded_dpp as free runs, I found it useful to be able to compare the 3 solutions side by side 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

Sorry for the noise around that today, hopefully more stable now

## Did you have fun?
Make sure you had fun coding 🙃
