### PR TITLE
[feature] Unit test with and without buckets for all ShardedDDP unit tests

### DIFF
--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -329,7 +329,6 @@ class ShardedDataParallel(nn.Module):
                 See :meth:`torch.optim.Optimizer.zero_grad` for details.
         """
 
-        print("zeroing grads", flush=True)
         for index, trainable_param in enumerate(self._all_params):
             if set_to_none and not self._should_bucket_grad[index]:
                 trainable_param.grad = None

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -412,7 +412,7 @@ class OSS(Optimizer):
 
     def refresh_trainable(self) -> None:
         """ Updates the partitioning and communication patterns if the trainability (`requires_grad`)
-        of some parameters changed
+        of some parameters changed.
         """
 
         # Create the optim which will work on the param shard

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -54,7 +54,7 @@ skip_if_single_gpu = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 2, reason="multiple GPUs required"
 )
 
-skip_if_less_four_gpu = pytest.mark.skipif(
+skip_if_less_than_four_gpu = pytest.mark.skipif(
     not torch.cuda.is_available() or torch.cuda.device_count() < 4, reason="4 GPUs or more required"
 )
 

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -418,3 +418,31 @@ def check_same_model_params(model_a: torch.nn.Module, model_b: torch.nn.Module, 
 
     for b_a, b_b in zip(model_a.buffers(), model_b.buffers()):
         assert torch.allclose(b_a, b_b), f"Model buffers differ {b_a} - {b_b}\n" + message
+
+
+def check_same_models_across_ranks(
+    model: torch.nn.Module, process_group: Any, params_should_be_equal: bool, check_broadcast_buffers: bool
+) -> None:
+    world_size = dist.get_world_size(process_group)
+    rank = dist.get_rank(process_group)
+    for param in model.parameters():
+        # collect the params across the rank
+        receptacle = [param.clone() for _ in range(world_size)]
+        dist.all_gather(receptacle, param, group=process_group)
+
+        if rank == 0:
+            for sync_p in receptacle[1:]:
+                assert not params_should_be_equal or torch.all(
+                    torch.eq(receptacle[0], sync_p)
+                ), "Models differ in between ranks"
+
+    # Check that all the buffers are in sync (authoritative rank is 0, its buffer is 0)
+    if check_broadcast_buffers:
+        for buffer in model.buffers():
+            receptacle = [buffer.clone() for _ in range(world_size)]
+            dist.all_gather(receptacle, buffer, group=process_group)
+            if rank == 0:
+                for sync_b in receptacle[1:]:
+                    assert not params_should_be_equal or torch.all(
+                        torch.eq(receptacle[0], sync_b)
+                    ), "Models differ in between ranks"

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -67,6 +67,11 @@ skip_if_py39_no_cuda = pytest.mark.skipif(
     reason="Python3.9 wo CUDA is skipped",
 )
 
+available_devices = ["cpu"]
+if torch.cuda.is_available():
+    available_devices.append("cuda")
+
+
 _, filename_mpi = tempfile.mkstemp()
 
 

--- a/tests/nn/data_parallel/test_sharded_ddp.py
+++ b/tests/nn/data_parallel/test_sharded_ddp.py
@@ -515,7 +515,7 @@ def run_test_training_change(rank, world_size, backend, device, temp_file_name, 
 
     model = Sequential(Linear(2, 3), Linear(3, 3)).to(device)
     optimizer = OSS(params=model.parameters(), optim=torch.optim.SGD, lr=0.01, momentum=0.99)
-    ddp_model = ShardedDataParallel(model, optimizer, process_group=group, reduce_buffer_size=bucket_size)
+    ddp_model = ShardedDataParallel(model, optimizer, process_group=group, reduce_buffer_size=reduce_buffer_size)
 
     inputs = torch.rand((10, 2), device=device)
     outputs = ddp_model(inputs)  # assert if the module has not been changed properly

--- a/tests/nn/data_parallel/test_sharded_ddp.py
+++ b/tests/nn/data_parallel/test_sharded_ddp.py
@@ -171,18 +171,8 @@ def run_ddp_parity(rank, world_size, backend, temp_file_name):
                     loss.backward()
 
             with model.no_sync() if should_accumulate else suppress():
-                for param in model.parameters():
-                    if param.requires_grad and param.grad is not None:
-                        print(rank, torch.norm(param.grad), flush=True)
-                        break
-
                 for _ in range(accumulate_steps - 1):
                     step()
-
-                    for param in model.parameters():
-                        if param.requires_grad and param.grad is not None:
-                            print(rank, torch.norm(param.grad), flush=True)
-                            break
 
             if not _manual_reduction:
                 step()


### PR DESCRIPTION
# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Too many papercuts (or full fledged bugs) slipped through recently, and I realized that the unit tests were not covering all combinations. The module can flip from train to test, be under a no_sync context, be using AMP, trainability can change on a per-parameter basis, and buckets can be used or not.

This PR adds buckets yes/no to all tests but one, including the ddp_parity test which covers most of the matrix above. It fixes a bug which went unseen on that field (not a silent bug though, as it would assert), when leaving a no_sync context and using buckets. It fixes another bug which went unseen in handling several groups while using buckets. 

Fixes https://github.com/facebookresearch/fairscale/issues/398
Makes sure that https://github.com/facebookresearch/fairscale/issues/397 does not happen again

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
