### PR TITLE
[fix] Lightning-compat: deactivating buckets for a single rank, should not crash but not useful

### DIFF
--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -165,6 +165,9 @@ class ShardedDataParallel(nn.Module):
                 self.buffer_max_size / 2 ** 20, model_size / 2 ** 20
             )
         )
+        if dist.get_world_size(self.process_group) == 1:
+            self.buffer_max_size = 0
+            logging.info("Training is not really distributed, single rank. Deactivating buckets")
         self.use_buckets = self.buffer_max_size > 0
 
         self.buckets: Dict[torch.device, List[Bucket]] = {}

--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -160,14 +160,16 @@ class ShardedDataParallel(nn.Module):
         # - setup buckets and tensor views
         model_size = sum([p.numel() for p in self.module.parameters()])
         self.buffer_max_size = min(reduce_buffer_size, model_size)
+
+        if dist.get_world_size(self.process_group) == 1:
+            self.buffer_max_size = 0
+            logging.info("Training is not really distributed, single rank. Deactivating buckets")
+
         logging.info(
             "ShardedDDP bucket size: {:.2f}M parameters, model size {:.2f}M parameters".format(
                 self.buffer_max_size / 2 ** 20, model_size / 2 ** 20
             )
         )
-        if dist.get_world_size(self.process_group) == 1:
-            self.buffer_max_size = 0
-            logging.info("Training is not really distributed, single rank. Deactivating buckets")
         self.use_buckets = self.buffer_max_size > 0
 
         self.buckets: Dict[torch.device, List[Bucket]] = {}

--- a/tests/nn/data_parallel/test_sharded_ddp_features.py
+++ b/tests/nn/data_parallel/test_sharded_ddp_features.py
@@ -408,9 +408,9 @@ def run_test_gpt2(rank, world_size, backend, device, temp_file_name):
 
 @skip_if_no_cuda
 @skip_if_single_gpu
-def test_gpt2():
-    # Check that the ShardedDDP wrapper accepts tuple(tensors) as inputs
-    world_size = 2
+@pytest.mark.parametrize("world_size", [1, 2])
+def test_gpt2(world_size):
+    # Check that having trainable unused params is fine
     backend = "gloo"
     temp_file_name = tempfile.mkstemp()[1]
     device = "cuda"


### PR DESCRIPTION
# Before submitting
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests? Updated GPT2 test to run on one and two ranks, but it already worked before

## What does this PR do?
- in any case, using buckets for a world size of one, so deactivating them 
- shardedddp does not make a lot of sense for a world size of one, but consistency and reproducibility are important, it should work
- this happens to fix #509, but I think that something else is wrong in Lightning's code in that example since Autograd is never invoked (root reason why the buckets were not flushed). It does not seems consistent, a bit flaky in my trials, happy to help debug @ananthsub and @SeanNaren 

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
