### PR TITLE
[chore] disheartening switch off of a OSS cpu test

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           python -m cibuildwheel --output-dir dist
         env:
-          CIBW_BUILD: "cp36-*64 cp37-*64 cp38-*64 cp39-*64"
+          CIBW_BUILD: "cp37-*64 cp38-*64 cp39-*64"
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux1
           CIBW_BEFORE_BUILD: pip install .
 

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -58,6 +58,10 @@ skip_if_py38 = pytest.mark.skipif(
     sys.version_info.major == 3 and sys.version_info.minor == 8, reason="Python3.8 is skipped"
 )
 
+skip_if_py39 = pytest.mark.skipif(
+    sys.version_info.major == 3 and sys.version_info.minor == 9, reason="Python3.9 is skipped"
+)
+
 _, filename_mpi = tempfile.mkstemp()
 
 

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -58,8 +58,9 @@ skip_if_py38 = pytest.mark.skipif(
     sys.version_info.major == 3 and sys.version_info.minor == 8, reason="Python3.8 is skipped"
 )
 
-skip_if_py39 = pytest.mark.skipif(
-    sys.version_info.major == 3 and sys.version_info.minor == 9, reason="Python3.9 is skipped"
+skip_if_py39_no_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available() and sys.version_info.major == 3 and sys.version_info.minor == 9,
+    reason="Python3.9 wo CUDA is skipped",
 )
 
 _, filename_mpi = tempfile.mkstemp()

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -22,7 +22,7 @@ import torch.multiprocessing as mp
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 import fairscale.optim as optim
-from fairscale.utils.testing import skip_if_no_cuda, skip_if_single_gpu
+from fairscale.utils.testing import skip_if_no_cuda, skip_if_py39, skip_if_single_gpu
 
 BACKEND = dist.Backend.NCCL if torch.cuda.is_available() else dist.Backend.GLOO  # type: ignore
 DEVICE = "cuda" if torch.cuda.is_available() else torch.device("cpu")
@@ -493,6 +493,7 @@ def test_reproducibility():
     )
 
 
+@skip_if_py39
 def run_test_multiple_groups(rank, world_size, tempfile_name):
     # Only work with the even ranks, to check that the global_rank indexing is properly used
     dist_init(rank=rank, world_size=world_size, tempfile_name=tempfile_name, backend="gloo")

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -22,7 +22,7 @@ import torch.multiprocessing as mp
 from torch.nn.parallel import DistributedDataParallel as DDP
 
 import fairscale.optim as optim
-from fairscale.utils.testing import skip_if_no_cuda, skip_if_py39, skip_if_single_gpu
+from fairscale.utils.testing import skip_if_no_cuda, skip_if_py39_no_cuda, skip_if_single_gpu
 
 BACKEND = dist.Backend.NCCL if torch.cuda.is_available() else dist.Backend.GLOO  # type: ignore
 DEVICE = "cuda" if torch.cuda.is_available() else torch.device("cpu")
@@ -493,7 +493,6 @@ def test_reproducibility():
     )
 
 
-@skip_if_py39
 def run_test_multiple_groups(rank, world_size, tempfile_name):
     # Only work with the even ranks, to check that the global_rank indexing is properly used
     dist_init(rank=rank, world_size=world_size, tempfile_name=tempfile_name, backend="gloo")
@@ -565,6 +564,7 @@ def run_test_multiple_groups(rank, world_size, tempfile_name):
     dist.destroy_process_group(process_group)
 
 
+@skip_if_py39_no_cuda
 def test_multiple_groups():
     world_size = 6
     temp_file_name = tempfile.mkstemp()[1]


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
This test runs on CPU, and typically never fails, on agents which are cuda enabled (it does use Gloo and device==cpu). The newer jobs which don't have cuda randomly fail on this very same test with python3.9, even if to the best of my knowledge nothing should change. This test remains active for gpu enabled agents, even if 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
