### PR TITLE
Workaround need for pip --no-build-isolation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "torch >= 1.4.0",
     "wheel >= 0.30.0"
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "setuptools.build_meta:__legacy__"
 
 [tool.black]
 line-length = 120


### PR DESCRIPTION
Build isolation means that pip will create an isolated build environment and only provide the packages listed in fairscale/pyproject.toml. As `torch` is liste in fairscale/pyproject.toml, pip will always download the default torch package with gpu support from pypi. This package is very large and typically not the same as the one used in the runtime environment. I think it's better to disable the build isolation feature by default and build against the torch library that fairscale is actually being used with at runtime.

See https://github.com/facebookresearch/fairscale/issues/305