### PR TITLE
[refactor] multiprocess_pipe: remove pipelined_backward

### DIFF
--- a/benchmarks/experimental_ampnet.py
+++ b/benchmarks/experimental_ampnet.py
@@ -423,7 +423,6 @@ def run_mp_worker(args, available_workers):
         chunks=args.chunks,
         worker_map=get_worker_map(),
         input_device=torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),
-        pipelined_backward=False,
         checkpoint=args.checkpoint,
     )
     if torch.cuda.is_available():

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -523,7 +523,6 @@ def run_mp_worker(args, available_workers):
         chunks=args.chunks,
         worker_map=get_worker_map(),
         input_device=torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu"),
-        pipelined_backward=args.pipelined_backward,
         checkpoint=args.checkpoint,
         # TODO(anj-s): Do we need to comment this out? loss_fn=benchmark_config["criterion"],
     )
@@ -592,7 +591,6 @@ parser.add_argument(
 parser.add_argument(
     "--checkpoint", default="never", choices=["always", "except_last", "never"], help="Checkpointing strategy for pipe"
 )
-parser.add_argument("--pipelined-backward", action="store_true", help="Pipelined backward pass")
 parser.add_argument("--use_synthetic_data", action="store_true", help="Uses synthetic data for running benchmarks.")
 parser.add_argument("--dry_run", action="store_true", help="Run a sample training run without regression testing.")
 parser.add_argument(

--- a/fairscale/nn/pipe/async_pipe.py
+++ b/fairscale/nn/pipe/async_pipe.py
@@ -39,6 +39,10 @@ class PartitionInfo:
 
 
 class AsyncPipe(MultiProcessPipe):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+        self.pipelined_backward = False
+
     def create_pipeline(self) -> None:
         # The micro-batch index where the checkpointing stops.
         checkpoint_stop = {"always": self.chunks, "except_last": self.chunks - 1, "never": 0}[self.checkpoint]

--- a/tests/nn/model_parallel/test_layers.py
+++ b/tests/nn/model_parallel/test_layers.py
@@ -443,7 +443,6 @@ def run_test_pipe(rank, world_size, filename, filename_rpc, skip_dist_init=False
             worker_map=worker_map,
             input_device=torch.cuda.current_device(),
             chunks=chunk_size,
-            pipelined_backward=True,
         ).cuda()
         torch.distributed.barrier()
         pipe_rank = torch.distributed.get_rank(group=mpu.get_pipeline_parallel_group())

--- a/tests/nn/pipe_process/test_pipe.py
+++ b/tests/nn/pipe_process/test_pipe.py
@@ -26,7 +26,11 @@ import pytest
 import torch
 from torch import nn
 
-from fairscale.nn.model_parallel.initialize import get_pipeline_parallel_group
+from fairscale.nn.model_parallel.initialize import (
+    destroy_model_parallel,
+    get_pipeline_parallel_group,
+    initialize_model_parallel,
+)
 from fairscale.nn.pipe import AsyncPipe, LazyModule, MultiProcessPipe
 from fairscale.utils.testing import get_worker_map, torch_spawn, torch_version
 

--- a/tests/nn/pipe_process/test_pipe.py
+++ b/tests/nn/pipe_process/test_pipe.py
@@ -754,6 +754,24 @@ def verify_module_duplicate_parameters_on_distinct_partitions(pipe_class):
 
 
 @torch_spawn([4])
+@pytest.mark.parametrize("pipe_class", [MultiProcessPipe])
+def pipelined_backward(pipe_class):
+    model = nn.Sequential(nn.ReLU(), nn.ReLU())
+
+    destroy_model_parallel()
+    initialize_model_parallel(1, 4)
+    pipe = pipe_class(model, [1, 1], worker_map=get_worker_map())
+
+    assert pipe.pipelined_backward is False
+
+    destroy_model_parallel()
+    initialize_model_parallel(2, 2)
+    pipe = pipe_class(model, [1, 1], worker_map=get_worker_map())
+
+    assert pipe.pipelined_backward is True
+
+
+@torch_spawn([4])
 def async_event_loop():
 
     model = nn.Sequential(nn.Linear(10, 10), nn.ReLU(), nn.Linear(10, 10), nn.ReLU())


### PR DESCRIPTION
We want to limit the number of __init__ params. If pipelined_backward
is important, we'll add it back but not make it an option.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
