### PR TITLE
Fix lint/typing in FlattenParamsWrapper

### DIFF
--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -366,7 +366,7 @@ class GPT2(nn.Module):
         return self.clf_head(h), logits
 
 
-def objects_are_equal(a, b, raise_exception=False) -> bool:
+def objects_are_equal(a: Any, b: Any, raise_exception: bool = False) -> bool:
     """
     Test that two objects are equal. Tensors are compared to ensure matching
     size, dtype, device and values.

--- a/stubs/torch/__init__.pyi
+++ b/stubs/torch/__init__.pyi
@@ -27,6 +27,7 @@ from .autograd import no_grad as no_grad, enable_grad as enable_grad, \
 from . import cuda as cuda
 from . import optim as optim
 from . import nn as nn
+from . import testing as testing
 
 #MODIFIED BY TORCHGPIPE
 from . import backends

--- a/stubs/torch/testing/__init__.pyi
+++ b/stubs/torch/testing/__init__.pyi
@@ -1,0 +1,9 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+
+#MODIFIED FOR FlattenParamsWrapper
+
+from typing import Any
+
+def assert_allclose(actual: Any, expected: Any, rtol: float = ..., atol: float = ..., equal_nan: bool = ..., msg: str = ...) -> None: ...
+
+#END

--- a/tests/nn/misc/test_flatten_params_wrapper.py
+++ b/tests/nn/misc/test_flatten_params_wrapper.py
@@ -153,7 +153,7 @@ class TestFlattenParams(unittest.TestCase):
         flat_module = FlattenParamsWrapper(flat_module)
         ref_output = self._get_output(flat_module)
 
-        flat_state_dict = flat_module.state_dict(unflatten_params=False)
+        flat_state_dict = flat_module.flat_state_dict()
 
         new_module = self._get_shared_params_transformer(seed=1234)
         new_module = FlattenParamsWrapper(new_module)


### PR DESCRIPTION
Add some types to make mypi (mostly) happy.

However, for some reason mypi doesn't like `state_dict`:
```
$ mypy --ignore-missing-imports --scripts-are-modules --pretty .
fairscale/nn/misc/flatten_params_wrapper.py:140: error: Signature of "state_dict" incompatible with supertype "Module"
        def state_dict(
        ^
Found 1 error in 1 file (checked 98 source files)
```
Any ideas?

Also, [CI seems to complain](https://app.circleci.com/pipelines/github/facebookresearch/fairscale/1315/workflows/799993ed-c34c-4d3c-8b63-4d11814e5499/jobs/5751) about import sorting in `tests/nn/misc/test_flatten_params_wrapper.py`, although I cannot reproduce this error locally (i.e., my local `isort` is happy with the file).