### PR TITLE
[fix]:  let FSDP handle model with multiple forward pass and checkpoint

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -207,8 +207,8 @@ class FullyShardedDataParallel(nn.Module):
 
         self.gradient_predivide_factor: int = self.get_gradient_predivide_factor(self.world_size)
         self.gradient_postdivide_factor: float = self.world_size / self.gradient_predivide_factor
-        self.gradient_predivide_factor = 1
-        self.gradient_postdivide_factor = 2.0
+        # self.gradient_predivide_factor = 1
+        # self.gradient_postdivide_factor = 2.0
         # print("XXX", self.gradient_predivide_factor, self.gradient_postdivide_factor)
 
         self.numel_padded_per_param: List[int] = []
@@ -945,9 +945,8 @@ class FullyShardedDataParallel(nn.Module):
         #
         # Some model does forward pass multiple times, we need to register the
         # pre-backward hook on every output since the last output's hook has to
-        # fire first to setup for backward. However, we use
-        # self._pre_backward_hook_has_run prevent repeated overhead from multiple
-        # hook callbacks.
+        # fire first to setup for backward. However, we use ``self._pre_backward_hook_has_run``
+        # to prevent repeated overhead from multiple hook callbacks.
         outputs = self._register_pre_backward_hooks(outputs)
 
         # Done with a forward pass.

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -942,8 +942,6 @@ class FullyShardedDataParallel(nn.Module):
         self._lazy_init()
 
         # Start of a forward pass.
-        # if self.rank == 0:
-        #    print("XXX fwd", self._id)
         self.training_state = TrainingState.FORWARD
 
         if self._is_root and self.mixed_precision:
@@ -982,8 +980,6 @@ class FullyShardedDataParallel(nn.Module):
         outputs = self._register_pre_backward_hooks(outputs)
 
         # Done with a forward pass.
-        # if self.rank == 0:
-        #    print("XXX fwd done, idle", self._id)
         self.training_state = TrainingState.IDLE
 
         return outputs
@@ -1004,8 +1000,6 @@ class FullyShardedDataParallel(nn.Module):
             self._pre_backward_hook_has_run = True
 
             # Start of a backward pass.
-            # if self.rank == 0:
-            #    print("XXX bwd pre", self._id if hasattr(self, "_id") else "bn")
             self.assert_state([TrainingState.IDLE, TrainingState.BACKWARD_PRE])
             self.training_state = TrainingState.BACKWARD_PRE
 
@@ -1111,18 +1105,9 @@ class FullyShardedDataParallel(nn.Module):
             self.assert_state([TrainingState.BACKWARD_PRE, TrainingState.BACKWARD_POST, TrainingState.IDLE])
         else:
             self.assert_state([TrainingState.BACKWARD_PRE, TrainingState.BACKWARD_POST])
-        # if self.rank == 0:
-        #    print("XXX bwd post", self._id)
         self.training_state = TrainingState.BACKWARD_POST
         if param.grad is None:
             return
-        # if self.rank == 0:
-        #    print("XXX", self._id, param.grad.sum().item())
-        # if self._id == "block2":
-        #    self._b2_counter += 1
-        #    if self._b2_counter % 3 != 0:
-        #        print("XXX skip")
-        #        return
 
         if param.grad.requires_grad:
             raise RuntimeError("FullyShardedDataParallel only works with gradients that don't require gradients")
@@ -1237,8 +1222,6 @@ class FullyShardedDataParallel(nn.Module):
     def _wait_for_post_backward(self) -> None:
         """Wait for post-backward to finish. Only called on root instance."""
         assert self._is_root
-        # if self.rank == 0:
-        #    print("XXX _wait_for_post_backward", self._id)
         if self._has_params:
             self.assert_state(TrainingState.BACKWARD_POST)
         else:
@@ -1277,8 +1260,6 @@ class FullyShardedDataParallel(nn.Module):
                         m.assert_state(TrainingState.IDLE)
                 else:
                     m.assert_state(TrainingState.BACKWARD_PRE)
-                # if self.rank == 0:
-                #    print("XXX bwd done", self._id)
                 m.training_state = TrainingState.IDLE
 
     @torch.no_grad()

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -284,7 +284,6 @@ class FullyShardedDataParallel(nn.Module):
         # Flag to guard multiple pre-forward hook being executed per iteration.
         # This is reset at the end of the backward().
         self._pre_backward_hook_has_run = False
-        # self._b2_counter = 0
 
     def _get_gradient_predivide_factor(self, world_size: int) -> float:
         factor: int = 1
@@ -1252,7 +1251,6 @@ class FullyShardedDataParallel(nn.Module):
                 m._pre_backward_hook_has_run = False
                 if m._has_params:
                     if any(p.requires_grad for p in m.params):
-                        # pass
                         m.assert_state(TrainingState.BACKWARD_POST)
                     else:
                         # Unlikely case, should only happens if `m` has params but none of the

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1122,8 +1122,7 @@ class FullyShardedDataParallel(nn.Module):
         #        return
 
         if param.grad.requires_grad:
-            raise RuntimeError("FullyShardedDataParallel only works with gradients that "
-                               "don't require gradients")
+            raise RuntimeError("FullyShardedDataParallel only works with gradients that don't require gradients")
 
         # If this is a checkpointed module, we check if the following
         # counter reaches 0. If not, it is not the final backward call
@@ -1611,7 +1610,7 @@ class FullyShardedDataParallel(nn.Module):
                     v_shard = v[0] if self.rank >= len(v) else v[self.rank]
                     assert ou.is_singleton_tensor(v_shard)
                 else:
-                    v_shard = v  # dont shard entries that are not tensors
+                    v_shard = v  # don't shard entries that are not tensors
                 full_optim_state_dict["state"][id][k] = v_shard
 
         return full_optim_state_dict

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -282,7 +282,7 @@ class FullyShardedDataParallel(nn.Module):
         )
 
         # Flag to guard multiple pre-forward hook being executed per iteration.
-        # This is reset at the end of the backward().
+        # This is reset at the end of the backward pass.
         self._pre_backward_hook_has_run = False
 
     def _get_gradient_predivide_factor(self, world_size: int) -> float:

--- a/fairscale/nn/misc/checkpoint_activations.py
+++ b/fairscale/nn/misc/checkpoint_activations.py
@@ -15,10 +15,12 @@ import torch.utils.checkpoint as torch_checkpoint
 
 from fairscale.utils.containers import pack_kwargs, split_non_tensors, unpack_kwargs, unpack_non_tensors
 
-from .misc import CheckpointForwardPassCounter, patch_batchnorm
+from .misc import dec_counter, inc_counter, init_counter, patch_batchnorm
 
 
-def checkpoint_wrapper(module: nn.Module, offload_to_cpu: bool = False) -> nn.Module:
+def checkpoint_wrapper(
+    module: nn.Module, offload_to_cpu: bool = False, maintain_forward_counter: bool = False
+) -> nn.Module:
     """
     A friendlier wrapper for performing activation checkpointing.
 
@@ -58,8 +60,12 @@ def checkpoint_wrapper(module: nn.Module, offload_to_cpu: bool = False) -> nn.Mo
     Args:
         module (nn.Module):
             The module to be wrapped
-        offload_to_cpu (Optional, bool):
+        offload_to_cpu (bool):
             Whether to offload activations to CPU.
+        maintain_forward_counter (bool):
+            If True, maintain a forward counter per inner module. The counter will first
+            increases in forward calls of outer forward pass and then decreases in the
+            forward calls of outer backward pass. It is used by FullyShardedDataParallel.
 
     Returns:
         (nn.Module):
@@ -68,8 +74,8 @@ def checkpoint_wrapper(module: nn.Module, offload_to_cpu: bool = False) -> nn.Mo
     # Patch the batchnorm layers in case there are any in this module.
     patch_batchnorm(module)
 
-    # Add forward pass counter
-    CheckpointForwardPassCounter.add_checkpoint_counter(module)
+    if maintain_forward_counter:
+        init_counter(module)
 
     # The use of weakref here is to prevent creating a ref cycle: m -> m.forward -> m.
     # When such cycle exists, gc won't collect the module when the module is freed.
@@ -171,7 +177,8 @@ class CheckpointFunction(torch.autograd.Function):
         with torch.no_grad():
             unpacked_args, unpacked_kwargs = unpack_kwargs(kwarg_keys, args)
             outputs = run_function(*unpacked_args, **unpacked_kwargs)
-            CheckpointForwardPassCounter.inc()
+            the_module = unpacked_args[0]
+            inc_counter(the_module)
 
         if not isinstance(outputs, torch.Tensor):
             # Autograd Functions don't like non-Tensor outputs. We can split the
@@ -204,7 +211,8 @@ class CheckpointFunction(torch.autograd.Function):
             unpacked_args, unpacked_kwargs = unpack_kwargs(ctx.kwarg_keys, inputs)
             outputs = ctx.run_function(*unpacked_args, **unpacked_kwargs)
             tensor_outputs, _ = split_non_tensors(outputs)
-            CheckpointForwardPassCounter.dec()
+            the_module = unpacked_args[0]
+            dec_counter(the_module)
 
         # Set the states back to what it was at the start of this function.
         set_rng_state(bwd_rng_state)

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -26,6 +26,7 @@ you see fit, but refrain from ad-hoc test utils within the different feature set
 relative imports.
 """
 
+import contextlib
 import functools
 import inspect
 import logging
@@ -35,7 +36,7 @@ import random
 import subprocess
 import sys
 import tempfile
-from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Callable, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy
 import pytest
@@ -645,3 +646,15 @@ def rmf(filename: str) -> None:
         os.remove(filename)
     except FileNotFoundError:
         pass
+
+
+@contextlib.contextmanager
+def temp_files_ctx(num: int) -> Generator:
+    """ A context to get tempfiles and ensure they are cleaned up. """
+    files = [tempfile.mkstemp()[1] for _ in range(num)]
+
+    yield tuple(files)
+
+    # temp files could have been removed, so we use rmf.
+    for name in files:
+        rmf(name)

--- a/stubs/torch/nn/modules/module.pyi
+++ b/stubs/torch/nn/modules/module.pyi
@@ -108,6 +108,8 @@ class Module(Generic[T_co]):
 
     def extra_repr(self) -> str: ...
 
-#MODIFIED BY TORCHGPIPE
+    # This is added by checkpoint_wrapper
+    _checkpoint_fwd_counter: int
+
+    # This is added torchgpipe
     training: bool
-#END

--- a/t.py
+++ b/t.py
@@ -84,6 +84,7 @@ def _distributed_worker(gpu_id: int, with_fsdp: bool, double_forward: bool, with
         model = FSDP(model)
         model._id = "root"
         context = contextlib.suppress()
+        model.set_gradient_divide_factors(1., 2., True)
     else:
         model = DistributedDataParallel(model, device_ids=[gpu_id])
         context = model.no_sync()

--- a/t.py
+++ b/t.py
@@ -1,0 +1,118 @@
+import argparse
+import contextlib
+from typing import List, Union
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+from torch.nn.parallel import DistributedDataParallel
+import torch.optim as optim
+
+from fairscale.nn import checkpoint_wrapper
+from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
+from fairscale.nn.data_parallel import auto_wrap_bn
+
+
+class Model(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.block1 = nn.Sequential(nn.Conv2d(3, 64, kernel_size=3), nn.BatchNorm2d(64), nn.ReLU(inplace=True),)
+        self.block2 = nn.Sequential(
+            nn.Conv2d(64, 128, kernel_size=3),
+            nn.BatchNorm2d(128),
+            nn.ReLU(inplace=True),
+            nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+            nn.Flatten(),
+        )
+        """
+        self.block2 = nn.Sequential(
+            nn.Conv2d(64, 64, kernel_size=3),
+            nn.Conv2d(64, 64, kernel_size=3),
+            nn.AdaptiveAvgPool2d(output_size=(1, 1)),
+            nn.Flatten(),
+        )
+        """
+        self.head = nn.Linear(128, 10)
+
+    def forward(self, x: Union[torch.Tensor, List[torch.Tensor]]):
+        if isinstance(x, torch.Tensor):
+            return self.head(self.block2(self.block1(x)))
+        elif isinstance(x, list):
+            ys = [self.head(self.block2(self.block1(e))) for e in x]
+            return torch.cat(ys, dim=0)
+
+
+def create_model(with_fsdp: bool, with_checkpoint: bool):
+    model = Model()
+    if with_fsdp:
+        model.block1 = auto_wrap_bn(model.block1, single_rank_pg=False)
+        model.block2 = auto_wrap_bn(model.block2, single_rank_pg=False)
+        if with_checkpoint:
+            model.block2 = checkpoint_wrapper(model.block2)
+        model.block1 = FSDP(model.block1)
+        model.block1._id = "block1"
+        model.block2 = FSDP(model.block2)
+        model.block2._id = "block2"
+        model.head = FSDP(model.head)
+        model.head._id = "head"
+    else:
+        if with_checkpoint:
+            model.block2 = checkpoint_wrapper(model.block2)
+    return model
+
+
+def _distributed_worker(gpu_id: int, with_fsdp: bool, double_forward: bool, with_checkpoint: bool):
+    torch.cuda.set_device(gpu_id)
+    dist.init_process_group(backend="nccl", init_method="tcp://127.0.0.1:9099", world_size=2, rank=gpu_id)
+
+    torch.manual_seed(0)
+    torch.backends.cudnn.deterministic = True
+    if double_forward:
+        batch = [
+            torch.randn(size=(2, 3, 224, 224)).cuda(),
+            torch.randn(size=(2, 3, 96, 96)).cuda(),
+            torch.randn(size=(2, 3, 96, 96)).cuda(),
+        ]
+    else:
+        batch = torch.randn(size=(4, 3, 224, 224)).cuda()
+
+    model = create_model(with_fsdp, with_checkpoint)
+    model = model.cuda()
+
+    if with_fsdp:
+        model = FSDP(model)
+        model._id = "root"
+        context = contextlib.suppress()
+    else:
+        model = DistributedDataParallel(model, device_ids=[gpu_id])
+        context = model.no_sync()
+
+    if gpu_id == 0:
+        print(model)
+
+    target = torch.LongTensor([0, 1, 2, 3, 4, 5]).cuda()
+    criterion = nn.CrossEntropyLoss()
+    optimizer = optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
+
+    with context:
+        for iteration in range(3):
+            out = model(batch)
+            loss = criterion(out, target)
+            print("Loss", iteration, ":", loss.item())
+            optimizer.zero_grad()
+            loss.backward()
+            if not with_fsdp:
+                for p in model.parameters():
+                    dist.all_reduce(p.grad.data)
+                    p.grad.data.div_(2.0)
+            optimizer.step()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-f", "--fsdp", action="store_const", const=True, default=False)
+    parser.add_argument("-d", "--double", action="store_const", const=True, default=False)
+    parser.add_argument("-c", "--checkpoint", action="store_const", const=True, default=False)
+    args = parser.parse_args()
+    mp.spawn(_distributed_worker, (args.fsdp, args.double, args.checkpoint), nprocs=2)

--- a/tests/ci_test_list_1.txt
+++ b/tests/ci_test_list_1.txt
@@ -1,3 +1,4 @@
-tests/nn/misc/test_flatten_params_wrapper.py
-tests/nn/data_parallel/test_fsdp.py
+tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
 tests/nn/data_parallel/test_fsdp_freezing_weights.py
+tests/nn/data_parallel/test_fsdp.py
+tests/nn/misc/test_flatten_params_wrapper.py

--- a/tests/nn/data_parallel/test_fsdp_freezing_weights.py
+++ b/tests/nn/data_parallel/test_fsdp_freezing_weights.py
@@ -118,7 +118,7 @@ def temp_files():
 
 
 @skip_if_single_gpu
-def tests1(temp_files):
+def test_freezing_weights(temp_files):
     world_size = 2
     # DDP
     fsdp = False

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
@@ -57,8 +57,9 @@ def create_model(with_fsdp, with_checkpoint):
     model = Model()
     if with_fsdp:
         # XXX: test auto_wrap_bn on & off.
-        model.block1 = auto_wrap_bn(model.block1, single_rank_pg=False)
-        model.block2 = auto_wrap_bn(model.block2, single_rank_pg=False)
+        if True:
+            model.block1 = auto_wrap_bn(model.block1, single_rank_pg=False)
+            model.block2 = auto_wrap_bn(model.block2, single_rank_pg=False)
         if with_checkpoint:
             model.block2 = checkpoint_wrapper(model.block2, maintain_forward_counter=True)
         model.block1 = FSDP(model.block1)

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
@@ -12,6 +12,7 @@
 import contextlib
 import pickle
 
+import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
@@ -22,7 +23,8 @@ import torch.optim as optim
 from fairscale.nn import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import auto_wrap_bn
-from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, temp_files_ctx
+from fairscale.nn.wrap import enable_wrap, wrap
+from fairscale.utils.testing import dist_init, objects_are_equal, skip_if_single_gpu, teardown, temp_files_ctx
 
 
 class Model(nn.Module):
@@ -46,25 +48,33 @@ class Model(nn.Module):
             return torch.cat(ys, dim=0)
 
 
-def create_model(with_fsdp, with_checkpoint):
+def create_model(with_fsdp, with_checkpoint, mixed_precision, flatten, wrap_bn, fp32_reduce_scatter):
     model = Model()
     if with_fsdp:
-        # XXX: test auto_wrap_bn on & off.
-        if True:
+        if wrap_bn:
             model.block1 = auto_wrap_bn(model.block1, single_rank_pg=False)
             model.block2 = auto_wrap_bn(model.block2, single_rank_pg=False)
         if with_checkpoint:
             model.block2 = checkpoint_wrapper(model.block2, maintain_forward_counter=True)
-        model.block1 = FSDP(model.block1)
-        model.block2 = FSDP(model.block2)
-        model.head = FSDP(model.head)
+        with enable_wrap(
+            wrapper_cls=FSDP,
+            flatten_parameters=flatten,
+            mixed_precision=mixed_precision,
+            compute_dtype=torch.float32,
+            fp32_reduce_scatter=fp32_reduce_scatter,
+        ):
+            model.block1 = wrap(model.block1)
+            model.block2 = wrap(model.block2)
+            model.head = wrap(model.head)
     else:
         if with_checkpoint:
             model.block2 = checkpoint_wrapper(model.block2, maintain_forward_counter=False)
     return model
 
 
-def _distributed_worker(gpu_id, world_size, with_fsdp, with_checkpoint, files):
+def _distributed_worker(
+    gpu_id, world_size, with_fsdp, with_checkpoint, files, mixed_precision, flatten, wrap_bn, fp32_reduce_scatter
+):
     filename, filename_rpc = files[:2]
     filename_loss = files[2:]
 
@@ -89,18 +99,31 @@ def _distributed_worker(gpu_id, world_size, with_fsdp, with_checkpoint, files):
         torch.randn(size=(2, 3, 96, 96)).cuda(),
     ]
 
-    model = create_model(with_fsdp, with_checkpoint)
+    if mixed_precision and not with_fsdp:
+        batch = [x.half() for x in batch]
+
+    model = create_model(with_fsdp, with_checkpoint, mixed_precision, flatten, wrap_bn, fp32_reduce_scatter)
     model = model.cuda()
 
     if with_fsdp:
-        model = FSDP(model)
-        context = contextlib.suppress()
+        model = FSDP(
+            model,
+            flatten_parameters=flatten,
+            mixed_precision=mixed_precision,
+            compute_dtype=torch.float32,
+            fp32_reduce_scatter=fp32_reduce_scatter,
+        )
         model.set_gradient_divide_factors(1.0, 2.0, True)
+        no_sync_context = contextlib.suppress()
     else:
         # With DDP, we need no_sync and manual gradient reduction below because
         # it can't handle multiple forward pass + checkpointing otherwise.
         model = DistributedDataParallel(model, device_ids=[gpu_id])
-        context = model.no_sync()
+        no_sync_context = model.no_sync()
+
+    mp_context = contextlib.suppress()
+    if mixed_precision:
+        mp_context = torch.cuda.amp.autocast(enabled=True)
 
     if gpu_id == 0:
         print(model)
@@ -111,19 +134,22 @@ def _distributed_worker(gpu_id, world_size, with_fsdp, with_checkpoint, files):
 
     losses = {}
     i = 0
-    with context:
+    with no_sync_context:
         for iteration in range(3):
-            out = model(batch)
-            loss = criterion(out, target)
-            print("Loss", iteration, ":", loss.item())
-            losses[f"iter_{i}"] = loss.item()
-            i += 1
-            optimizer.zero_grad()
-            loss.backward()
+            with mp_context:
+                out = model(batch)
+                loss = criterion(out, target)
+                print("Loss", iteration, ":", loss.item())
+                losses[f"iter_{i}"] = loss
+                i += 1
+                optimizer.zero_grad()
+                loss.backward()
+            # Manual grad reduction, no autocast.
             if not with_fsdp:
                 for p in model.parameters():
                     dist.all_reduce(p.grad.data)
                     p.grad.data.div_(2.0)
+            # Stepping, no autocast
             optimizer.step()
 
     # Due to dist.all_reduce code block above with ddp.no_sync, we seem to hit a bug
@@ -136,7 +162,15 @@ def _distributed_worker(gpu_id, world_size, with_fsdp, with_checkpoint, files):
 
 
 @skip_if_single_gpu
-def test_multiple_forward_checkpoint():
+@pytest.mark.parametrize("precision", ["full", "mixed"])
+@pytest.mark.parametrize("flatten", ["flatten", "no_flatten"])
+@pytest.mark.parametrize("wrap_bn", ["auto_wrap_bn", "no_auto_wrap_bn"])
+def test_multiple_forward_checkpoint(precision, flatten, wrap_bn):
+    mixed_precision = precision == "mixed"
+    flatten = flatten == "flatten"
+    wrap_bn = wrap_bn == "auto_wrap_bn"
+    fp32_reduce_scatter = True if mixed_precision else None
+
     world_size = 2
     expected_losses = None
     # Ensure ddp == ddp+ckpt == fsdp == fsdp+ckpt.
@@ -144,7 +178,20 @@ def test_multiple_forward_checkpoint():
         for with_checkpoint in [False, True]:
             # Get 4 files: 2 for dist_init and 2 for each rank to save the losses.
             with temp_files_ctx(num=2 + world_size) as temp_files:
-                mp.spawn(_distributed_worker, (world_size, with_fsdp, with_checkpoint, temp_files), nprocs=world_size)
+                mp.spawn(
+                    _distributed_worker,
+                    (
+                        world_size,
+                        with_fsdp,
+                        with_checkpoint,
+                        temp_files,
+                        mixed_precision,
+                        flatten,
+                        wrap_bn,
+                        fp32_reduce_scatter,
+                    ),
+                    nprocs=world_size,
+                )
                 final_losses = {}
                 for rank in range(world_size):
                     with open(temp_files[2 + rank], "rb") as f:
@@ -153,4 +200,4 @@ def test_multiple_forward_checkpoint():
                     expected_losses = final_losses
                 else:
                     print(f"fsdp: {with_fsdp} ckpt: {with_checkpoint}")
-                    assert expected_losses == final_losses
+                    assert objects_are_equal(expected_losses, final_losses, raise_exception=True)


### PR DESCRIPTION
This PR adds support of multiple passes of a module in a forward pass and activation checkpoint on the module at the same time.

Right now, the tested cases are:

1. FSDP(ckpt(module))
2. FSDP(ckpt(module, FSDP(BN), module))

Next commit will test and enable FSDP(ckpt(), ..., ckpt()) type of cases.

The fix is to add an option to `checkpoint_wrapper` so that it can keep a counter on the checkpointed modules so that FSDP can check the counter to determine if the backward callback fired from the module is the last one in the bigger, outer backward pass.

A new API to override the pre/post gradient divide factors. It is currently used in the test to make sure numerical match with DDP.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?

## What does this PR do?
Fixes part of  #617 .

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
