### PR TITLE
[fix] OSS - enforce cuda parameters for state consolidation if NCCL backend

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -326,7 +326,7 @@ class OSS(Optimizer):
 
         self._all_states = []
         should_collect_state = self.rank == recipient_rank or recipient_rank == -1
-        should_send_state = (self.rank != recipient_rank and recipient_rank != -1) or recipient_rank == -1
+        should_send_state = self.rank != recipient_rank
 
         # NCCL requires CUDA tensors for all communication primitives
         dist_device = torch.device("cuda") if self.backend == dist.Backend.NCCL else self._default_device

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -328,6 +328,8 @@ class OSS(Optimizer):
         should_collect_state = self.rank == recipient_rank or recipient_rank == -1
         should_send_state = (self.rank != recipient_rank and recipient_rank != -1) or recipient_rank == -1
 
+        dist_device = torch.device("cuda") if self.backend == dist.Backend.NCCL else self._default_device
+
         for rank in range(self.world_size):
             if rank == self.rank:
                 if should_collect_state:
@@ -340,18 +342,18 @@ class OSS(Optimizer):
                 state_to_share = (
                     self.optim.state_dict()
                     if should_send_state
-                    else torch.tensor([0], dtype=torch.uint8, device=self._default_device)
+                    else torch.tensor([0], dtype=torch.uint8, device=dist_device)
                 )
                 broadcast_object(
-                    state_to_share, src_rank=self.global_rank, group=self.group, dist_device=self._default_device,
+                    state_to_share, src_rank=self.global_rank, group=self.group, dist_device=dist_device,
                 )
             else:
                 # Fetch the optim state from the other replicas
                 replica_state = broadcast_object(
-                    torch.tensor([0], dtype=torch.uint8, device=self._default_device),
+                    torch.tensor([0], dtype=torch.uint8, device=dist_device),
                     src_rank=self._local_to_global_rank[rank],
                     group=self.group,
-                    dist_device=self._default_device,
+                    dist_device=dist_device,
                 )
 
                 if should_collect_state:

--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -328,6 +328,7 @@ class OSS(Optimizer):
         should_collect_state = self.rank == recipient_rank or recipient_rank == -1
         should_send_state = (self.rank != recipient_rank and recipient_rank != -1) or recipient_rank == -1
 
+        # NCCL requires CUDA tensors for all communication primitives
         dist_device = torch.device("cuda") if self.backend == dist.Backend.NCCL else self._default_device
 
         for rank in range(self.world_size):

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -470,6 +470,11 @@ def run_test_collect_shards(rank, world_size, reference_rank, tempfile_name):
     _ = optimizer.step(closure=closure)
     check_same_models_across_ranks(model, dist.group.WORLD, params_should_be_equal=True, check_broadcast_buffers=False)
 
+    # Check that if the model is moved to cpu, the optimizer consolidation still works
+    model.cpu()
+    optimizer = optim.OSS(model.parameters(), lr=0.1, momentum=0.99)
+    optimizer.consolidate_state_dict(recipient_rank=reference_rank)
+
     dist.destroy_process_group()
 
 


### PR DESCRIPTION
# Before submitting
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Should fix https://fb.workplace.com/groups/pytorchLightning/permalink/1419090048427529/
A usecase that I did not think of was that the model could be moved to cpu() at some point, then OSS state consolidated. In that case the state consolidation would fail because NCCL only supports cuda tensors

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃

cc @ananthsub