### PR TITLE
[minor] use dist.group.WORLD for default process group

### DIFF
--- a/fairscale/utils/parallel.py
+++ b/fairscale/utils/parallel.py
@@ -62,9 +62,9 @@ def get_process_group_cached(ranks: Optional[Sequence[int]] = None) -> ProcessGr
     """
     Singleton PyTorch distributed group cache. Inspired by the code from fairseq.
 
-    Just like torch.distributed.new_group, this needs to be called on all ranks
-    at the same time when a new group is created, no matter the rank is a member of
-    that group of not.
+    Just like torch.distributed.new_group, this method needs to be called on all ranks
+    at the same time when a new group is created. This is true for all ranks irrespective
+    of their group membership status.
 
     For FSDP, it is important to use the same group between outer and inner FSDP instances,
     otherwise, inner FSDP instances will not share the gradient reduction bucket buffer with

--- a/fairscale/utils/parallel.py
+++ b/fairscale/utils/parallel.py
@@ -98,7 +98,7 @@ def get_process_group_cached(ranks: Optional[List[int]] = None) -> ProcessGroup:
         cache = get_process_group_cached._global_group_cache  # type: ignore
         assert dist.group.WORLD is not None
         cache[None] = dist.group.WORLD
-        cache[list(range(dist.get_world_size()))] = dist.group.WORLD
+        cache[frozenset(list(range(dist.get_world_size())))] = dist.group.WORLD
 
     # Lookup and fill the cache if needed.
     cache = get_process_group_cached._global_group_cache  # type: ignore
@@ -106,6 +106,6 @@ def get_process_group_cached(ranks: Optional[List[int]] = None) -> ProcessGroup:
         # take care of ordering and duplicates in the ranks list.
         ranks = sorted(list(set(ranks)))
     if ranks not in cache:
-        cache[ranks] = dist.new_group(ranks)
+        cache[frozenset(ranks) if ranks is not None else ranks] = dist.new_group(ranks)
 
-    return cache[ranks]
+    return cache[frozenset(ranks) if ranks is not None else ranks]

--- a/fairscale/utils/parallel.py
+++ b/fairscale/utils/parallel.py
@@ -97,8 +97,12 @@ def get_process_group_cached(ranks: Optional[Sequence[int]] = None) -> ProcessGr
         # Populate with default process group.
         cache = get_process_group_cached._global_group_cache  # type: ignore
         assert dist.group.WORLD is not None
-        cache[None] = dist.group.WORLD
-        cache[frozenset(list(range(dist.get_world_size())))] = dist.group.WORLD
+        default_pg = dist.group.WORLD
+        if type(default_pg) == object:
+            # For PyTorch 1.6 and 1.7, dist.group.WORLD is an object, not a world process group, like that in 1.8 and 1.9.
+            default_pg = dist.new_group()
+        cache[None] = default_pg
+        cache[frozenset(list(range(dist.get_world_size())))] = default_pg
 
     # Lookup and fill the cache if needed.
     cache = get_process_group_cached._global_group_cache  # type: ignore

--- a/stubs/torch/distributed/__init__.pyi
+++ b/stubs/torch/distributed/__init__.pyi
@@ -1,6 +1,6 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
 
-from typing import Any, List, Union, Optional
+from typing import Any, List, Union, Optional, Sequence
 from torch import Tensor
 import datetime
 
@@ -37,7 +37,7 @@ def broadcast_object_list(object_list: List[Any], src: int, group:Optional[Proce
 def is_initialized() -> bool: ...
 
 def init_process_group(backend: Union[str, Backend], init_method: Optional[str] = None, timeout: datetime.timedelta = datetime.timedelta(0, 1800), rank: Optional[int] = None, world_size: Optional[int] = None): ...
-def new_group(ranks: Optional[List[int]] = None,
+def new_group(ranks: Optional[Sequence[int]] = None,
               timeout: Optional[datetime.timedelta] = datetime.timedelta(0, 1800),
               backend: Optional[Union[str, Backend]] = None): ...
 


### PR DESCRIPTION
- this is slightly more efficient than the previous commit
  for get_process_group_cached.

## What does this PR do?
Fixes # (issue).

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
