### PR TITLE
[feat][minor] Enabling ViT in OSS benchmarks

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -12,3 +12,4 @@ torch >= 1.5.1
 torchvision >= 0.6.0
 # NOTE(msb) not a dependency but needed by torch
 numpy == 1.17.4
+timm == 0.3.4


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Enabler for efforts like https://github.com/facebookresearch/fairscale/issues/277.
Makes it trivial to test models a little closer to SOTA, versus RN101 which previously the biggest available model

`python3 benchmarks/oss.py  --epochs 2 --optim_type oss_sharded_ddp --model vit_small_patch16_224 --batch_size 32` is all it takes to test a ViT, the compute cost difference is pretty obvious locally. Should make it easy to test follow ups from @myleott in a CV use case

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
