### PR TITLE
preliminary loss scaler

### DIFF
--- a/fairscale/experimental/optim/dynamic_loss_scaler.py
+++ b/fairscale/experimental/optim/dynamic_loss_scaler.py
@@ -1,0 +1,139 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import torch
+from collections import defaultdict, abc
+import warnings
+from enum import Enum
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class OptState(Enum):
+    READY = 0
+    UNSCALED = 1
+    STEPPED = 2
+
+
+def _refresh_per_optimizer_state():
+    return {"stage": OptState.READY}
+
+class DynamicLossScaler(object):
+    def __init__(
+        self,
+        init_scale=2.0 ** 15,
+        scale_factor=2.0,
+        scale_window=2000,
+        tolerance=0.0,
+        threshold=None,
+        min_loss_scale=1e-4,
+    ):
+        self.loss_scale = init_scale
+        self.scale_factor = scale_factor
+        self.scale_window = scale_window
+        self.tolerance = tolerance
+        self.threshold = threshold
+        self._iter = 0
+        self._last_overflow_iter = -1
+        self._last_rescale_iter = -1
+        self._overflows_since_rescale = 0
+        self.min_loss_scale = min_loss_scale
+        self._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
+        self._scale = None
+
+
+    def scale(self, outputs):
+        print(outputs)
+        return self.loss_scale * outputs
+
+
+    def update(self):
+        if (self._iter - self._last_overflow_iter) % self.scale_window == 0:
+            self.loss_scale *= self.scale_factor
+            self._last_rescale_iter = self._iter
+        self._iter += 1
+        self._per_optimizer_states = defaultdict(_refresh_per_optimizer_state)
+
+
+    def step(self, optimizer, *args, **kwargs):
+        if "closure" in kwargs:
+            raise RuntimeError("Closure use is not currently supported if GradScaler is enabled.")
+
+        optimizer_state = self._per_optimizer_states[id(optimizer)]
+
+        if optimizer_state["stage"] is OptState.STEPPED:
+            raise RuntimeError("step() has already been called since the last update().")
+
+        retval = None
+
+        if optimizer_state["stage"] is OptState.READY:
+            self.unscale_(optimizer)
+
+        retval = optimizer.step(*args, **kwargs)
+
+        optimizer_state["stage"] = OptState.STEPPED
+
+        return retval
+
+
+
+
+    def unscale_(self, optimizer):
+
+        optimizer_state = self._per_optimizer_states[id(optimizer)]
+
+        if optimizer_state["stage"] is OptState.UNSCALED:
+            raise RuntimeError("unscale_() has already been called on this optimizer since the last update().")
+        elif optimizer_state["stage"] is OptState.STEPPED:
+            raise RuntimeError("unscale_() is being called after step().")
+
+        assert self.loss_scale is not None
+        inv_scale = 1.0 / float(self.loss_scale)
+
+        with torch.no_grad():
+            for group in optimizer.param_groups:
+                for param in group["params"]:
+                    if param.grad is None:
+                        continue
+                    else:
+                        param.grad.data.mul_(inv_scale)
+
+        optimizer_state["stage"] = OptState.UNSCALED
+
+
+    def _decrease_loss_scale(self):
+        self.loss_scale /= self.scale_factor
+        if self.threshold is not None:
+            self.loss_scale = max(self.loss_scale, self.threshold)
+
+
+    def check_overflow(self, grad_norm):
+        # detect inf and nan
+        if grad_norm == float("inf") or grad_norm != grad_norm:
+            # overflow has occured
+            prev_scale = self.loss_scale
+            iter_since_rescale = self._iter - self._last_rescale_iter
+
+            self._last_overflow_iter = self._iter
+            self._overflows_since_rescale += 1
+            pct_overflow = self._overflows_since_rescale / float(iter_since_rescale)
+            if pct_overflow >= self.tolerance:
+                self._decrease_loss_scale()
+                self._last_rescale_iter = self._iter
+                self._overflows_since_rescale = 0
+
+            if self.loss_scale <= self.min_loss_scale:
+                # Use FloatingPointError as an uncommon error that parent
+                # functions can safely catch to stop training.
+                self.loss_scale = prev_scale
+                raise FloatingPointError(
+                    (
+                        "Minimum loss scale reached ({}). Your loss is probably exploding. "
+                        "Try lowering the learning rate, using gradient clipping or "
+                        "increasing the batch size."
+                    ).format(self.min_loss_scale)
+                )
+
+            self._iter += 1
+            raise OverflowError("setting loss scale to: " + str(self.loss_scale))

--- a/fairscale/experimental/optim/testrun.py
+++ b/fairscale/experimental/optim/testrun.py
@@ -1,0 +1,63 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Testing scaler
+"""
+
+import numpy as np
+import torch
+import torch.optim as optim
+import torch.nn as nn
+from torch.utils.data import Dataset, TensorDataset, DataLoader
+from torch.utils.data.dataset import random_split
+from dynamic_loss_scaler import DynamicLossScaler
+
+scaler = DynamicLossScaler()
+np.random.seed(42)
+x = np.random.rand(100, 1)
+y = 1 + 2 * x + .1 * np.random.randn(100, 1)
+
+# Shuffles the indices
+idx = np.arange(100)
+np.random.shuffle(idx)
+
+# Uses first 80 random indices for train
+train_idx = idx[:80]
+# Uses the remaining indices for validation
+val_idx = idx[80:]
+
+# Generates train and validation sets
+x_train, y_train = x[train_idx], y[train_idx]
+x_val, y_val = x[val_idx], y[val_idx]
+
+device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
+torch.manual_seed(42)
+a = torch.randn(1, requires_grad=True, dtype=torch.float, device=device)
+b = torch.randn(1, requires_grad=True, dtype=torch.float, device=device)
+print(a, b)
+
+x_train_tensor = torch.from_numpy(x_train).float().to(device)
+y_train_tensor = torch.from_numpy(y_train).float().to(device)
+
+lr = 1e-1
+n_epochs = 1000
+
+loss_fn = nn.MSELoss(reduction='mean')
+
+optimizer = optim.SGD([a, b], lr=lr)
+
+for epoch in range(n_epochs):
+    yhat = a + b * x_train_tensor
+
+    loss = loss_fn(y_train_tensor, yhat)
+
+    scaler.scale(loss).backward()
+    scaler.step(optimizer)
+    scaler.update()
+    optimizer.zero_grad()
+
+print(a, b)


### PR DESCRIPTION
This is a start point for the loss scaler. The testrun.py is a script to verify the DynamicLossScaler.  I will move the file under fairscale/tests/experimental/ later.  

python testrun.py 
tensor([1.0235], requires_grad=True) tensor([1.9690], requires_grad=True)
[tmarkstrum@devvm1106.frc0 ~/fairscale_tmark/fairscale/experimental/optim] 

The DynamicLossScaler currently has a 1-1 mapping with PyTorch’s torch.cuda.amp.GradScaler. Support for scaling up and down. 
Todo:
Support for saving/loading loss scale during training.
Support for skipping updates if we hit NaNs.
