### PR TITLE
[refactor]Split benchmarks/ configs to contain model tuning vs run configs separately.

### DIFF
--- a/benchmarks/datasets/wikitext2_data.py
+++ b/benchmarks/datasets/wikitext2_data.py
@@ -21,11 +21,11 @@ def _batchify(data, batch_size):
     return data
 
 
-def _get_total_batch_size(benchmark_config):
-    return benchmark_config["seq_len"] * benchmark_config["batch_size"]
+def _get_total_batch_size(benchmark_config, model_specs):
+    return model_specs["seq_len"] * benchmark_config["batch_size"]
 
 
-def get_real_dataloaders(args, benchmark_config):
+def get_real_dataloaders(args, benchmark_config, model_specs):
     """Return real dataloaders for training, testing and validation."""
 
     url = "https://s3.amazonaws.com/research.metamind.io/wikitext/wikitext-2-v1.zip"
@@ -47,21 +47,21 @@ def get_real_dataloaders(args, benchmark_config):
         batch_size = args.batch_size
         return _batchify(data, batch_size)
 
-    total_batch_size = _get_total_batch_size(benchmark_config)
+    total_batch_size = _get_total_batch_size(benchmark_config, model_specs)
     train_dataloader = DataLoader(train_dataset, batch_size=total_batch_size, collate_fn=batchify)
     valid_dataloader = DataLoader(valid_dataset, batch_size=total_batch_size, collate_fn=batchify)
     test_dataloader = DataLoader(test_dataset, batch_size=total_batch_size, collate_fn=batchify)
     return len(vocab.stoi), train_dataloader, valid_dataloader, test_dataloader
 
 
-def get_synthetic_dataloaders(args, benchmark_config):
+def get_synthetic_dataloaders(args, benchmark_config, model_specs):
     """Return synthetic dataloaders for training, testing and validation."""
 
     def batchify(data):
         batch_size = args.batch_size
         return _batchify(data, batch_size)
 
-    total_batch_size = total_batch_size = _get_total_batch_size(benchmark_config)
+    total_batch_size = total_batch_size = _get_total_batch_size(benchmark_config, model_specs)
     # vocab_size is 10000 and length of the real data is 2049990.
     lm_dataset = torch.randint(1, 10000, (2049990,))
 

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -5,23 +5,28 @@ import torch.nn as nn
 from fairscale.optim import GradScaler
 
 
-def get_benchmark_config():
-
+def get_model_config():
     return {
-        "epochs": 1,
         "vocab_size": 10000,
         "ninp": 2048,  # embedding dimension
         "nhid": 2048,  # the dimension of the feedforward network model in nn.TransformerEncoder
         "nhead": 32,  # the number of heads in the multiheadattention models
         "dropout": 0,
         "initrange": 0.1,
-        "criterion": nn.CrossEntropyLoss(),
-        "lr": 0.001,  # learning rate
         "scaler": GradScaler(),
         "clip_value": 0.05,
-        "batch_size": 8,
         "num_decoder_layers": 10,
         "seq_len": 32,
+    }
+
+
+def get_benchmark_config():
+
+    return {
+        "epochs": 1,
+        "lr": 0.001,  # learning rate
+        "batch_size": 8,
+        "criterion": nn.CrossEntropyLoss(),
     }
 
 


### PR DESCRIPTION
# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Split the benchmark configs to separate out those required for the model construction vs running the benchmark. This allows for code reuse across different modules.

Part of the offload work which uses the model config but not the run config.

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
