### PR TITLE
[fix] OSS speed ref adjusted down..

### DIFF
--- a/benchmarks/golden_configs/oss_mnist.py
+++ b/benchmarks/golden_configs/oss_mnist.py
@@ -4,7 +4,7 @@
 def get_golden_real_stats():
 
     return {
-        "reference_speed": 660,
+        "reference_speed": 650,
         "reference_memory": 1000,
         "reference_loss": 0.026,
     }


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
The tests in https://github.com/facebookresearch/fairscale/pull/474 were green multiple times so I thought that it was enough, it turns out it is not (master just broke because of that). The takeaway is that using Variable queue is slower than not using it, but it enables buckets for all models which in multi-node is a fair enough compromise in my view (without buckets the speed just tanks). May be possible to get back to improving raw speed, but not a priority I think

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
