### PR TITLE
[refactor] Refactor and enable multiprocess nn.Pipe benchmarks.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,6 +121,12 @@ run_pipe_benchmark: &run_pipe_benchmark
       command: |
         python benchmarks/pipe.py
 
+run_mp_pipe_benchmark: &run_mp_pipe_benchmark
+  - run:
+      name: Run Multiprocess Pipe Benchmark
+      command: |
+        python benchmarks/pipe.py --multiprocess
+
 run_oss_benchmark: &run_oss_benchmark
   - run:
       name: Run OSS Benchmark
@@ -328,6 +334,8 @@ jobs:
       - <<: *install_repo_gpu
 
       - <<: *run_pipe_benchmark
+
+      - <<: *run_mp_pipe_benchmark
 
       - <<: *run_oss_benchmark
 

--- a/benchmarks/datasets/wikitext2_data.py
+++ b/benchmarks/datasets/wikitext2_data.py
@@ -1,6 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
 import io
+import tempfile
 
 import torch
 from torch.utils.data import DataLoader
@@ -24,7 +25,8 @@ def get_real_dataloaders(args):
     """Return real dataloaders for training, testing and validation."""
 
     url = "https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip"
-    test_filepath, valid_filepath, train_filepath = extract_archive(download_from_url(url, root="/tmp"))
+    tmpdir = tempfile.TemporaryDirectory()
+    test_filepath, valid_filepath, train_filepath = extract_archive(download_from_url(url, root=tmpdir.name))
     tokenizer = get_tokenizer("basic_english")
 
     def data_process(raw_text_iter):

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -31,12 +31,13 @@ def get_golden_real_stats(multiprocess=False):
             "avg_wps": 703.778,
             "std_dev_wps": 5.732,
             "peak_mem_usage": [2320996352, 1396742144, 1396742144, 2340010496],
+            
         }
     else:
         return {
             "avg_wps": 647.404,
             "std_dev_wps": 14.51,
-            "peak_mem_usage": [2941729280, 2941729280, 2941729280, 2941729280],
+            "peak_mem_usage": [3305007616, 2578692608, 3304524288, 2578692608],
         }
 
 

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -31,7 +31,6 @@ def get_golden_real_stats(multiprocess=False):
             "avg_wps": 703.778,
             "std_dev_wps": 5.732,
             "peak_mem_usage": [2320996352, 1396742144, 1396742144, 2340010496],
-            
         }
     else:
         return {

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -20,6 +20,7 @@ def get_benchmark_config():
         "scaler": GradScaler(),
         "clip_value": 0.05,
         "batch_size": 8,
+        "num_decoder_layers": 10,
     }
 
 

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -25,13 +25,19 @@ def get_benchmark_config():
     }
 
 
-def get_golden_real_stats():
-
-    return {
-        "avg_wps": 703.778,
-        "std_dev_wps": 5.732,
-        "peak_mem_usage": [2320996352, 1396742144, 1396742144, 2340010496],
-    }
+def get_golden_real_stats(single_process=True):
+    if single_process:
+        return {
+            "avg_wps": 703.778,
+            "std_dev_wps": 5.732,
+            "peak_mem_usage": [2320996352, 1396742144, 1396742144, 2340010496],
+        }
+    else:
+        return {
+            "avg_wps": 647.404,
+            "std_dev_wps": 14.51,
+            "peak_mem_usage": [2941729280, 2941729280, 2941729280, 2941729280],
+        }
 
 
 def get_golden_synthetic_stats():

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -25,8 +25,8 @@ def get_benchmark_config():
     }
 
 
-def get_golden_real_stats(single_process=True):
-    if single_process:
+def get_golden_real_stats(multiprocess=False):
+    if not multiprocess:
         return {
             "avg_wps": 703.778,
             "std_dev_wps": 5.732,

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -291,7 +291,7 @@ def train(model_config, model, benchmark_config, args):
             if i % log_interval == 0 and i > 0:
                 cur_loss = total_loss / log_interval
                 elapsed = time.time() - start_time
-                if not args.multiprocess or dist.get_rank() == 1:
+                if not args.multiprocess or dist.get_rank() == dist.get_world_size() - 1:
                     print(
                         "| batch {:5d} | wps {:5.2f} | loss {:5.2f} | ppl {:8.2f}".format(
                             i, total_tokens_per_log_interval / elapsed, cur_loss, math.exp(cur_loss)
@@ -380,7 +380,7 @@ def benchmark_language_model(model_config, model, benchmark_config, args):
     print("-" * 110)
     print("| end of epoch {:1d} | time: {:5.2f}s | train loss {:5.2f} ".format(epoch, elapsed_time, loss))
     print("-" * 110)
-    if dist.get_rank() == 1:
+    if dist.get_rank() == dist.get_world_size() - 1:
         print("Throughput(wps) is {:.2f}.".format(wps))
     print(
         "Peak allocated bytes on cuda:{}: {:1d}".format(

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -604,6 +604,6 @@ if __name__ == "__main__":
         print(f"Running single process benchmark with args: {args}")
         benchmark_single_process(args)
     else:
-        world_size = min(torch.cuda.device_count(), 2)
+        world_size = max(torch.cuda.device_count(), 1)
         print(f"Running multiprocess benchmark with args: {args}")
         mp.spawn(benchmark_multiprocess, args=(world_size, args), nprocs=world_size, join=True)

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -361,7 +361,7 @@ def verify_lm_run(wps, golden_config, args):
         print("Peak allocated bytes on cuda:0: {:1d}".format(torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]))
         current_device_usage = torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]
         golden_ref = golden_config["peak_mem_usage"][rank]
-        if not current_device_usage < golden_ref * 1.1:
+        if not current_device_usage < golden_ref * 1.5:
             raise RuntimeError(
                 "Peak memory usage for cuda device {:d} is {:d} which"
                 "is less than golden reference value of {:d}".format(rank, current_device_usage, golden_ref)

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -384,8 +384,7 @@ def benchmark_language_model(model_config, model, benchmark_config, args):
     print("-" * 110)
     if dist.get_rank() == 1:
         print("Throughput(wps) is {:.2f}.".format(wps))
-        for i in range(2):
-            print("Peak allocated bytes on cuda:0: {:1d}".format(torch.cuda.memory_stats(i)["allocated_bytes.all.peak"]))
+    print("Peak allocated bytes on cuda:{}: {:1d}".format(dist.get_rank(), torch.cuda.memory_stats(dist.get_rank())["allocated_bytes.all.peak"]))
 
     if not args.multiprocess and len(model.balance) == 4:
 

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -307,7 +307,7 @@ def train(model_config, model, benchmark_config, args):
         raise RuntimeError(
             "Unable to benchmark on a single batch. Increase the size " " of the dataset and rerun the benchmark."
         )
-    if not args.multiprocess or dist.get_rank() == dist.get_world_size()-1:
+    if not args.multiprocess or dist.get_rank() == dist.get_world_size() - 1:
         return wps, loss.item()
     else:
         return 0.0, 0.0
@@ -371,22 +371,22 @@ def verify_lm_run(wps, golden_config):
 def benchmark_language_model(model_config, model, benchmark_config, args):
     golden_config = get_golden_config(args.model_name, args)
     epoch = benchmark_config["epochs"]
-    print("-" * 110)
-    print("| start of epoch {:1d}".format(epoch))
-    print("-" * 110)
     start_time = time.time()
     wps, loss = train(model_config, model, benchmark_config, args)
     elapsed_time = time.time() - start_time
-    print("-" * 110)
-    print("| end of epoch {:1d} | time: {:5.2f}s | train loss {:5.2f} ".format(epoch, elapsed_time, loss))
-    print("-" * 110)
     if dist.get_rank() == dist.get_world_size() - 1:
+        print("-" * 110)
+        print("| start of epoch {:1d}".format(epoch))
+        print("-" * 110)
+        print("-" * 110)
+        print("| end of epoch {:1d} | time: {:5.2f}s | train loss {:5.2f} ".format(epoch, elapsed_time, loss))
+        print("-" * 110)
         print("Throughput(wps) is {:.2f}.".format(wps))
-    print(
-        "Peak allocated bytes on cuda:{}: {:1d}".format(
-            dist.get_rank(), torch.cuda.memory_stats(dist.get_rank())["allocated_bytes.all.peak"]
+        print(
+            "Peak allocated bytes on cuda:{}: {:1d}".format(
+                dist.get_rank(), torch.cuda.memory_stats(dist.get_rank())["allocated_bytes.all.peak"]
+            )
         )
-    )
 
     if len(model.balance) == 4:
 

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -188,7 +188,7 @@ def get_device(model, index):
         return torch.cuda.current_device()
 
 
-def get_fake_dataloader(lm_dataloader_len):
+def get_fake_dataloader(lm_dataloader_len, args):
     fake_input = {"input": torch.zeros(args.batch_size)}
 
     class FakeDataset:
@@ -227,7 +227,7 @@ def train(model_config, model, benchmark_config, args):
 
     # TODO(anj-s): Avoid sending fake data to all replicas except the first and last one.
     if pipe_group and pipe_group.rank() != 0 and pipe_group.rank() != (pipe_group.size() - 1):
-        lm_dataloader = get_fake_dataloader(len(lm_dataloader))
+        lm_dataloader = get_fake_dataloader(len(lm_dataloader), args)
 
     total_tokens = 0
     total_tokens_per_log_interval = 0

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -514,7 +514,7 @@ def run_mp_worker(args, available_workers):
         print(f"running all at once")
         pipe_model.pipeline.all_at_once = True
 
-    if args.use_synthetic_data:
+    if args.dry_run:
         train(model_config, pipe_model, benchmark_config, args)
     else:
         benchmark_language_model(model_config, pipe_model, benchmark_config, args)

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -307,7 +307,7 @@ def train(model_config, model, benchmark_config, args):
         raise RuntimeError(
             "Unable to benchmark on a single batch. Increase the size " " of the dataset and rerun the benchmark."
         )
-    if not args.multiprocess or dist.get_rank() == 1:
+    if not args.multiprocess or dist.get_rank() == dist.get_world_size()-1:
         return wps, loss.item()
     else:
         return 0.0, 0.0

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -340,7 +340,7 @@ def get_number_of_words(data):
     return data.size()[0] * data.size()[1]
 
 
-def verify_lm_run(wps, golden_config):
+def verify_lm_run(wps, golden_config, args):
     """Verify that words per second for a given benchmark run matches the golden data."""
 
     # Verify wps only on the last rank in multiprocess pipe
@@ -401,9 +401,8 @@ def benchmark_language_model(model_config, model, benchmark_config, args):
         )
 
     if len(model.balance) == 4:
-
         if args.model_name == "lm":
-            verify_lm_run(wps, golden_config)
+            verify_lm_run(wps, golden_config, args)
         else:
             raise RuntimeError("Unrecognized args.model_name " % args.model_name)
 

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -369,7 +369,7 @@ def verify_lm_run(wps, golden_config):
 
 
 def benchmark_language_model(model_config, model, benchmark_config, args):
-    golden_config = get_golden_config(args.model_name)
+    golden_config = get_golden_config(args.model_name, args)
     epoch = benchmark_config["epochs"]
     print("-" * 110)
     print("| start of epoch {:1d}".format(epoch))
@@ -388,7 +388,7 @@ def benchmark_language_model(model_config, model, benchmark_config, args):
         )
     )
 
-    if not args.multiprocess and len(model.balance) == 4:
+    if len(model.balance) == 4:
 
         if args.model_name == "lm":
             verify_lm_run(wps, golden_config)
@@ -470,11 +470,11 @@ def create_benchmark_config(model_name):
         raise RuntimeError("Unrecognized args.model_mame " % args.model_name)
 
 
-def get_golden_config(model_name):
+def get_golden_config(model_name, args):
     """Return a dict with the golden data for throughput and memory usage."""
 
     if model_name == "lm":
-        return lm_wikitext2.get_golden_real_stats()
+        return lm_wikitext2.get_golden_real_stats(args.single_process)
     else:
         raise RuntimeError("Unrecognized args.model_mame " % args.model_name)
 

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -344,7 +344,7 @@ def verify_lm_run(wps, golden_config):
     """Verify that words per second for a given benchmark run matches the golden data."""
 
     # Verify wps only on the last rank in multiprocess pipe
-    if not args.multiprocess or dist.get_rank() == dist.get_world_size()-1:
+    if not args.multiprocess or dist.get_rank() == dist.get_world_size() - 1:
         # Assert that words per second is within 3 standard deviations of the average
         # of five golden runs
         print("Throughput(wps) is {:.2f}.".format(wps))
@@ -360,11 +360,11 @@ def verify_lm_run(wps, golden_config):
         rank = dist.get_rank()
         print("Peak allocated bytes on cuda:0: {:1d}".format(torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]))
         current_device_usage = torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]
-            if not current_device_usage < golden_ref * 1.1:
-                raise RuntimeError(
-                    "Peak memory usage for cuda device {:d} is {:d} which"
-                    "is less than golden reference value of {:d}".format(rank, current_device_usage, golden_ref)
-                )
+        if not current_device_usage < golden_ref * 1.1:
+            raise RuntimeError(
+                "Peak memory usage for cuda device {:d} is {:d} which"
+                "is less than golden reference value of {:d}".format(rank, current_device_usage, golden_ref)
+            )
     else:
         for i in range(4):
             print("Peak allocated bytes on cuda:0: {:1d}".format(torch.cuda.memory_stats(i)["allocated_bytes.all.peak"]))

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -182,7 +182,7 @@ def get_device(model, index):
 
     if not torch.cuda.is_available():
         return torch.device("cpu")
-    if model.devices:
+    if hasattr(model, "devices"):
         return model.devices[index]
     else:
         return torch.cuda.current_device()

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -474,7 +474,7 @@ def get_golden_config(model_name, args):
     """Return a dict with the golden data for throughput and memory usage."""
 
     if model_name == "lm":
-        return lm_wikitext2.get_golden_real_stats(args.single_process)
+        return lm_wikitext2.get_golden_real_stats(args.multiprocess)
     else:
         raise RuntimeError("Unrecognized args.model_mame " % args.model_name)
 

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -227,7 +227,7 @@ def train(model_config, model, benchmark_config, args):
 
     # TODO(anj-s): Avoid sending fake data to all replicas except the first and last one.
     if pipe_group and pipe_group.rank() != 0 and pipe_group.rank() != (pipe_group.size() - 1):
-        lm_dataloader = get_synthetic_dataloaders(args, benchmark_config)
+        lm_dataloader, _, _ = get_synthetic_dataloaders(args, benchmark_config)
 
     total_tokens = 0
     total_tokens_per_log_interval = 0

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -340,7 +340,7 @@ def get_number_of_words(data):
     return data.size()[0] * data.size()[1]
 
 
-def verify_peak_memory(rank, std_dev):
+def verify_peak_memory(rank, golden_config, std_dev):
     print("Peak allocated bytes on cuda:0: {:1d}".format(torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]))
     current_device_usage = torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]
     golden_ref = golden_config["peak_mem_usage"][rank]
@@ -368,10 +368,10 @@ def verify_lm_run(wps, golden_config, args):
             )
 
     if args.multiprocess:
-        verify_peak_memory(dist.get_rank(), 1.5)
+        verify_peak_memory(dist.get_rank(), golden_config, 1.5)
     else:
         for i in range(4):
-            verify_peak_memory(i, 1.1)
+            verify_peak_memory(i, golden_config, 1.1)
 
 
 def benchmark_language_model(model_config, model, benchmark_config, args):

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -554,12 +554,13 @@ def run_worker(rank, world_size, args):
 def benchmark_multiprocess(rank, world_size, args):
 
     init_method_pgroup = "tcp://localhost:{}".format(MPI_PORT)
+    # TODO(anj-s): Add regression benchmarks for nccl as well.
     torch.distributed.init_process_group(
         backend="gloo", rank=rank, world_size=world_size, init_method=init_method_pgroup
     )
 
     torch.cuda.set_device(rank % torch.cuda.device_count())
-
+    # TODO(anj-s): Move to TensorPipeRpcBackendOptions.
     rpc.init_rpc(
         f"Test{rank}",
         rank=rank,
@@ -603,6 +604,9 @@ parser.add_argument(
 
 if __name__ == "__main__":
     args = parser.parse_args()
+
+    # TODO(anj-s): Remove print statements and introduce logging levels.
+
     if not args.multiprocess:
         print(f"Running single process benchmark with args: {args}")
         benchmark_single_process(args)

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -507,7 +507,7 @@ def benchmark_single_process(args):
 def run_mp_worker(args, available_workers):
 
     benchmark_config = create_benchmark_config(args.model_name)
-    model_config = create_model_config(args, config=benchmark_config)
+    model_config = create_model_config(args, benchmark_config=benchmark_config)
     model = model_config["model"]
 
     print("get_pipeline_parallel_group().size() ", get_pipeline_parallel_group().size())
@@ -515,7 +515,7 @@ def run_mp_worker(args, available_workers):
     pipe_model = MultiProcessPipe(
         model,
         balance,
-        style=Pipe.MultiProcess,
+        style=MultiProcessPipe.MultiProcess,
         chunks=args.chunks,
         worker_map=get_worker_map(),
         input_device=torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -227,7 +227,7 @@ def train(model_config, model, benchmark_config, args):
 
     # TODO(anj-s): Avoid sending fake data to all replicas except the first and last one.
     if pipe_group and pipe_group.rank() != 0 and pipe_group.rank() != (pipe_group.size() - 1):
-        lm_dataloader = get_fake_dataloader(len(lm_dataloader), args)
+        lm_dataloader = get_synthetic_dataloaders(args, benchmark_config)
 
     total_tokens = 0
     total_tokens_per_log_interval = 0
@@ -510,20 +510,12 @@ def run_mp_worker(args, available_workers):
     model_config = create_model_config(args, config=benchmark_config)
     model = model_config["model"]
 
-<<<<<<< HEAD
     print("get_pipeline_parallel_group().size() ", get_pipeline_parallel_group().size())
     balance = generate_balance(get_pipeline_parallel_group().size(), len(model))
-    pipe_model = pipe.Pipe(
-        model,
-        balance,
-        style=Pipe.MultiProcess,
-=======
-    balance = generate_balance_weighted(get_pipeline_parallel_group().size(), len(model), 0.8)
     pipe_model = MultiProcessPipe(
         model,
         balance,
-        style=MultiProcessPipe.AsyncSchedule,
->>>>>>> master
+        style=Pipe.MultiProcess,
         chunks=args.chunks,
         worker_map=get_worker_map(),
         input_device=torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -360,6 +360,7 @@ def verify_lm_run(wps, golden_config, args):
         rank = dist.get_rank()
         print("Peak allocated bytes on cuda:0: {:1d}".format(torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]))
         current_device_usage = torch.cuda.memory_stats(rank)["allocated_bytes.all.peak"]
+        golden_ref = golden_config["peak_mem_usage"][rank]
         if not current_device_usage < golden_ref * 1.1:
             raise RuntimeError(
                 "Peak memory usage for cuda device {:d} is {:d} which"


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
* Reenables multiprocess nn.Pipe benchmarks(backend=nccl, rpc initialization is deprecated ProcessGroupRpcBackend)
* Moves num_decoder levels from args to config dict.
* Removes flags that we are not current testing with single or multiprocess benchmarks. They were for testing MPI + AsyncPipeline style. (we should add that benchmark in a followup PR)
* General cleanup.


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
