### PR TITLE
[fix] Buffers, like params go back to fp32 after fwd

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -413,9 +413,6 @@ class FullyShardedDataParallel(nn.Module):
         .. warning:: This needs to be called on all ranks, since synchronization
             primitives will be used.
         """
-        if self.mixed_precision:
-            # Buffers dtype stays consistent with parameters.
-            self._all_buffers_to(torch.float32)
 
         if self._return_full_state_dict:
             if self.training_state != TrainingState.SUMMON_FULL_PARAMS:
@@ -434,9 +431,6 @@ class FullyShardedDataParallel(nn.Module):
             else:
                 state_dict = super().state_dict(*args, **kwargs)
 
-        if self.mixed_precision:
-            # In case we are in mixed precision, restore buffers back to fp16.
-            self._all_buffers_to(self.compute_dtype)
         return state_dict
 
     # TODO (Min): figuring out how to do typing for this overloaded function.
@@ -578,7 +572,7 @@ class FullyShardedDataParallel(nn.Module):
             self._set_is_root()
             self._setup_streams()
 
-        if self.cpu_offload:  # Buffers stay on GPU, and don't get sharded
+        if self.cpu_offload:  # Buffers stay on GPU, and don't get sharded, regardless of cpu_offload
             self._all_buffers_to(self.compute_dtype, device=torch.device("cuda"))
         else:
             self._all_buffers_to(self.compute_dtype)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -733,7 +733,6 @@ class FullyShardedDataParallel(nn.Module):
         if self.mixed_precision:
             args, kwargs = cast_inputs_to_fp16(*args, **kwargs)
             # Buffers are cast to compute_dtype in lazy_init
-            self.compute_dtype
 
         # All-gather full parameters. This will also transfer FP32 parameters to
         # ``self.compute_dtype`` (e.g., FP16 if *mixed_precision* is ``True``).
@@ -1087,7 +1086,7 @@ def cast_buffers_(
 ) -> None:
     """Cast all of module.named_buffers to device and floating point buffers to dtype."""
     # if buffers are already on the right device and/or dtype this is just python loop cost
-    assert dtype in {torch.float32, torch.float16}, dtype  # assumes compute_dtype == float16
+    assert dtype in {torch.float32, torch.float16}, f"dtype {dtype} not in {torch.float32, torch.float16}"
     for key, buf in module.named_buffers(recurse=False):
         if buf is not None:
             buf = buf.to(device=device)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -219,7 +219,7 @@ class FullyShardedDataParallel(nn.Module):
         return self._fsdp_wrapped_module  # note: may be a FlattenParamsWrapper instance
 
     @torch.no_grad()
-    def _all_buffers_to(self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None) -> None:
+    def _all_buffers_to(self, dtype: torch.dtype, device: Optional[torch.device] = None) -> None:
         """Move all buffers to the specified device and dtype, recursively."""
         cast_fn = functools.partial(cast_buffers_, device=device, dtype=dtype)
         self.apply(cast_fn)
@@ -413,9 +413,6 @@ class FullyShardedDataParallel(nn.Module):
         .. warning:: This needs to be called on all ranks, since synchronization
             primitives will be used.
         """
-        if self.mixed_precision:
-            # Buffers dtype stays consistent with parameters.
-            self._all_buffers_to(dtype=torch.float32)
 
         if self._return_full_state_dict:
             if self.training_state != TrainingState.SUMMON_FULL_PARAMS:
@@ -434,9 +431,6 @@ class FullyShardedDataParallel(nn.Module):
             else:
                 state_dict = super().state_dict(*args, **kwargs)
 
-        if self.mixed_precision:
-            # In case we are in mixed precision, restore buffers back to fp16.
-            self._all_buffers_to(dtype=self.compute_dtype)
         return state_dict
 
     # TODO (Min): figuring out how to do typing for this overloaded function.
@@ -578,10 +572,10 @@ class FullyShardedDataParallel(nn.Module):
             self._set_is_root()
             self._setup_streams()
 
-        if self.cpu_offload:  # Buffers stay on GPU, and don't get sharded
-            self._all_buffers_to(device=torch.device("cuda"), dtype=self.compute_dtype)
+        if self.cpu_offload:  # Buffers stay on GPU, and don't get sharded, regardless of cpu_offload
+            self._all_buffers_to(self.compute_dtype, device=torch.device("cuda"))
         else:
-            self._all_buffers_to(dtype=self.compute_dtype)
+            self._all_buffers_to(self.compute_dtype)
 
         if self._is_root:
             # Don't free the full params for the outer-most (root) instance,
@@ -738,6 +732,7 @@ class FullyShardedDataParallel(nn.Module):
 
         if self.mixed_precision:
             args, kwargs = cast_inputs_to_fp16(*args, **kwargs)
+            # Buffers are cast to compute_dtype in lazy_init
 
         # All-gather full parameters. This will also transfer FP32 parameters to
         # ``self.compute_dtype`` (e.g., FP16 if *mixed_precision* is ``True``).
@@ -758,6 +753,7 @@ class FullyShardedDataParallel(nn.Module):
         # initialized with the correct dtype and (sharded) size, since optimizer
         # state is typically initialized lazily in ``optim.step()``.
         self._use_fp32_param_shard()
+        self._all_buffers_to(torch.float32)
 
         # Register pre-backward hooks to all-gather the params for the backward
         # pass (if needed).
@@ -1090,7 +1086,7 @@ def cast_buffers_(
 ) -> None:
     """Cast all of module.named_buffers to device and floating point buffers to dtype."""
     # if buffers are already on the right device and/or dtype this is just python loop cost
-    assert dtype in {torch.float32, torch.float16}  # assumes compute_dtype == float16
+    assert dtype in {torch.float32, torch.float16}, f"dtype {dtype} not in {torch.float32, torch.float16}"
     for key, buf in module.named_buffers(recurse=False):
         if buf is not None:
             buf = buf.to(device=device)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -219,7 +219,7 @@ class FullyShardedDataParallel(nn.Module):
         return self._fsdp_wrapped_module  # note: may be a FlattenParamsWrapper instance
 
     @torch.no_grad()
-    def _all_buffers_to(self, dtype: torch.dtype, device: Optional[torch.device] = None) -> None:
+    def _all_buffers_to(self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None) -> None:
         """Move all buffers to the specified device and dtype, recursively."""
         cast_fn = functools.partial(cast_buffers_, device=device, dtype=dtype)
         self.apply(cast_fn)
@@ -413,6 +413,9 @@ class FullyShardedDataParallel(nn.Module):
         .. warning:: This needs to be called on all ranks, since synchronization
             primitives will be used.
         """
+        if self.mixed_precision:
+            # Buffers dtype stays consistent with parameters.
+            self._all_buffers_to(dtype=torch.float32)
 
         if self._return_full_state_dict:
             if self.training_state != TrainingState.SUMMON_FULL_PARAMS:
@@ -431,6 +434,9 @@ class FullyShardedDataParallel(nn.Module):
             else:
                 state_dict = super().state_dict(*args, **kwargs)
 
+        if self.mixed_precision:
+            # In case we are in mixed precision, restore buffers back to fp16.
+            self._all_buffers_to(dtype=self.compute_dtype)
         return state_dict
 
     # TODO (Min): figuring out how to do typing for this overloaded function.
@@ -572,10 +578,10 @@ class FullyShardedDataParallel(nn.Module):
             self._set_is_root()
             self._setup_streams()
 
-        if self.cpu_offload:  # Buffers stay on GPU, and don't get sharded, regardless of cpu_offload
-            self._all_buffers_to(self.compute_dtype, device=torch.device("cuda"))
+        if self.cpu_offload:  # Buffers stay on GPU, and don't get sharded
+            self._all_buffers_to(device=torch.device("cuda"), dtype=self.compute_dtype)
         else:
-            self._all_buffers_to(self.compute_dtype)
+            self._all_buffers_to(dtype=self.compute_dtype)
 
         if self._is_root:
             # Don't free the full params for the outer-most (root) instance,
@@ -732,7 +738,6 @@ class FullyShardedDataParallel(nn.Module):
 
         if self.mixed_precision:
             args, kwargs = cast_inputs_to_fp16(*args, **kwargs)
-            # Buffers are cast to compute_dtype in lazy_init
 
         # All-gather full parameters. This will also transfer FP32 parameters to
         # ``self.compute_dtype`` (e.g., FP16 if *mixed_precision* is ``True``).
@@ -753,7 +758,6 @@ class FullyShardedDataParallel(nn.Module):
         # initialized with the correct dtype and (sharded) size, since optimizer
         # state is typically initialized lazily in ``optim.step()``.
         self._use_fp32_param_shard()
-        self._all_buffers_to(torch.float32)
 
         # Register pre-backward hooks to all-gather the params for the backward
         # pass (if needed).
@@ -1086,7 +1090,7 @@ def cast_buffers_(
 ) -> None:
     """Cast all of module.named_buffers to device and floating point buffers to dtype."""
     # if buffers are already on the right device and/or dtype this is just python loop cost
-    assert dtype in {torch.float32, torch.float16}, f"dtype {dtype} not in {torch.float32, torch.float16}"
+    assert dtype in {torch.float32, torch.float16}  # assumes compute_dtype == float16
     for key, buf in module.named_buffers(recurse=False):
         if buf is not None:
             buf = buf.to(device=device)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -738,7 +738,8 @@ class FullyShardedDataParallel(nn.Module):
 
         if self.mixed_precision:
             args, kwargs = cast_inputs_to_fp16(*args, **kwargs)
-            self._all_buffers_to(torch.float16)
+            # Buffers are cast to compute_dtype in lazy_init
+            self.compute_dtype
 
         # All-gather full parameters. This will also transfer FP32 parameters to
         # ``self.compute_dtype`` (e.g., FP16 if *mixed_precision* is ``True``).

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -481,6 +481,7 @@ class DeviceAndTypeCheckModule(Base):
         self.expected_loss_device = expected_loss_device
 
         self.linear = nn.Linear(5, 5)
+        self.register_buffer('buffer', torch.rand((5,)))
 
     def _check(
         self,
@@ -497,6 +498,7 @@ class DeviceAndTypeCheckModule(Base):
 
         param = self.linear.weight
         self._check("param.dtype", param.dtype, self.expected_param_dtype)
+        self._check("buffer.dtype", self.buffer.dtype, self.expected_param_dtype)
         self._check("param.device", param.device, self.expected_param_device)
 
         loss = self.linear(x).sum()

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -481,7 +481,7 @@ class DeviceAndTypeCheckModule(Base):
         self.expected_loss_device = expected_loss_device
 
         self.linear = nn.Linear(5, 5)
-        self.register_buffer('buffer', torch.rand((5,)))
+        self.register_buffer("buffer", torch.rand((5,)))
 
     def _check(
         self,
@@ -498,7 +498,8 @@ class DeviceAndTypeCheckModule(Base):
 
         param = self.linear.weight
         self._check("param.dtype", param.dtype, self.expected_param_dtype)
-        self._check("buffer.dtype", self.buffer.dtype, self.expected_param_dtype)
+        for b in self.buffers():
+            self._check("buffer.dtype", b.dtype, self.expected_param_dtype)
         self._check("param.device", param.device, self.expected_param_device)
 
         loss = self.linear(x).sum()

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -87,6 +87,7 @@ class TestMixedPrecision(DistributedTest):
             torch.float32,  # expected_param_dtype
             torch.float32,  # expected_loss_dtype
             torch.float32,  # expected_reduce_dtype
+            #torch.float32,  # expected_buffer_dtype
         )
 
     def test_mixed_precision(self):
@@ -167,9 +168,10 @@ class TestMixedPrecision(DistributedTest):
             x = torch.rand(2, 5).to(device)
             with torch.cuda.amp.autocast(enabled=autocast):
                 loss = model(x)
-            for n,b in model.named_buffers():
-                 model._check(f'{n}.after_fwd_dtype', b.dtype, expected=reduce_dtype)
+
             loss.backward()
+        for n,b in model.named_buffers():
+             model._check(f'{n}.after_fwd_dtype', b.dtype, expected=torch.float32)
 
 
 keys = ["reshard_after_forward", "mixed_precision", "flatten_parameters"]

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -653,7 +653,7 @@ class TestNoSync(DistributedTest):
 
     @classmethod
     def _test_transformer(self, rank, group, config):
-        model = self.get_wrapped_model(group, config=config)
+        model = self.get_wrapped_model(group, config=config, add_bn=False)
         model.eval()  # turn off dropout for the test
         self._test_no_sync(model, batch_dim=1)
 
@@ -678,7 +678,7 @@ class TestNoSync(DistributedTest):
         for x, y in zip(batch1, batch2):
             assert not torch.all(x == y)
 
-        # Concat the batches along batch dimension.
+        # Concat the batches along batch dimension.  (This breaks the unit-test batch norm implem)
         concat_batch = tuple(torch.cat((x, y), dim=batch_dim) for (x, y) in zip(batch1, batch2))
 
         # Establish reference behavior on the concat batch.

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -157,6 +157,8 @@ class TestMixedPrecision(DistributedTest):
         def _reduce_scatter(output, input_list, **kwargs):
             for tensor in input_list:
                 model._check("reduce_scatter.dtype", tensor.dtype, expected=reduce_dtype)
+
+
             return orig_reduce_scatter(output, input_list, **kwargs)
 
         with mock.patch("torch.distributed.reduce_scatter", new=_reduce_scatter):
@@ -165,6 +167,8 @@ class TestMixedPrecision(DistributedTest):
             x = torch.rand(2, 5).to(device)
             with torch.cuda.amp.autocast(enabled=autocast):
                 loss = model(x)
+            for n,b in model.named_buffers():
+                 model._check(f'{n}.after_fwd_dtype', b.dtype, expected=reduce_dtype)
             loss.backward()
 
 

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -195,9 +195,7 @@ class TestComparisonToPyTorchDDP(DistributedTest):
 
     def test_transformer_batch_norm_breaks(self):
         model_fn = functools.partial(TransformerWithSharedParams, add_bn=True)
-        test_fn = functools.partial(
-            self._test_identical_outputs, model_fn, {'mixed_precision': True}, lr=0.01
-        )
+        test_fn = functools.partial(self._test_identical_outputs, model_fn, {"mixed_precision": True}, lr=0.01)
         spawn_and_init(test_fn)
 
     def test_cpu_offload_and_cpu_grads(self):
@@ -723,21 +721,21 @@ class TransformerWithSharedParams(nn.Module):
 
         self.bs = 2
         self.bn = torch.nn.BatchNorm1d(self.bs) if add_bn else torch.nn.Identity()
-        print(f'FWD: {self.bn.weight.dtype, self.bn.running_mean.dtype}')
+        print(f"FWD: {self.bn.weight.dtype, self.bn.running_mean.dtype}")
 
     def get_input(self, device):
         torch.manual_seed(1 + self.rank)  # keep everything deterministic
-        src = torch.arange(self.bs*6, device=device).view(6, self.bs)  # T x B
-        tgt = torch.arange(self.bs*4, device=device).view(4, self.bs)  # T x B
+        src = torch.arange(self.bs * 6, device=device).view(6, self.bs)  # T x B
+        tgt = torch.arange(self.bs * 4, device=device).view(4, self.bs)  # T x B
         return (src, tgt)
 
     def forward(self, src_ids, tgt_ids):
         src = self.embed_tokens(src_ids)
         src = src + self.vocab_bias + self.long_buffer.type_as(src)
         tgt = self.embed_tokens(tgt_ids)
-        print(f'FWD: {self.bn.weight.dtype, self.bn.running_mean.dtype}')
+        print(f"FWD: {self.bn.weight.dtype, self.bn.running_mean.dtype}")
         tgt = self.bn(tgt)
-        #print(f'FWD: {self.bn.weight.dtype, self.bn.running_mean.dtype}')
+        # print(f'FWD: {self.bn.weight.dtype, self.bn.running_mean.dtype}')
         x = self.transformer(src, tgt)
         return self.output_proj(x)
 


### PR DESCRIPTION

## 🐛 Bug (copy pasted from issue)

In FSDP with `mixed_precision=True`, we only maintain buffers in FP16. This could lead to underflow/overflow for buffers that wouldn't happen with standard AMP training.

Ideally we could keep the buffers in their original dtype, but it's unclear how/when/if to cast to `compute_dtype`. For static buffers it doesn't matter, but for BatchNorm we want updates to happen in full precision.