### PR TITLE
Fixed RNN support for containers

### DIFF
--- a/fairscale/utils/containers.py
+++ b/fairscale/utils/containers.py
@@ -7,12 +7,13 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, Union
 
 import torch
+from torch.nn.utils.rnn import PackedSequence
 
 """Useful functions to deal with tensor types with other python container types."""
 
 
 def apply_to_tensors(fn: Callable, container: Union[torch.Tensor, Dict, List, Tuple, Set]) -> Any:
-    """Recursively apply to all tensor in 4 kinds of container types."""
+    """Recursively apply to all tensor in 6 kinds of container types."""
 
     def _apply(x: Union[torch.Tensor, Dict, List, Tuple, Set]) -> Any:
         if torch.is_tensor(x):
@@ -22,6 +23,9 @@ def apply_to_tensors(fn: Callable, container: Union[torch.Tensor, Dict, List, Tu
             for key, value in x.items():
                 od[key] = _apply(value)
             return od
+        elif isinstance(x, PackedSequence):
+            _apply(x.data)
+            return x
         elif isinstance(x, dict):
             return {key: _apply(value) for key, value in x.items()}
         elif isinstance(x, list):

--- a/fairscale/utils/containers.py
+++ b/fairscale/utils/containers.py
@@ -13,7 +13,7 @@ from torch.nn.utils.rnn import PackedSequence
 
 
 def apply_to_tensors(fn: Callable, container: Union[torch.Tensor, Dict, List, Tuple, Set]) -> Any:
-    """Recursively apply to all tensor in 6 kinds of container types."""
+    """Recursively apply to all tensor in different kinds of container types."""
 
     def _apply(x: Union[torch.Tensor, Dict, List, Tuple, Set]) -> Any:
         if torch.is_tensor(x):


### PR DESCRIPTION
## What does this PR do?

Tried FSDP auto-wrap with RNNs, on master this fails. 

```python
import os

import torch
import torch.nn as nn
from fairscale.nn import FullyShardedDataParallel

os.environ['RANK'] = str(0)
os.environ['WORLD_SIZE'] = str(1)
os.environ["MASTER_ADDR"] = "localhost"
os.environ['MASTER_PORT'] = str(1337)

torch.cuda.set_device(0)

torch.distributed.init_process_group(backend="nccl", rank=0, world_size=1)

rnn = nn.RNN(5, 5)
rnn = FullyShardedDataParallel(rnn)

x = torch.rand((5, 1, 5), dtype=torch.float)
seq_length = torch.tensor([4], dtype=torch.int)

x = nn.utils.rnn.pack_padded_sequence(x, seq_length)
x, h = rnn(x)
x, _ = nn.utils.rnn.pad_packed_sequence(x)  # breaks because PackedSequence has not been preserved
```

Adding an additional condition to the container to ensure we preserve the object type.

# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
