### PR TITLE
[offload] Add pragma directives to ensure we ignore the backward pass functions.

### DIFF
--- a/fairscale/experimental/nn/offload.py
+++ b/fairscale/experimental/nn/offload.py
@@ -117,6 +117,9 @@ class ModelShard(nn.Module):
             # Restore all the parameter buffers
             self.model_shard.to(device=self.device, non_blocking=non_blocking)
 
+    # Ignore the following function for code coverage since the backward pass
+    # is triggered by C++ code and cannot be calculated when overriding
+    # autograd.Function
     def backward_load(self, non_blocking: bool = True) -> None:  # pragma: no cover
         with torch.cuda.stream(self._cpu_to_gpu_stream):
             self.model_shard.to(self.device, non_blocking=non_blocking)
@@ -125,6 +128,9 @@ class ModelShard(nn.Module):
         with torch.cuda.stream(self._gpu_to_cpu_stream):
             self.model_shard.to(self.offload_device, non_blocking=non_blocking)
 
+    # Ignore the following function for code coverage since the backward pass
+    # is triggered by C++ code and cannot be calculated when overriding
+    # autograd.Function
     def backward_drop(self, non_blocking: bool = True) -> None:  # pragma: no cover
         with torch.cuda.stream(self._gpu_to_cpu_stream):
             self.model_shard.to(self.offload_device, non_blocking=non_blocking)
@@ -206,6 +212,9 @@ class OffloadFunction(torch.autograd.Function):
             r.requires_grad = True
         return result[0] if len(result) == 1 else result
 
+    # Ignore the following function for code coverage since the backward pass
+    # is triggered by C++ code and cannot be calculated when overriding
+    # autograd.Function
     @staticmethod
     @_conditional_amp_bwd_decorator
     def backward(ctx, *grad_outputs):  # type: ignore # pragma: no cover
@@ -324,6 +333,9 @@ class ShardSyncLayer(torch.autograd.Function):
 
         return inputs if isinstance(inputs, tuple) else (inputs,)
 
+    # Ignore the following function for code coverage since the backward pass
+    # is triggered by C++ code and cannot be calculated when overriding
+    # autograd.Function
     @staticmethod
     @_conditional_amp_bwd_decorator
     def backward(ctx, *grad_outputs):  # type: ignore # pragma: no cover

--- a/fairscale/experimental/nn/offload.py
+++ b/fairscale/experimental/nn/offload.py
@@ -208,7 +208,7 @@ class OffloadFunction(torch.autograd.Function):
 
     @staticmethod
     @_conditional_amp_bwd_decorator
-    def backward(ctx, *grad_outputs):   # type: ignore pragma: no cover
+    def backward(ctx, *grad_outputs):  # type: ignore # pragma: no cover
         if not torch.autograd._is_checkpoint_valid():
             raise RuntimeError("Checkpointing is not compatible with .grad(), please use .backward() if possible")
         inputs = ctx.inputs
@@ -326,7 +326,7 @@ class ShardSyncLayer(torch.autograd.Function):
 
     @staticmethod
     @_conditional_amp_bwd_decorator
-    def backward(ctx, *grad_outputs):   # type: ignore pragma: no cover
+    def backward(ctx, *grad_outputs):  # type: ignore # pragma: no cover
 
         load_index = ctx.index
         drop_index = load_index + 1

--- a/fairscale/experimental/nn/offload.py
+++ b/fairscale/experimental/nn/offload.py
@@ -208,7 +208,7 @@ class OffloadFunction(torch.autograd.Function):
 
     @staticmethod
     @_conditional_amp_bwd_decorator
-    def backward(ctx, *grad_outputs):  # pragma: no cover
+    def backward(ctx, *grad_outputs):   # type: ignore pragma: no cover
         if not torch.autograd._is_checkpoint_valid():
             raise RuntimeError("Checkpointing is not compatible with .grad(), please use .backward() if possible")
         inputs = ctx.inputs
@@ -326,7 +326,7 @@ class ShardSyncLayer(torch.autograd.Function):
 
     @staticmethod
     @_conditional_amp_bwd_decorator
-    def backward(ctx, *grad_outputs):  # pragma: no cover
+    def backward(ctx, *grad_outputs):   # type: ignore pragma: no cover
 
         load_index = ctx.index
         drop_index = load_index + 1

--- a/fairscale/experimental/nn/offload.py
+++ b/fairscale/experimental/nn/offload.py
@@ -208,7 +208,7 @@ class OffloadFunction(torch.autograd.Function):
 
     @staticmethod
     @_conditional_amp_bwd_decorator
-    def backward(ctx, *grad_outputs):  # type: ignore
+    def backward(ctx, *grad_outputs):  # pragma: no cover
         if not torch.autograd._is_checkpoint_valid():
             raise RuntimeError("Checkpointing is not compatible with .grad(), please use .backward() if possible")
         inputs = ctx.inputs
@@ -326,7 +326,7 @@ class ShardSyncLayer(torch.autograd.Function):
 
     @staticmethod
     @_conditional_amp_bwd_decorator
-    def backward(ctx, *grad_outputs):  # type: ignore
+    def backward(ctx, *grad_outputs):  # pragma: no cover
 
         load_index = ctx.index
         drop_index = load_index + 1

--- a/fairscale/experimental/nn/offload.py
+++ b/fairscale/experimental/nn/offload.py
@@ -117,7 +117,7 @@ class ModelShard(nn.Module):
             # Restore all the parameter buffers
             self.model_shard.to(device=self.device, non_blocking=non_blocking)
 
-    def backward_load(self, non_blocking: bool = True) -> None:
+    def backward_load(self, non_blocking: bool = True) -> None:  # pragma: no cover
         with torch.cuda.stream(self._cpu_to_gpu_stream):
             self.model_shard.to(self.device, non_blocking=non_blocking)
 
@@ -125,7 +125,7 @@ class ModelShard(nn.Module):
         with torch.cuda.stream(self._gpu_to_cpu_stream):
             self.model_shard.to(self.offload_device, non_blocking=non_blocking)
 
-    def backward_drop(self, non_blocking: bool = True) -> None:
+    def backward_drop(self, non_blocking: bool = True) -> None:  # pragma: no cover
         with torch.cuda.stream(self._gpu_to_cpu_stream):
             self.model_shard.to(self.offload_device, non_blocking=non_blocking)
 


### PR DESCRIPTION
## What does this PR do?
Adds pragma directives to ensure that we ignore backward passes when calculating code coverage. 
Backward passes are called from C++ code which means we never really end up calling the python functions we write when overriding autograd.Function.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
