### PR TITLE
[FSDP] Add gradient predivide factor to avoid overflow/underflow with large world size

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -174,7 +174,6 @@ class FullyShardedDataParallel(nn.Module):
         bucket_cap_mb: int = 25,
         compute_device: Optional[torch.device] = None,
     ):
-        print(f"inside this new FSDP...")
         super().__init__()
         self.process_group = process_group or dist.new_group()
         self.rank = self.process_group.rank()
@@ -258,7 +257,6 @@ class FullyShardedDataParallel(nn.Module):
         factor = 1
         while world_size % factor == 0 and world_size / factor > factor:
             factor = factor * 2
-        print(f"factor = {factor}")
         return factor
 
     @property

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -187,7 +187,8 @@ class FullyShardedDataParallel(nn.Module):
         self.buffer_dtype = buffer_dtype or self.compute_dtype
         self.move_grads_to_cpu = cpu_offload if move_grads_to_cpu is None else move_grads_to_cpu
         self.bucket_cap_mb = bucket_cap_mb
-        self.gradient_predivide_factor = self.get_gradient_predivide_factor(self.world_size)
+        self.gradient_predivide_factor: int = self.get_gradient_predivide_factor(self.world_size)
+        self.gradient_postdivide_factor: float = self.world_size / self.gradient_predivide_factor
 
         self.numel_padded_per_param: List[int] = []
         self.compute_device = compute_device
@@ -1076,7 +1077,7 @@ class FullyShardedDataParallel(nn.Module):
                 # Cast grad to FP32.
                 param.grad.data = param.grad.data.to(param.dtype)
 
-            if self.world_size > 1:
+            if self.gradient_predivide_factor > 1:
                 # Average grad by world_size for consistency with PyTorch DDP.
                 param.grad.data.div_(self.gradient_predivide_factor)
 
@@ -1105,7 +1106,10 @@ class FullyShardedDataParallel(nn.Module):
         assert torch.cuda.current_stream() == self._streams["post_backward"]
         assert param.grad is not None
         self.assert_state(TrainingState.BACKWARD_POST)
-        param.grad.data = reduced_grad.div_(self.world_size/self.gradient_predivide_factor)
+        param.grad.data = reduced_grad
+        if self.gradient_postdivide_factor > 1:
+            # Average grad by world_size for consistency with PyTorch DDP.
+            param.grad.data.div_(self.gradient_postdivide_factor)
         # Cast grad to param's dtype (typically FP32). Note: we do this
         # before the move_grads_to_cpu step so that this entire hook remains
         # non-blocking. The downside is a bit more D2H transfer in that case.


### PR DESCRIPTION
This PR tries to optimally scale gradients when the world_size is big.
For example, `reduce_scatter(gradient) / world_size` might overflow and `reduce_scatter(gradient / world_size)` might underflow with world_size=1024. We might prefer instead `reduce_scatter(gradient / 32) / 32`.
See [Nvidia’s note](https://github.com/NVIDIA/apex/blob/master/apex/parallel/distributed.py#L155) about this

Testing:
After 10 updates, I see ~ consistent loss/gnorm with the main branch and this branch.
Main:
`2021-03-31 16:55:49 | INFO | train | epoch 001 | loss 16.361 | nll_loss 16.324 | moe_gate_loss 2.56751 | overflow_expert1 24.327 | overflow_expert2 53.304 | entropy_gating 1.994 | expert1_balance_top 68.159 | expert1_balance_bottom 2.701 | unused_expert1_count 0 | expert2_balance_top 54.38 | expert2_balance_bottom 4.655 | unused_expert2_count 0 | ppl 82053.2 | wps 212239 | ups 6.47 | wpb 32768 | bsz 32 | num_updates 10 | lr 0.002 | gnorm 4.115 | loss_scale 32 | train_wall 4 | gb_free 29.2 | wall 24`
This Branch:
`2021-03-31 16:57:48 | INFO | train | epoch 001 | loss 16.361 | nll_loss 16.324 | moe_gate_loss 2.56767 | overflow_expert1 24.324 | overflow_expert2 53.299 | entropy_gating 1.994 | expert1_balance_top 68.156 | expert1_balance_bottom 2.7 | unused_expert1_count 0 | expert2_balance_top 54.396 | expert2_balance_bottom 4.65 | unused_expert2_count 0 | ppl 82051.3 | wps 216940 | ups 6.61 | wpb 32768 | bsz 32 | num_updates 10 | lr 0.002 | gnorm 4.116 | loss_scale 32 | train_wall 6 | gb_free 29.2 | wall 24`

After 100 updates, the loss/gnorm numbers are slightly different after the 2nd decimal place between the main branch and this branch
Main:
`2021-03-31 17:01:50 | INFO | train | epoch 001 | loss 11.751 | nll_loss 11.713 | moe_gate_loss 2.63956 | overflow_expert1 43.949 | overflow_expert2 64.359 | entropy_gating 2.022 | expert1_balance_top 84.331 | expert1_balance_bottom 1.088 | unused_expert1_count 0 | expert2_balance_top 75.253 | expert2_balance_bottom 1.84 | unused_expert2_count 0 | ppl 3356.47 | wps 229459 | ups 7 | wpb 32768 | bsz 32 | num_updates 100 | lr 0 | gnorm 0.931 | loss_scale 32 | train_wall 16 | gb_free 29.2 | wall 38`

This Branch:
`2021-03-31 16:59:44 | INFO | train | epoch 001 | loss 11.747 | nll_loss 11.706 | moe_gate_loss 2.79818 | overflow_expert1 44.95 | overflow_expert2 65.851 | entropy_gating 2.003 | expert1_balance_top 84.568 | expert1_balance_bottom 0.411 | unused_expert1_count 0 | expert2_balance_top 76.632 | expert2_balance_bottom 0.981 | unused_expert2_count 0 | ppl 3341.38 | wps 227973 | ups 6.96 | wpb 32768 | bsz 32 | num_updates 100 | lr 0 | gnorm 0.937 | loss_scale 32 | train_wall 18 | gb_free 29.2 | wall 37`


Would love advice on how to proceed given these differences which would tend to emerge since we are scaling the gradients a bit differently now.