### PR TITLE
[minor] clarify a comment

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1317,18 +1317,15 @@ class FullyShardedDataParallel(nn.Module):
             if isinstance(m, FullyShardedDataParallel):
                 _remove_shard_bwd_hook(m)
                 m._pre_backward_hook_has_run = False
-                # Note: m.parameters() should not be an empty list. FSDP
-                # wrapping modules without weights is not tested at the moment.
                 if any(p.requires_grad for p in m.parameters()):
                     if m._has_params:
                         m.assert_state(TrainingState.BACKWARD_POST)
                     else:
                         m.assert_state(TrainingState.BACKWARD_PRE)
                 else:
-                    # Unlikely case. When m and its children has no params
-                    # with `requires_grad==True`, then m's pre-backward and
-                    # post-backward hooks aren't called by autograd. Therefore,
-                    # it is in IDLE state.
+                    # Unlikely case. When `m` and its children has no params or has params but
+                    # none with `requires_grad==True`, then m's pre-backward and post-backward
+                    # hooks aren't called by autograd. Therefore, it is in IDLE state.
                     m.assert_state(TrainingState.IDLE)
                 m.training_state = TrainingState.IDLE
 


### PR DESCRIPTION
- we do have a use case of empty params inside a FSDP -- for the
overlapping fsdp unit test, we use it to measure timing of compute
when no params is needed for all_gather
- therefore, I updated the comment to be more correct there.
- fixes #661

# Before submitting

- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Did you make sure to update the docs?
- [x] Did you write any new necessary tests?
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)


## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.

## Did you have fun?
Make sure you had fun coding 🙃
