### PR TITLE
Save FSDP metadata for offline unflattening

### DIFF
--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -119,6 +119,9 @@ class DistributedTest(unittest.TestCase):
             assert objects_are_equal(ref_state_dict, shard_state_dict, raise_exception=True)
         except (AssertionError, RuntimeError) as e:
             raise Exception(f"FullyShardedDataParallel didn't match PyTorch DDP using config: {config}\n\n {e}")
+        if config.get("flatten_parameters", True):
+            metadata = model.shard_reconstruction_info()
+            assert isinstance(metadata, dict)
 
 
 class TestMixedPrecision(DistributedTest):


### PR DESCRIPTION
Context: @QuentinDuval  and I agreed that I could support the streaming checkpoint effort by making a method that returns all the extra info needed to combine `local_state_dict`s  into larger unflat checkpoints offline.



VERY rough idea of where to go after saving `shard_reconstruction_info()`.

```python

info = [torch.load(f'checkpoint-layer_1_reconstruction_info_{i}.pt') for i in world_size]
state = [torch.load(f'checkpoint-layer_1_rank_{i}.pt') for i in world_size]
```
#info[i] should correspond to state[i]

1) unpad using numel_padded_per_param
2) torch.cat(unpadded_tensors)
3) unflatten as below

```python
(t.view(s) for (t, s) in zip(flat_param.split(param_numels), unflat_shapes))  # copy the source code from FlattenParamsWrapper.get_param_views
```


cc @QuentinDuval @prigoyal @min-xu-ai 