### PR TITLE
[fix] check before calling _specify_ddp_gpu_num

### DIFF
--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -539,10 +539,11 @@ class ShardedDataParallel(nn.Module):
         Adapted from ``torch.nn.distributed.DistributedDataParallel``.
         """
         for layer in module.modules():
-            if isinstance(layer, torch.nn.modules.SyncBatchNorm):
+            if isinstance(layer, torch.nn.modules.SyncBatchNorm) and hasattr(layer, "_specify_ddp_gpu_num"):
                 assert self.device_type != "cpu", "SyncBatchNorm layers only work with GPU modules"
                 # device_id logic has not been handled, assume single-process single-device
                 # SyncBatchNorm only supports DDP with single-process single-device anyway'
+                # This function is removed from pytorch since 1.9.
                 layer._specify_ddp_gpu_num(1)  # type: ignore
 
     def _setup_bucket_strategy(self) -> None:

--- a/fairscale/utils/parallel.py
+++ b/fairscale/utils/parallel.py
@@ -50,8 +50,9 @@ def enable_pytorch_sync_bn(module: torch.nn.Module) -> None:
        is happily running even without DDP. E.g. this is used by FSDP.
     """
     for layer in module.modules():
-        if isinstance(layer, torch.nn.modules.SyncBatchNorm):
+        if isinstance(layer, torch.nn.modules.SyncBatchNorm) and hasattr(layer, "_specify_ddp_gpu_num"):
             # Number "1" below meant to be the number of GPUs for each DDP worker.
             # (i.e. "device_ids" in DDP. As far as I see, the value is not actually
             # used, but this call needs to be made to avoid an exception.
+            # This function is removed from pytorch since 1.9.
             layer._specify_ddp_gpu_num(1)  # type: ignore


### PR DESCRIPTION
- this function is being removed in pytorch
- we only need to call it in case we are working with older pytorch
- internal diff:   https://www.internalfb.com/diff/D27866440?entry_point=2


# Before submitting

- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Did you make sure to update the docs?
- [ ] Did you write any new necessary tests?

## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
