### PR TITLE
[chore] Updating PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,16 @@
 # Before submitting
 
+- [ ] Did you have fun?
+  - Make sure you had fun coding 🙃
 - [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
-- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements) [ ] N/A
-- [ ] Did you make sure to update the docs? [ ] N/A
-- [ ] Did you write any new necessary tests? [ ] N/A
-- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed) [ ] N/A
+- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
+  - [ ] N/A
+- [ ] Did you make sure to update the docs?
+  - [ ] N/A
+- [ ] Did you write any new necessary tests?
+  - [ ] N/A
+- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
+  - [ ] N/A
 
 
 ## What does this PR do?
@@ -13,6 +19,3 @@ Fixes # (issue).
 ## PR review
 Anyone in the community is free to review the PR once the tests have passed.
 If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
-
-## Did you have fun?
-Make sure you had fun coding 🙃

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,10 +1,10 @@
 # Before submitting
 
-- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
 - [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
-- [ ] Did you make sure to update the docs?
-- [ ] Did you write any new necessary tests?
-- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
+- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements) [ ] N/A
+- [ ] Did you make sure to update the docs? [ ] N/A
+- [ ] Did you write any new necessary tests? [ ] N/A
+- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed) [ ] N/A
 
 
 ## What does this PR do?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,7 @@
-# Before submitting
+## What does this PR do?
+Fixes # (issue).
+
+## Before submitting
 
 - [ ] Did you have fun?
   - Make sure you had fun coding 🙃
@@ -12,9 +15,6 @@
 - [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
   - [ ] N/A
 
-
-## What does this PR do?
-Fixes # (issue).
 
 ## PR review
 Anyone in the community is free to review the PR once the tests have passed.


### PR DESCRIPTION
Add N/A (Not Applicable) options to some of the questions in the PR template

# Before submitting

- [x] Did you have fun?
   - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
   - [x] N/A
- [x] Did you make sure to update the docs?
   - [x] N/A
- [x] Did you write any new necessary tests?
   - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
   - [x] N/A


## What does this PR do?
Fixes # (issue).

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.