### PR TITLE
[docs] Remove broken link from fairscale docs.

### DIFF
--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example under the examples folder in the fairscale repo.
+You can find a complete example under the `examples folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>` in the fairscale repo.

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -60,7 +60,7 @@ You can then define any optimizer and loss function
     
 
 
-Finally, to run the model and compute the loss function, make sure that outputs and target are on the same device
+Finally, to run the model and compute the loss function, make sure that outputs and target are on the same device.
 
 .. code-block:: default   
 
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-run the example `here <../../../examples/tutorial_pipe.py>`_. 
+You can find a complete example `here <../../../examples/tutorial_pipe.py>`_. 

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example under the [examples folder](https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py) in the fairscale repo.
+You can find a complete example under the [examples folder] (https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py) in the fairscale repo.

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example under the examples `folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>` in the fairscale repo.
+You can find a complete example under the examples `folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>`_ in the fairscale repo.

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example `here <../../../examples/tutorial_pipe.py>`_. 
+You can find a complete example under the examples folder in the fairscale repo.

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example under the [examples folder] (https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py) in the fairscale repo.
+You can find a complete example under the examples `folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>` in the fairscale repo.

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example under the examples `folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>`_ in the fairscale repo.
+You can find a complete example under the `examples folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>`_ in the fairscale repo.

--- a/docs/source/tutorials/pipe.rst
+++ b/docs/source/tutorials/pipe.rst
@@ -77,4 +77,4 @@ Finally, to run the model and compute the loss function, make sure that outputs 
 
 
 
-You can find a complete example under the `examples folder <https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py>` in the fairscale repo.
+You can find a complete example under the [examples folder](https://github.com/facebookresearch/fairscale/blob/master/examples/tutorial_pipe.py) in the fairscale repo.


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [X ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
The link at the end of the pipe [tutorial](https://fairscale.readthedocs.io/en/latest/tutorials/pipe.html) is broken. This PR removes the link and modifies the wording.
I don't think you can refer to the examples directory from the docs directory. Let me know if I missed something. I could add a link to the repo example if you prefer. None of the other tutorials have a link to examples so I figured we can stay consistent and let people refer to it as needed. 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
