### PR TITLE
[fix]: support pytorch SyncBatchNorm under AMP & checkpointing with FSDP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - SDP: re-expose the module property ([#647](https://github.com/facebookresearch/fairscale/pull/647))
 
 ### Added
+- FSDP: added `force\_input\_to\_fp32` flag for SyncBatchNorm
 - FSDP: better memory usage for reduce bucket ([#633](https://github.com/facebookresearch/fairscale/pull/633))
 
 ## [0.3.6] - 2021-04-26

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1831,9 +1831,8 @@ def auto_wrap_bn(
             # No bucketing or small bucketing should be enough for BNs.
             "bucket_cap_mb": 0,
             # Setting this for SyncBatchNorm. This may have a performance impact. If
-            # SyncBatchNorm is not used, this can be disabled by using passing in
-            # the `fsdp_config` argument to `auto_wrap_bn`.
-            "force_input_to_fp32": True,
+            # SyncBatchNorm is used, this can be enabled by passing in the `fsdp_config` argument.
+            "force_input_to_fp32": False,
         }
 
     with enable_wrap(wrap_bn_only_policy, **fsdp_config):

--- a/tests/ci_test_list_1.txt
+++ b/tests/ci_test_list_1.txt
@@ -1,5 +1,4 @@
 tests/nn/data_parallel/test_fsdp_memory.py
-tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
 tests/nn/data_parallel/test_fsdp_multiple_wrapping.py
 tests/nn/data_parallel/test_fsdp_freezing_weights.py
 tests/nn/data_parallel/test_fsdp_regnet.py
@@ -8,6 +7,5 @@ tests/nn/data_parallel/test_fsdp_grad_scaler.py
 tests/nn/data_parallel/test_fsdp_no_sync.py
 tests/nn/data_parallel/test_fsdp_summon_full_params.py
 tests/nn/data_parallel/test_fsdp_input.py
-tests/nn/data_parallel/test_fsdp_multiple_forward.py
 tests/nn/data_parallel/test_fsdp_optimizer_utils.py
 tests/nn/data_parallel/test_fsdp.py

--- a/tests/ci_test_list_1.txt
+++ b/tests/ci_test_list_1.txt
@@ -11,5 +11,3 @@ tests/nn/data_parallel/test_fsdp_input.py
 tests/nn/data_parallel/test_fsdp_multiple_forward.py
 tests/nn/data_parallel/test_fsdp_optimizer_utils.py
 tests/nn/data_parallel/test_fsdp.py
-tests/nn/misc/test_flatten_params_wrapper.py
-tests/nn/pipe/test_parity.py

--- a/tests/ci_test_list_1.txt
+++ b/tests/ci_test_list_1.txt
@@ -2,6 +2,14 @@ tests/nn/data_parallel/test_fsdp_memory.py
 tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
 tests/nn/data_parallel/test_fsdp_multiple_wrapping.py
 tests/nn/data_parallel/test_fsdp_freezing_weights.py
+tests/nn/data_parallel/test_fsdp_regnet.py
+tests/nn/data_parallel/test_fsdp_uneven.py
+tests/nn/data_parallel/test_fsdp_grad_scaler.py
+tests/nn/data_parallel/test_fsdp_no_sync.py
+tests/nn/data_parallel/test_fsdp_summon_full_params.py
+tests/nn/data_parallel/test_fsdp_input.py
+tests/nn/data_parallel/test_fsdp_multiple_forward.py
+tests/nn/data_parallel/test_fsdp_optimizer_utils.py
 tests/nn/data_parallel/test_fsdp.py
 tests/nn/misc/test_flatten_params_wrapper.py
 tests/nn/pipe/test_parity.py

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -1,3 +1,5 @@
+tests/nn/misc/test_checkpoint_activations.py
+tests/nn/misc/test_checkpoint_activations_norm.py
 tests/nn/data_parallel/test_fsdp_multiple_forward.py
 tests/nn/data_parallel/test_fsdp_apply.py
 tests/nn/data_parallel/test_fsdp_state_dict.py

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -1,4 +1,3 @@
-tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
 tests/nn/data_parallel/test_fsdp_multiple_forward.py
 tests/nn/data_parallel/test_fsdp_apply.py
 tests/nn/data_parallel/test_fsdp_state_dict.py

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -1,11 +1,11 @@
+tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+tests/nn/data_parallel/test_fsdp_multiple_forward.py
+tests/nn/data_parallel/test_fsdp_apply.py
+tests/nn/data_parallel/test_fsdp_state_dict.py
 tests/utils/test_reduce_scatter_bucketer.py
 tests/utils/test_containers.py
 tests/utils/test_parallel.py
 tests/utils/test_state_dict.py
-tests/nn/misc/test_checkpoint_activations.py
-tests/nn/misc/test_checkpoint_activations_norm.py
-tests/nn/misc/test_grad_bucket.py
-tests/nn/misc/test_param_bucket.py
 tests/nn/wrap/test_wrap.py
 tests/nn/pipe_process/test_pipe.py
 tests/nn/pipe_process/test_transparency.py
@@ -38,5 +38,3 @@ tests/nn/moe/test_top2gating.py
 tests/experimental/nn/ampnet_pipe_process/test_ampnet_pipe.py
 tests/experimental/nn/test_offload.py
 tests/experimental/optim/test_dynamic_loss_scaler.py
-tests/nn/data_parallel/test_fsdp_apply.py
-tests/nn/data_parallel/test_fsdp_state_dict.py

--- a/tests/ci_test_list_3.txt
+++ b/tests/ci_test_list_3.txt
@@ -1,5 +1,7 @@
+tests/nn/misc/test_flatten_params_wrapper.py
 tests/nn/data_parallel/test_sharded_ddp_features.py
 tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py
+tests/nn/pipe/test_parity.py
 tests/nn/pipe/skip/test_gpipe.py
 tests/nn/pipe/skip/test_verify_skippables.py
 tests/nn/pipe/skip/test_stash_pop.py

--- a/tests/ci_test_list_3.txt
+++ b/tests/ci_test_list_3.txt
@@ -1,6 +1,4 @@
 tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
-tests/nn/misc/test_checkpoint_activations.py
-tests/nn/misc/test_checkpoint_activations_norm.py
 tests/nn/misc/test_grad_bucket.py
 tests/nn/misc/test_param_bucket.py
 tests/nn/misc/test_flatten_params_wrapper.py

--- a/tests/ci_test_list_3.txt
+++ b/tests/ci_test_list_3.txt
@@ -1,11 +1,3 @@
-tests/nn/data_parallel/test_fsdp_regnet.py
-tests/nn/data_parallel/test_fsdp_uneven.py
-tests/nn/data_parallel/test_fsdp_grad_scaler.py
-tests/nn/data_parallel/test_fsdp_no_sync.py
-tests/nn/data_parallel/test_fsdp_summon_full_params.py
-tests/nn/data_parallel/test_fsdp_input.py
-tests/nn/data_parallel/test_fsdp_multiple_forward.py
-tests/nn/data_parallel/test_fsdp_optimizer_utils.py
 tests/nn/data_parallel/test_sharded_ddp_features.py
 tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py
 tests/nn/pipe/skip/test_gpipe.py

--- a/tests/ci_test_list_3.txt
+++ b/tests/ci_test_list_3.txt
@@ -1,3 +1,7 @@
+tests/nn/misc/test_checkpoint_activations.py
+tests/nn/misc/test_checkpoint_activations_norm.py
+tests/nn/misc/test_grad_bucket.py
+tests/nn/misc/test_param_bucket.py
 tests/nn/misc/test_flatten_params_wrapper.py
 tests/nn/data_parallel/test_sharded_ddp_features.py
 tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py

--- a/tests/ci_test_list_3.txt
+++ b/tests/ci_test_list_3.txt
@@ -1,3 +1,4 @@
+tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
 tests/nn/misc/test_checkpoint_activations.py
 tests/nn/misc/test_checkpoint_activations_norm.py
 tests/nn/misc/test_grad_bucket.py

--- a/tests/nn/data_parallel/test_fsdp_freezing_weights.py
+++ b/tests/nn/data_parallel/test_fsdp_freezing_weights.py
@@ -111,7 +111,7 @@ def _distributed_worker(
     if gpu_id == 0:
         print(model)
 
-    target = torch.LongTensor([0, 1]).cuda()
+    target = torch.tensor([0, 1], dtype=torch.long).cuda()
     criterion = nn.CrossEntropyLoss()
     optimizer = optim.SGD(model.parameters(), lr=0.1, momentum=0.9)
 

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
@@ -291,6 +291,13 @@ def test_multiple_forward_checkpoint(precision, flatten, wrap_bn, model_type, bn
     with_model2 = model_type == "model2"
     with_sync_bn = bn_type == "sync_bn"
 
+    if torch_version() >= (1, 7, 0) and torch_version() < (1, 8, 0) and with_sync_bn:
+        # SyncBN is buggy in 1.7, errors like:
+        # E         File "/home/circleci/venv/lib/python3.8/site-packages/torch/nn/modules/_functions.py", line 13, in forward
+        # E           dtype=running_mean.dtype,
+        # E       AttributeError: 'NoneType' object has no attribute 'dtype'
+        pytest.skip("SyncBatchNorm in 1.7 is buggy")
+
     if with_sync_bn and not wrap_bn:
         pytest.skip("SyncBatchNorm requires auto_wrap_bn")
 

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
@@ -212,7 +212,7 @@ def _distributed_worker(
 @pytest.mark.parametrize("flatten", ["flatten", "no_flatten"])
 @pytest.mark.parametrize("wrap_bn", ["auto_wrap_bn", "no_auto_wrap_bn"])
 @pytest.mark.parametrize("model_type", ["model1", "model2"])
-def test_multiple_forward_checkpoint(precision, flatten, wrap_bn):
+def test_multiple_forward_checkpoint(precision, flatten, wrap_bn, model_type):
     mixed_precision = precision == "mixed"
     flatten = flatten == "flatten"
     wrap_bn = wrap_bn == "auto_wrap_bn"


### PR DESCRIPTION
- there is an issue of sync_bn with checkpoint_wrapper in AMP, particularly due to checkpoint_wrapper sets `track_running_stats` to False, which interacts badly with AMP.
- add force_input_to_fp32 flag to workaround this issue
- this flag can be used to workaround sync batch norm when AMP and checkpoint is used.
- it can also be used in case a layer insist on using fp32 inputs.
- enhanced the unit test so that it covers more types of models as well as runs faster by caching the ddp results.
- also rebalance the tests a bit.

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)


## What does this PR do?
fixes #617 . (The second test in the issue does not need to be run since we have a double forward & checkpoint test that is even bigger than that test and it doesn't hit any assertions. The bigger test do have memory issues that's separate and is being debugged.)

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
