### PR TITLE
[refactor] OSS only use flat buffers

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -3,19 +3,19 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
-from collections import OrderedDict, deque
+from collections import OrderedDict
 import copy
 from itertools import chain
 import logging
 from math import inf
-from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, List, Optional, Type, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Type, Union
 
 import torch
 import torch.distributed as dist
 from torch.nn import Parameter
 from torch.optim import SGD, Optimizer
 
-from .utils import Workhandle, broadcast_object, recursive_copy_to_device
+from .utils import broadcast_object, recursive_copy_to_device
 
 __all__ = ["OSS"]
 
@@ -101,12 +101,9 @@ class OSS(Optimizer):
 
         # Current default device is set by the parameters allocated to this rank
         self._device = list(self.per_device_params.keys())[0]
-        self.buckets: Dict[torch.device, List[torch.Tensor]] = {}
-        self.buffer_max_size = broadcast_buffer_size
 
-        self.should_bucket_param: List[bool] = []
-        self.work_handles: Deque[Workhandle] = deque()
-        self._setup_bucket_strategy()
+        self.buckets: Dict[torch.device, List[torch.Tensor]] = {}
+        self._setup_flat_buffers()
 
     # Partition helpers
     def partition_parameters(self) -> List[List[dict]]:
@@ -509,7 +506,7 @@ class OSS(Optimizer):
                 self.optim.add_param_group(param_groups[-1])
 
             # Update the bucketing strategy accordingly
-            self._setup_bucket_strategy()
+            self._setup_flat_buffers()
 
     def _clear_cache(self) -> None:
         self._partition_parameters.clear()
@@ -540,94 +537,36 @@ class OSS(Optimizer):
     def _broadcast_params(self) -> None:
         """Helper function to broadcast all the parameters from a given device"""
 
-        i_param = 0
         last_work_handle = None  # Work handles are consumed within this scope, no callback
 
-        for (device, device_params,) in self.per_device_params.items():  # all the params on this device (inc all ranks)
-            buckets = self.buckets[device]
+        for device in self.per_device_params.keys():
             # Bucket and issue all the async calls
-            for (src_rank, params), bucket in zip(enumerate(device_params), buckets):
+            for src_rank, bucket in enumerate(self.buckets[device]):
                 global_src_rank = self.get_global_rank(self.group, src_rank)
-
-                # Direct broadcasts only
-                for param in params:
-                    if not self.should_bucket_param[i_param]:
-                        last_work_handle = dist.broadcast(
-                            tensor=param.data, src=global_src_rank, group=self.group, async_op=True
-                        )
-
-                    i_param += 1
-
-                # Bucket broadcasts
                 last_work_handle = dist.broadcast(tensor=bucket, src=global_src_rank, group=self.group, async_op=True)
 
         # Only check on the last handle, they're all inlined on the same CUDA stream
         if last_work_handle:
             last_work_handle.wait()
 
-    def _consume_work_handles(self) -> None:
-        """Consume all the futures which are tied to this optimizer's buckets.
-        We start from the first/older ones, since they are the most likely to be ready and non-blocking
+    def _setup_flat_buffers(self) -> None:
+        """Make all params which are on the same device and tied to the same rank views of a single buffer
         """
-
-        while len(self.work_handles) > 0:
-            work_handle = self.work_handles.popleft()
-            work_handle.handle.wait()
-            if work_handle.callback is not None:
-                work_handle.callback()
-
-    def _try_consume_work_handle(self) -> None:
-        """Try to consume the oldest future. This is non blocking, if not ready we'll pass"""
-        while len(self.work_handles) > 0 and self.work_handles[0].handle.is_completed():
-            work_handle = self.work_handles.popleft()
-            if work_handle.callback is not None:
-                work_handle.callback()
-
-    def _setup_bucket_strategy(self) -> None:
-        """Tag parameters to either bucket them or broadcast/reduce them directly. The parameters are ordered
-        (smallest first), the bucket will hold the smallest elements, the remaining ones will be directly sent
-        over the wire.
-
-        Generating the partition once and for all allows us to save some time at runtime, and to know when all the
-        network requests have been issued.
-        """
-
-        # (re) allocate the buckets
-        #  - Get the correct size for the buckets, cannot be bigger than the model
-        model_size = sum([p.numel() for p in self.param_to_rank.keys()])
-        self.bucket_size = min(self.buffer_max_size, model_size)
-        logging.info(
-            "Bucket size: {:.2f}M parameters, model size {:.2f}M parameters".format(
-                self.bucket_size / 2 ** 20, model_size / 2 ** 20
-            )
-        )
-
-        # - Allocate one buffer per rank and per device to group the small parameters
-        for device, per_device in self.per_device_params.items():
-            self.buckets[device] = [
-                torch.zeros(self.bucket_size, dtype=per_device[0][0].dtype, device=device)
-                for _ in range(len(per_device))
-            ]
 
         # Devise the bucketing strategy
         for device, per_rank_params in self.per_device_params.items():
+            self.buckets[device] = []
+
             for dst_rank, params in enumerate(per_rank_params):
+
+                buffer_size = sum(map(lambda x: x.numel(), filter(lambda x: x.requires_grad, params)))
+                self.buckets[device].append(torch.zeros(buffer_size, dtype=params[0].dtype, device=device))
                 offset = 0
 
-                for param in params:
-                    # Criteria to decide whether this parameter is to be bucketed or not:
-                    # - enough room in the bucket
-                    if param.requires_grad and (offset + param.numel()) < self.bucket_size:
-                        self.should_bucket_param.append(True)
+                for param in filter(lambda x: x.requires_grad, params):
+                    # This parameter becomes a view of the bucket
+                    offset_next = offset + param.numel()
 
-                        # This parameter becomes a view of the bucket
-                        offset_next = offset + param.numel()
-
-                        self.buckets[device][dst_rank][offset:offset_next].copy_(param.data.flatten())
-                        param.data = self.buckets[device][dst_rank][offset:offset_next].view_as(param.data)
-                        offset = offset_next
-                    else:
-                        self.should_bucket_param.append(False)
-
-                # Resize the bucket to remove lost space in the end
-                self.buckets[device][dst_rank].resize_(offset)
+                    self.buckets[device][dst_rank][offset:offset_next].copy_(param.data.flatten())
+                    param.data = self.buckets[device][dst_rank][offset:offset_next].view_as(param.data)
+                    offset = offset_next

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -51,9 +51,7 @@ class OSS(Optimizer):
         group (group):
             torch.distributed group (default: group.WORLD)
         broadcast_buffer_size (int):
-            the max size of the buffer used to batch the small parameter tensors, in number of elements (default 16M).
-            this will not impact the long term memory consumption, but the peak memory can be impacted by the moment
-            when the buffers are allocated and the bucketed params have not yet been relocated to them.
+            (deprecated) used to cap the size of the broadcast buffers, not being used anymore.
     """
 
     #: The optimizer used for a given shard
@@ -66,7 +64,7 @@ class OSS(Optimizer):
         params: _params_t,
         optim: Type[Optimizer] = SGD,
         group: Optional[Any] = None,
-        broadcast_buffer_size: int = 2 ** 24,
+        broadcast_buffer_size: int = -1,
         **default: Any,
     ):
 

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -52,11 +52,6 @@ class OSS(Optimizer):
             torch.distributed group (default: group.WORLD)
         broadcast_buffer_size (int):
             (deprecated) used to cap the size of the broadcast buffers, not being used anymore.
-
-    .. warning: the communication patterns that OSS use depend on the "trainability" graph,
-        meaning that all the parameters which `require_grad` are handled differently. This is
-        not reevaluated at every step, please use `refresh_trainability()` if your model changed
-        (freeze or unfreeze for instance).
     """
 
     #: The optimizer used for a given shard
@@ -106,14 +101,6 @@ class OSS(Optimizer):
         self._device = list(self.per_device_params.keys())[0]
         self.work_handles: Deque[Workhandle] = deque()
         self.buckets: Dict[torch.device, List[torch.Tensor]] = {}
-        self._setup_flat_buffers()
-
-    def refresh_trainability(self) -> None:
-        """ Updates the partitioning and communication patterns if the trainability (`requires_grad`)
-        of some parameters changed
-        """
-
-        self._clear_cache()
         self._setup_flat_buffers()
 
     # Partition helpers

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -9,6 +9,7 @@ from itertools import chain
 import logging
 from math import inf
 from typing import TYPE_CHECKING, Any, Callable, Deque, Dict, List, Optional, Type, Union
+
 import torch
 import torch.distributed as dist
 from torch.nn import Parameter


### PR DESCRIPTION
# Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x]  Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Just a natural extension of the params being tensor views of a bigger tensor (#300), no need to keep the non-bucketed params, I feel a little dumb but it's just much simpler and just as fast to have one single buffer per device and per rank (or faster for multi node, less latency). 

So this PR just does that, all the trainable params which belong to the same device/rank link are packed into a single tensor, like before but not bounded. There's no tradeoff really, the original parameter memory is released.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
