### PR TITLE
[fix][FSDP] fix weight init when using apply() (fixes #490 and #444)

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -279,7 +279,6 @@ class FullyShardedDataParallel(nn.Module):
                     module._reset_lazy_init()
         return return_value
 
-    @torch.no_grad()
     def _cast_buffers(
         self, device: Optional[torch.device] = None, dtype: Optional[torch.dtype] = None, memo: Optional[Set] = None
     ) -> None:

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -259,7 +259,8 @@ class FullyShardedDataParallel(nn.Module):
         parameters of a model.
 
         Compared to ``torch.nn.Module.apply``, this version additionally gathers
-        the full parameters before applying ``fn``.
+        the full parameters before applying ``fn``. It should not be called from
+        within another ``summon_full_params`` context.
 
         Args:
             fn (nn.Module): function to be applied to each submodule
@@ -268,6 +269,7 @@ class FullyShardedDataParallel(nn.Module):
             Module: self
         """
         is_uninitialized = self._is_root is None
+        self.assert_state(TrainingState.IDLE)
         with self.summon_full_params(recurse=False):
             return_value = super().apply(fn)
         # summon_full_params will call _lazy_init, which sets _is_root. However,

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -33,3 +33,4 @@ tests/nn/pipe/test_deferred_batch_norm.py
 tests/nn/pipe/test_dependency.py
 tests/nn/pipe/test_stream.py
 tests/experimental/nn/test_multiprocess_pipe.py
+tests/nn/data_parallel/test_fsdp_apply.py

--- a/tests/nn/data_parallel/test_fsdp_apply.py
+++ b/tests/nn/data_parallel/test_fsdp_apply.py
@@ -1,0 +1,65 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import functools
+import unittest
+
+from parameterized import parameterized
+import torch.nn as nn
+
+from .test_fsdp import (
+    CONFIG_OPTIONS,
+    DistributedTest,
+    NestedWrappedModule,
+    TransformerWithSharedParams,
+    rename_test,
+    spawn_and_init,
+)
+
+
+class TestApply(DistributedTest):
+    @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
+    def test_transformer_weight_init(self, config):
+        model_init_fn = functools.partial(apply_custom_weight_init, TransformerWithSharedParams)
+        test_fn = functools.partial(self._test_identical_outputs, model_init_fn, config, lr=0.01)
+        spawn_and_init(test_fn)
+
+    @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
+    def test_nested_wrapped_weight_init(self, config):
+        model_init_fn = functools.partial(apply_custom_weight_init, NestedWrappedModule)
+        test_fn = functools.partial(self._test_identical_outputs, model_init_fn, config, lr=0.01)
+        spawn_and_init(test_fn)
+
+
+def apply_custom_weight_init(model_init_fn, *args, **kwargs):
+    model = model_init_fn(*args, **kwargs)
+    model.apply(init_bert_params_)
+    return model
+
+
+def init_bert_params_(module):
+    """
+    Initialize the weights specific to the BERT Model.
+    """
+
+    def normal_(data):
+        # with FSDP, module params will be on CUDA, so we cast them back to CPU
+        # so that the RNG is consistent with and without FSDP
+        data.copy_(data.cpu().normal_(mean=0.0, std=0.02))
+
+    if isinstance(module, nn.Linear):
+        normal_(module.weight.data)
+        if module.bias is not None:
+            module.bias.data.zero_()
+    if isinstance(module, nn.Embedding):
+        normal_(module.weight.data)
+        if module.padding_idx is not None:
+            module.weight.data[module.padding_idx].zero_()
+    if isinstance(module, nn.MultiheadAttention):
+        normal_(module.in_proj_weight.data)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/nn/data_parallel/test_fsdp_apply.py
+++ b/tests/nn/data_parallel/test_fsdp_apply.py
@@ -22,18 +22,18 @@ from .test_fsdp import (
 class TestApply(DistributedTest):
     @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
     def test_transformer_weight_init(self, config):
-        model_init_fn = functools.partial(apply_custom_weight_init, TransformerWithSharedParams)
+        model_init_fn = functools.partial(model_init_and_apply_custom_weight_init, TransformerWithSharedParams)
         test_fn = functools.partial(self._test_identical_outputs, model_init_fn, config, lr=0.01)
         spawn_and_init(test_fn)
 
     @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
     def test_nested_wrapped_weight_init(self, config):
-        model_init_fn = functools.partial(apply_custom_weight_init, NestedWrappedModule)
+        model_init_fn = functools.partial(model_init_and_apply_custom_weight_init, NestedWrappedModule)
         test_fn = functools.partial(self._test_identical_outputs, model_init_fn, config, lr=0.01)
         spawn_and_init(test_fn)
 
 
-def apply_custom_weight_init(model_init_fn, *args, **kwargs):
+def model_init_and_apply_custom_weight_init(model_init_fn, *args, **kwargs):
     model = model_init_fn(*args, **kwargs)
     model.apply(init_bert_params_)
     return model


### PR DESCRIPTION
- add `compute_device` so that we can use `summon_full_params` immediately after `FSDP.__init__`, even if the params are still on CPU (this also fixes #444)
- override `FSDP.apply` so that it calls `summon_full_params` first. This makes it possible to do weight inits via `model.apply(custom_weight_init_fn)` without segfaulting, and should give identical results to not using FSDP

This also required reworking `_all_buffers_to` to no longer use `apply`, since it is called from within `_lazy_init` and created some circular logic: `apply -> summon_full_params -> _lazy_init -> _all_buffers_to -> apply`.