### PR TITLE
[fix] FSDP: fix MoE corner case (fixes #467)

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1127,7 +1127,7 @@ class FullyShardedDataParallel(nn.Module):
         if params is None:
             params = self.params
         self.has_full_params = False
-        current_stream = torch.cuda.current_stream()
+        self._streams["all_gather"].wait_stream(torch.cuda.current_stream())
         with torch.cuda.stream(self._streams["all_gather"]):
             for p in params:
                 if not p._is_sharded:  # e.g., world_size == 1
@@ -1140,7 +1140,6 @@ class FullyShardedDataParallel(nn.Module):
                 # unshard parameters, we should reuse the original Tensor
                 # Storage object and unshard it in-place. For now, just resize
                 # the Storage to 0 to save memory.
-                p._full_param_padded.record_stream(current_stream)
                 free_storage_(p._full_param_padded)
 
     @torch.no_grad()


### PR DESCRIPTION
Add a new test (`test_mixture_of_experts_with_delay_before_free`) that includes a delay before freeing the full parameters. This uncovered a bug/corner case in MoE when combined with activation checkpointing, which was also periodically causing the regular MoE test (without a delay) to fail in #467.

The fix is to synchronize the all_gather stream and main stream before doing the free. This isn't critical for non-MoE models, because typically the all-gather stream will keep everything in sync.