### PR TITLE
[cleanup] run coverage on latest PyTorch only

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -128,7 +128,7 @@ run_coverage: &run_coverage
   - run:
       name: Run Unit Tests With Coverage
       command: |
-        pytest --cov-report=xml --cov=./ --timeout 60
+        pytest --junitxml=test-results/junit.xml --verbose --timeout 60 --cov-report=xml --cov=./
         #Uploading test coverage for Python code
         bash <(curl -s https://codecov.io/bash) -f coverage.xml -cF Python
 
@@ -357,8 +357,6 @@ jobs:
 
       - <<: *run_unittests
 
-      - <<: *run_coverage
-
       - store_test_results:
           path: test-results
 
@@ -390,7 +388,7 @@ jobs:
 
       - <<: *install_repo_gpu
 
-      - <<: *run_unittests
+      - <<: *run_coverage
 
       - store_test_results:
           path: test-results


### PR DESCRIPTION
Also, we can save time by only running unittests once instead of
twice (with and without coverage).

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
