### PR TITLE
[feat] Support model parallelism in OSS

### DIFF
--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -206,7 +206,6 @@ class ShardedDataParallel(nn.Module):
                 # Opportunistically try to empty the queue
                 optimizer._try_consume_work_handle()
 
-                logging.warning("reducing one parameter")
 
                 # If all the reduce operations have been called,
                 # make sure that all the asynchronous calls have concluded before moving on

--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -206,7 +206,6 @@ class ShardedDataParallel(nn.Module):
                 # Opportunistically try to empty the queue
                 optimizer._try_consume_work_handle()
 
-
                 # If all the reduce operations have been called,
                 # make sure that all the asynchronous calls have concluded before moving on
                 # and execute the delayed actions (release gradients, unroll the buckets)

--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -206,6 +206,8 @@ class ShardedDataParallel(nn.Module):
                 # Opportunistically try to empty the queue
                 optimizer._try_consume_work_handle()
 
+                logging.warning("reducing one parameter")
+
                 # If all the reduce operations have been called,
                 # make sure that all the asynchronous calls have concluded before moving on
                 # and execute the delayed actions (release gradients, unroll the buckets)

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -220,7 +220,7 @@ class OSS(Optimizer):
         self,
         max_norm: Union[float, int],
         norm_type: Union[float, int] = 2.0,
-        filter_params_fn: Callable[[chain[Parameter]], chain[Parameter]] = None,
+        filter_params_fn: Callable[[Any], Any] = None,
     ) -> torch.Tensor:
         """
         Clip all gradients at this point in time. The norm is computed over all gradients together, as if they were

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -266,7 +266,7 @@ class OSS(Optimizer):
         if norm_type == inf:
             total_norm = max(p.grad.detach().abs().max().to(self._device) for p in local_params)  # type: ignore
             # all reduce over data parallel and model parallel workers
-            dist.all_reduce(total_norm, op=torch.distributed.ReduceOp.MAX)
+            dist.all_reduce(total_norm, op=torch.distributed.ReduceOp.MAX, group=dist.group.WORLD)
         else:
             local_norm = torch.norm(
                 input=torch.stack([torch.norm(input=p.grad.detach(), p=norm_type, dtype=torch.float32).to(self._device) for p in local_params]),  # type: ignore

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -216,7 +216,12 @@ class OSS(Optimizer):
 
         return loss
 
-    def clip_grad_norm(self, max_norm: Union[float, int], norm_type: Union[float, int] = 2.0, filter_params_fn = None) -> torch.Tensor:
+    def clip_grad_norm(
+        self,
+        max_norm: Union[float, int],
+        norm_type: Union[float, int] = 2.0,
+        filter_params_fn: Callable[[chain[Parameter]], chain[Parameter]] = None,
+    ) -> torch.Tensor:
         """
         Clip all gradients at this point in time. The norm is computed over all gradients together, as if they were
         concatenated into a single vector. Gradients are modified in-place.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,4 +28,4 @@ use_parentheses = true
 skip_glob = ["build/*", "stubs/*"]
 # Don't split "import" and "from".
 force_sort_within_sections = true
-known_third_party = ["benchmark_dataset", "dataclasses", "helpers", "numpy", "pytest", "recommonmark", "setuptools", "torch", "torch_pg", "torchtext", "torchvision"]
+known_third_party = ["benchmark_dataset", "dataclasses", "datasets", "helpers", "models", "numpy", "pytest", "recommonmark", "setuptools", "torch", "torch_pg", "torchtext", "torchvision"]

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -605,6 +605,21 @@ def run_state_dict_distributed(rank, world_size, tempfile_name):
         optimizer.step()
         optimizer.zero_grad()
 
+    # save and reload without taking any steps
+    sharded_optimizer2.consolidate_state_dict()
+    state_dict2 = sharded_optimizer2.state_dict()
+    sharded_optimizer2 = optim.OSS(model_oss2.parameters(), lr=0.1, momentum=0.99)
+    sharded_optimizer2.load_state_dict(state_dict2)
+
+    # now take a step and check that parameters are equal
+    # take a step
+    run_grad_step(device, model_oss1, sharded_optimizer1)
+    run_grad_step(device, model_oss2, sharded_optimizer2)
+
+    # check that model parameters are equal
+    for param1, param2 in zip(model_oss1.parameters(), model_oss2.parameters()):
+        assert torch.allclose(param1, param2), "parameters of the two identical models have diverged (before any steps)"
+
     # take a step
     run_grad_step(device, model_oss1, sharded_optimizer1)
     run_grad_step(device, model_oss2, sharded_optimizer2)


### PR DESCRIPTION
This PR adds support for model parallelism in OSS. I added an [example integration with Fairseq](https://github.com/fairinternal/fairseq-py/pull/1531/files#diff-6c1200391a37100c04391c1bbee841eaa87808c15fb74bde964e0bccfde668c6R77).

The key idea is to expose `filter_params_fn` which can filter out weights that are replicated on various model parallel units. See below for an example of how this can be used. I personally think `_filter_model_parallel_params_fn` should live inside the user codebase (e.g. Fairseq) since it makes assumptions about the model architecture, but I'm also happy to add it here. The megatron code is used by many downstream codebases (including Fairscale) and should therefore appropriately mark weights with a `model_parallel` attribute.

```
        def _filter_model_parallel_params_fn(params):
            mp_rank_is_zero = (get_model_parallel_rank() == 0)
            params = list(params)
            parameters_for_norm = list(filter(
                lambda p: getattr(p, 'model_parallel', False) or mp_rank_is_zero, params))
            return parameters_for_norm
 ```