### PR TITLE
[utils] Compute the grad norm in fp32 no matter what

### DIFF
--- a/fairscale/optim/utils.py
+++ b/fairscale/optim/utils.py
@@ -120,5 +120,6 @@ def calc_grad_norm(parameters: List[torch.nn.Parameter], p: float) -> torch.Tens
     if p == inf:
         local_norm = max(par.grad.detach().abs().max() for par in parameters)  # type: ignore
     else:
-        local_norm = torch.norm(torch.stack([torch.norm(par.grad.detach(), p) for par in parameters]), p)  # type: ignore
+        # Compute the norm in full precision no matter what
+        local_norm = torch.norm(torch.stack([torch.norm(par.grad.detach(), p, dtype=torch.float32) for par in parameters]), p).to(dtype=parameters[0].dtype)  # type: ignore
     return local_norm


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
It used to be the case, top my head that's something that @joshim5 had to introduce following accuracy issues when computing the accumulated grad norm. Compute the grad norm in fp32 then cast back to the parameter type

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
