### PR TITLE
Add is root check to only cast to FP16 on main FSDP wrapper

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -736,7 +736,7 @@ class FullyShardedDataParallel(nn.Module):
         # Start of a forward pass.
         self.training_state = TrainingState.FORWARD
 
-        if self.mixed_precision:
+        if self._is_root and self.mixed_precision:
             args, kwargs = cast_inputs_to_fp16(*args, **kwargs)
 
         # All-gather full parameters. This will also transfer FP32 parameters to


### PR DESCRIPTION
## What does this PR do?

Related to #446, was running into an issue with nested FSDP wrappers. We should only cast the input on the main FSDP wrapper, excluding the check on nested FSDPs.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
