### PR TITLE
[perf] [FSDP] micro-optimization for memory usage

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -814,6 +814,8 @@ class FullyShardedDataParallel(nn.Module):
 
         if self.reshard_after_forward:
             self._free_full_params()
+            if self.mixed_precision:
+                self._free_fp16_param_shard()
 
         # Switch to main FP32 param shard. We maintain this invariant throughout
         # the code, i.e., ``p.data == p._fp32_shard`` after each function. This


### PR DESCRIPTION
When doing mixed precision training with reshard_after_forward (i.e., nested FSDP, ZeRO-3 mode), we don't need the FP16 param shard, since it will be cast back from the FP32 shard before the backward anyway. This saves a little bit of memory.