### PR TITLE
[feat] Save FSDP metadata for offline unflattening + Consolidate checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FSDP: added `force_input_to_fp32` flag for SyncBatchNorm [#659]
 - FSDP: better memory usage for reduce bucket [#633]
 - Experimental SyncBatchNorm [#662]
+- FSDP: added `local_metadata_dict` to save sharding relating information [#683]
+- FSDP: added `consolidate_shard_weights` to reconstruct the consolidated (non-sharded) model weights from saved sharded weights and metadata on the disk [#683]
 
 ## [0.3.6] - 2021-04-26
 ### Added

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -8,6 +8,7 @@ import copy
 from enum import Enum, auto
 import functools
 import logging
+import math
 from math import inf
 import time
 import traceback
@@ -1536,7 +1537,9 @@ class FullyShardedDataParallel(nn.Module):
         )
 
     @staticmethod
-    def consolidate_shard_weights(shard_weights: List[Dict[str, torch.Tensor]], shard_metadata: List[Dict[str, Any]]):
+    def consolidate_shard_weights(
+        shard_weights: List[Dict[str, torch.Tensor]], shard_metadata: List[Dict[str, Any]]
+    ) -> Dict[str, torch.Tensor]:
         """
         Given a list of weights and meta data associated to N shards, reconstruct
         the weights of an equivalent consolidated (non-sharded) model.
@@ -1905,15 +1908,12 @@ def _pre_load_state_dict_hook(
     replace_by_prefix_(state_dict, prefix, prefix + "_fsdp_wrapped_module.")
 
 
-def _clean_path(path: str):
+def _clean_path(path: str) -> str:
     return ".".join([split for split in path.split(".") if split not in {"_fsdp_wrapped_module", "_fpw_module"}])
 
 
-def _numel_from_size(size: torch.Size):
-    numel = 1
-    for dim in size:
-        numel *= dim
-    return numel
+def _numel_from_size(size: torch.Size) -> int:
+    return math.prod(size)
 
 
 ########################################################################################

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1508,7 +1508,7 @@ class FullyShardedDataParallel(nn.Module):
             # Dealing with FSDP(flatten_parameter=True)
             # Now, there is just one flattened parameter mapped to N different
             # parameters, so we need to export additional information (numels)
-            # on how to split the "merged" parameters, by extracing the meta-data
+            # on how to split the "merged" parameters, by extracting the meta-data
             # used in the FlattenParamsWrapper
             else:
                 param_names = []
@@ -1559,17 +1559,18 @@ class FullyShardedDataParallel(nn.Module):
 
         # Deal with the parameters of the model, for which there should be
         # a corresponding entry in the metadata
-        num_fsdp_wrappers = len(shard_metadata[0]["param_metadata"])
+        shard_0_metadata = shard_metadata[0]["param_metadata"]
+        num_fsdp_wrappers = len(shard_0_metadata)
         for fsdp_wrapper_index in range(num_fsdp_wrappers):
-            fsdp_path = shard_metadata[0]["param_metadata"][fsdp_wrapper_index]["fsdp_path"]
-            param_names = shard_metadata[0]["param_metadata"][fsdp_wrapper_index]["param_names"]
-            param_numels = shard_metadata[0]["param_metadata"][fsdp_wrapper_index]["param_numels"]
-            param_shapes = shard_metadata[0]["param_metadata"][fsdp_wrapper_index]["param_shapes"]
+            fsdp_path = shard_0_metadata[fsdp_wrapper_index]["fsdp_path"]
+            param_names = shard_0_metadata[fsdp_wrapper_index]["param_names"]
+            param_numels = shard_0_metadata[fsdp_wrapper_index]["param_numels"]
+            param_shapes = shard_0_metadata[fsdp_wrapper_index]["param_shapes"]
 
             # Dealing with FSDP(flatten_parameter=False)
             # For each parameter of the FSDP wrapper, get rid of the padding on each shard,
             # concatenate the shards and reshape them to their initial shape
-            if not shard_metadata[0]["param_metadata"][fsdp_wrapper_index]["is_flat"]:
+            if not shard_0_metadata[fsdp_wrapper_index]["is_flat"]:
                 for i in range(len(param_names)):
                     param_name = param_names[i]
                     param_name = ".".join([fsdp_path, param_name]) if fsdp_path else param_name

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1522,6 +1522,9 @@ class FullyShardedDataParallel(nn.Module):
         having to instantiate FSDP wrappers with the world size originally used
         to save the shards
         """
+        assert len(shard_weights) > 0, "Invalid number of shards: 0"
+        assert len(shard_weights) == len(shard_metadata), "Require meta data for each shard"
+
         consolidated_weights = {}
         original_world_size = len(shard_weights)
 

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -75,7 +75,7 @@ class FlattenParamsWrapper(nn.Module):
         params = []
         param_numels = []
         param_shapes = []
-        for m_name, m in self.named_modules():
+        for module_name, m in self.named_modules():
             for n, p in m.named_parameters(recurse=False):
                 if p is not None and (m, n) in self._param_set:
                     if p in shared_param_memo:
@@ -84,7 +84,7 @@ class FlattenParamsWrapper(nn.Module):
                     else:
                         shared_param_memo[p] = (m, n)
                         param_infos.append((m, n))
-                        param_full_infos.append((m_name, n))
+                        param_full_infos.append((module_name, n))
                         params.append(p.detach())
                         param_numels.append(p.numel())
                         param_shapes.append(p.size())

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -69,12 +69,13 @@ class FlattenParamsWrapper(nn.Module):
 
     def _init_flatten_params(self) -> List[Tensor]:
         param_infos = []
+        param_full_infos = []
         shared_param_memo: Dict[nn.Parameter, Tuple[nn.Module, str]] = {}
         shared_param_infos = []
         params = []
         param_numels = []
         param_shapes = []
-        for m in self.modules():
+        for m_name, m in self.named_modules():
             for n, p in m.named_parameters(recurse=False):
                 if p is not None and (m, n) in self._param_set:
                     if p in shared_param_memo:
@@ -83,6 +84,7 @@ class FlattenParamsWrapper(nn.Module):
                     else:
                         shared_param_memo[p] = (m, n)
                         param_infos.append((m, n))
+                        param_full_infos.append((m_name, n))
                         params.append(p.detach())
                         param_numels.append(p.numel())
                         param_shapes.append(p.size())
@@ -92,6 +94,7 @@ class FlattenParamsWrapper(nn.Module):
 
         # store the info for unflatten
         self._param_infos = tuple(param_infos)
+        self._param_full_infos = tuple(param_full_infos)
         self._shared_param_infos = tuple(shared_param_infos)
         self._param_numels = tuple(param_numels)
         self._param_shapes = tuple(param_shapes)

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -664,6 +664,21 @@ def rmf(filename: str) -> None:
 
 
 @contextlib.contextmanager
+def in_temporary_directory():
+    """
+    Context manager to create a temporary direction and remove
+    it at the end of the context
+    """
+    import shutil
+    temp_dir = tempfile.mkdtemp()
+    old_cwd = os.getcwd()
+    os.chdir(temp_dir)
+    yield temp_dir
+    os.chdir(old_cwd)
+    shutil.rmtree(temp_dir)
+
+
+@contextlib.contextmanager
 def temp_files_ctx(num: int) -> Generator:
     """ A context to get tempfiles and ensure they are cleaned up. """
     files = [tempfile.mkstemp()[1] for _ in range(num)]

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -34,6 +34,7 @@ import logging
 import multiprocessing
 import os
 import random
+import shutil
 from statistics import mean
 import subprocess
 import sys
@@ -669,7 +670,6 @@ def in_temporary_directory():
     Context manager to create a temporary direction and remove
     it at the end of the context
     """
-    import shutil
     temp_dir = tempfile.mkdtemp()
     old_cwd = os.getcwd()
     os.chdir(temp_dir)
@@ -699,7 +699,7 @@ def dump_all_tensors(rank: int) -> None:
             ttype = str(type(obj))
             if torch.is_tensor(obj) or (hasattr(obj, "data") and torch.is_tensor(obj.data)):
                 print(ttype, obj.shape, obj.dtype, obj.device, obj.storage().size())
-        except Exception as e:
+        except Exception:
             pass
     print(torch.cuda.memory_summary())
 

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -34,7 +34,6 @@ import logging
 import multiprocessing
 import os
 import random
-import shutil
 from statistics import mean
 import subprocess
 import sys
@@ -670,12 +669,11 @@ def in_temporary_directory() -> Generator:
     Context manager to create a temporary direction and remove
     it at the end of the context
     """
-    temp_dir = tempfile.mkdtemp()
     old_cwd = os.getcwd()
-    os.chdir(temp_dir)
-    yield temp_dir
-    os.chdir(old_cwd)
-    shutil.rmtree(temp_dir)
+    with tempfile.TemporaryDirectory() as temp_dir:
+        os.chdir(temp_dir)
+        yield temp_dir
+        os.chdir(old_cwd)
 
 
 @contextlib.contextmanager

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -665,7 +665,7 @@ def rmf(filename: str) -> None:
 
 
 @contextlib.contextmanager
-def in_temporary_directory():
+def in_temporary_directory() -> Generator:
     """
     Context manager to create a temporary direction and remove
     it at the end of the context

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -2,6 +2,7 @@ tests/nn/data_parallel/test_fsdp_overlap.py
 tests/nn/data_parallel/test_fsdp_multiple_forward.py
 tests/nn/data_parallel/test_fsdp_apply.py
 tests/nn/data_parallel/test_fsdp_state_dict.py
+tests/nn/data_parallel/test_fsdp_metadata.py
 tests/utils/test_reduce_scatter_bucketer.py
 tests/utils/test_containers.py
 tests/utils/test_parallel.py

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -119,6 +119,9 @@ class DistributedTest(unittest.TestCase):
             assert objects_are_equal(ref_state_dict, shard_state_dict, raise_exception=True)
         except (AssertionError, RuntimeError) as e:
             raise Exception(f"FullyShardedDataParallel didn't match PyTorch DDP using config: {config}\n\n {e}")
+        if config.get("flatten_parameters", True):
+            metadata = model.shard_reconstruction_info()
+            assert isinstance(metadata, dict)
 
 
 class TestMixedPrecision(DistributedTest):

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -8,14 +8,14 @@ import itertools
 from math import inf
 import pickle
 import sys
-from typing import Dict, List
+from typing import Dict
 import unittest
 from unittest import mock
 
 from parameterized import parameterized
 import torch
-import torch.distributed
 from torch import nn
+import torch.distributed
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel, TrainingState
@@ -26,7 +26,7 @@ from fairscale.utils.testing import (
     get_cycles_per_ms,
     objects_are_equal,
     spawn_for_all_world_sizes,
-    torch_version, temp_files_ctx, in_temporary_directory,
+    torch_version,
 )
 
 # How to use remote-pdb: https://gist.github.com/sshleifer/9d43351957179c13606e015b072927d4
@@ -525,88 +525,6 @@ class TestNoGrad(DistributedTest):
             no_grad_output = model(*input)
 
         assert objects_are_equal(ref_output, no_grad_output, raise_exception=True)
-
-
-class SimpleNestedModel(nn.Module):
-    def __init__(self, embedding_size: int, process_group):
-        super().__init__()
-        fc1 = nn.Linear(embedding_size, 2 * embedding_size)
-        fc2 = nn.Linear(2 * embedding_size, 2 * embedding_size)
-        fc3 = nn.Linear(2 * embedding_size, embedding_size)
-        self.fc1 = FullyShardedDataParallel(fc1, process_group=process_group)
-        self.fc2 = fc2
-        self.fc3 = FullyShardedDataParallel(fc3, process_group=process_group)
-        self.relu = nn.ReLU(inplace=True)
-
-    def forward(self, x):
-        x = self.fc1(x)
-        x = self.fc2(x)
-        return self.fc3(x)
-
-
-class TestCheckpointConsolidation(DistributedTest):
-
-    @staticmethod
-    def _worker(gpu_id: int, world_size: int, embedding_size: int, checkpoint_folder: str):
-        torch.cuda.set_device(gpu_id)
-        torch.distributed.init_process_group(
-            backend="nccl",
-            init_method="tcp://127.0.0.1:9099",
-            world_size=world_size,
-            rank=gpu_id,
-        )
-        process_group = torch.distributed.new_group()
-
-        batch_size = 16
-        torch.manual_seed(0)
-        input = torch.randn(size=(batch_size, embedding_size)).cuda()
-        target = torch.zeros(size=(batch_size, embedding_size)).cuda()
-        model = SimpleNestedModel(process_group=process_group, embedding_size=embedding_size).cuda()
-        model = FullyShardedDataParallel(model, process_group=process_group)
-        criterion = nn.MSELoss()
-        optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
-
-        for epoch in range(2):
-            out = model(input)
-            loss = criterion(out, target)
-            optimizer.zero_grad()
-            loss.backward()
-            optimizer.step()
-
-        with torch.no_grad():
-            before_checkpoint_loss = criterion(model(input), target).item()
-
-        cp_data = {
-            "weights": {k: v.cpu() for k, v in model.local_state_dict().items()},
-            "meta": model.local_metadata_dict(),
-        }
-        torch.save(cp_data, f"checkpoint_{gpu_id}.torch")
-        torch.distributed.barrier()
-
-        # Reconstruct a full checkpoint and load it
-        all_checkpoints = [torch.load(f"checkpoint_{rank}.torch") for rank in range(world_size)]
-        consolidated_checkpoint = FullyShardedDataParallel.consolidate_shard_weights(
-            shard_weights=[c["weights"] for c in all_checkpoints],
-            shard_metadata=[c["meta"] for c in all_checkpoints],
-        )
-
-        model = SimpleNestedModel(process_group=process_group, embedding_size=embedding_size).cuda()
-        model = FullyShardedDataParallel(model, process_group=process_group)
-        model.load_state_dict(consolidated_checkpoint)
-        for m in model.modules():
-            if isinstance(m, FullyShardedDataParallel):
-                m._reset_lazy_init()
-
-        with torch.no_grad():
-            after_checkpoint_loss = criterion(model(input), target).item()
-        assert before_checkpoint_loss == after_checkpoint_loss
-
-    def test_consolidation(self):
-        import torch.multiprocessing as mp
-        num_gpu = 2
-        embedding_size = 2048
-        with in_temporary_directory() as directory:
-            mp.spawn(self._worker, (num_gpu, embedding_size, directory), nprocs=num_gpu)
 
 
 class TransformerWithSharedParams(nn.Module):

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -120,7 +120,7 @@ class DistributedTest(unittest.TestCase):
         except (AssertionError, RuntimeError) as e:
             raise Exception(f"FullyShardedDataParallel didn't match PyTorch DDP using config: {config}\n\n {e}")
         if config.get("flatten_parameters", True):
-            metadata = model.shard_reconstruction_info()
+            metadata = model.local_metadata_dict()
             assert isinstance(metadata, dict)
 
 

--- a/tests/nn/data_parallel/test_fsdp_metadata.py
+++ b/tests/nn/data_parallel/test_fsdp_metadata.py
@@ -14,26 +14,48 @@ from fairscale.utils.testing import in_temporary_directory, skip_if_single_gpu, 
 class SimpleNestedModel(nn.Module):
     def __init__(self, embedding_size: int, with_fsdp: bool, process_group):
         super().__init__()
+        self.conv1 = self._conv_block(3, embedding_size)
+        self.conv2: nn.Module = self._conv_block(embedding_size, embedding_size // 2)
+        self.conv3: nn.Module = self._conv_block(embedding_size // 2, embedding_size)
+        self.pool = nn.AdaptiveAvgPool2d(output_size=(1, 1))
+        self.flatten = nn.Flatten(start_dim=1)
+        self.relu = nn.ReLU()
         self.fc1: nn.Module = nn.Linear(embedding_size, 2 * embedding_size)
         self.fc2: nn.Module = nn.Linear(2 * embedding_size, 2 * embedding_size)
         self.fc3: nn.Module = nn.Linear(2 * embedding_size, embedding_size + 1)
         self.fc4: nn.Module = nn.Linear(embedding_size + 1, embedding_size)
         if with_fsdp:
+            self.conv2 = FullyShardedDataParallel(self.conv2, process_group=process_group)
+            self.conv3 = FullyShardedDataParallel(self.conv3, process_group=process_group, flatten_parameters=False)
             self.fc1 = FullyShardedDataParallel(self.fc1, process_group=process_group)
             self.fc3 = FullyShardedDataParallel(self.fc3, process_group=process_group, flatten_parameters=False)
 
+    @staticmethod
+    def _conv_block(in_channels: int, out_channels: int):
+        return nn.Sequential(
+            nn.Conv2d(in_channels, out_channels, kernel_size=(3, 3)), nn.BatchNorm2d(out_channels), nn.ReLU(),
+        )
+
     def forward(self, x):
+        x = self.conv1(x)
+        x = self.conv2(x)
+        x = self.conv3(x)
+        x = self.pool(x)
+        x = self.flatten(x)
         x = self.fc1(x)
+        x = self.relu(x)
         x = self.fc2(x)
+        x = self.relu(x)
         x = self.fc3(x)
+        x = self.relu(x)
         x = self.fc4(x)
         return x
 
 
-def _create_model(embedding_size: int, with_fsdp: bool, process_group):
+def _create_model(embedding_size: int, with_fsdp: bool, process_group, flatten_parameters: bool = True):
     model = SimpleNestedModel(with_fsdp=with_fsdp, process_group=process_group, embedding_size=embedding_size).cuda()
     if with_fsdp:
-        return FullyShardedDataParallel(model, process_group=process_group)
+        return FullyShardedDataParallel(model, process_group=process_group, flatten_parameters=flatten_parameters)
     else:
         return model
 
@@ -51,9 +73,14 @@ def _worker(gpu_id: int, sync_file: str, world_size: int, embedding_size: int, f
     process_group = torch.distributed.new_group()
 
     # Create a dummy model with dummy inputs and targets
-    input = torch.randn(size=(16, embedding_size)).cuda()
+    input = torch.randn(size=(16, 3, 32, 32)).cuda()
     target = torch.zeros(size=(16, embedding_size)).cuda()
-    model = _create_model(with_fsdp=True, process_group=process_group, embedding_size=embedding_size)
+    model = _create_model(
+        with_fsdp=True,
+        process_group=process_group,
+        embedding_size=embedding_size,
+        flatten_parameters=flatten_parameters,
+    )
     criterion = nn.MSELoss()
     optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
 
@@ -89,7 +116,12 @@ def _worker(gpu_id: int, sync_file: str, world_size: int, embedding_size: int, f
         assert consolidated_checkpoint[k].shape == full_model_state_dict[k].shape
 
     # Verify that the checkpoint can be loaded by a FSDP model
-    loaded_model = _create_model(with_fsdp=True, process_group=process_group, embedding_size=embedding_size)
+    loaded_model = _create_model(
+        with_fsdp=True,
+        process_group=process_group,
+        embedding_size=embedding_size,
+        flatten_parameters=flatten_parameters,
+    )
     loaded_model.load_state_dict(consolidated_checkpoint)
     for m in loaded_model.modules():
         if isinstance(m, FullyShardedDataParallel):

--- a/tests/nn/data_parallel/test_fsdp_metadata.py
+++ b/tests/nn/data_parallel/test_fsdp_metadata.py
@@ -1,0 +1,109 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+import torch
+import torch.nn as nn
+
+from fairscale.nn import FullyShardedDataParallel
+from fairscale.utils.testing import in_temporary_directory, skip_if_single_gpu, temp_files_ctx
+
+
+class SimpleNestedModel(nn.Module):
+    def __init__(self, embedding_size: int, with_fsdp: bool, process_group):
+        super().__init__()
+        fc1 = nn.Linear(embedding_size, 2 * embedding_size)
+        fc2 = nn.Linear(2 * embedding_size, 2 * embedding_size)
+        fc3 = nn.Linear(2 * embedding_size, embedding_size + 1)
+        fc4 = nn.Linear(embedding_size + 1, embedding_size)
+        if with_fsdp:
+            self.fc1 = FullyShardedDataParallel(fc1, process_group=process_group)
+            self.fc2 = fc2  # To test different levels of nesting
+            self.fc3 = FullyShardedDataParallel(fc3, process_group=process_group)
+            self.fc4 = fc4
+        else:
+            self.fc1 = fc1
+            self.fc2 = fc2
+            self.fc3 = fc3
+            self.fc4 = fc4
+
+    def forward(self, x):
+        x = self.fc1(x)
+        x = self.fc2(x)
+        x = self.fc3(x)
+        x = self.fc4(x)
+        return x
+
+
+def _worker(gpu_id: int, sync_file: str, world_size: int, embedding_size: int):
+    torch.manual_seed(0)
+    torch.cuda.set_device(gpu_id)
+    torch.distributed.init_process_group(
+        backend="nccl", init_method=f"file://{sync_file}", world_size=world_size, rank=gpu_id,
+    )
+    process_group = torch.distributed.new_group()
+
+    # Create a dummy model with dummy inputs and targets
+    input = torch.randn(size=(16, embedding_size)).cuda()
+    target = torch.zeros(size=(16, embedding_size)).cuda()
+    model = SimpleNestedModel(with_fsdp=True, process_group=process_group, embedding_size=embedding_size).cuda()
+    model = FullyShardedDataParallel(model, process_group=process_group)
+    criterion = nn.MSELoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=1e-2)
+
+    # Train the model for a few epochs
+    for epoch in range(2):
+        out = model(input)
+        loss = criterion(out, target)
+        optimizer.zero_grad()
+        loss.backward()
+        optimizer.step()
+
+    # Save a bunch of checkpoint, one by shard
+    cp_data = {
+        "weights": {k: v.cpu() for k, v in model.local_state_dict().items()},
+        "meta": model.local_metadata_dict(),
+    }
+    torch.save(cp_data, f"checkpoint_{gpu_id}.torch")
+
+    # Wait for all files to be written on the disk
+    torch.distributed.barrier()
+
+    # Reconstruct a full checkpoint from the sharded checkpoints
+    all_checkpoints = [torch.load(f"checkpoint_{rank}.torch") for rank in range(world_size)]
+    consolidated_checkpoint = FullyShardedDataParallel.consolidate_shard_weights(
+        shard_weights=[c["weights"] for c in all_checkpoints], shard_metadata=[c["meta"] for c in all_checkpoints],
+    )
+
+    # Check that the reconstructed parameters are correct and of the right shape
+    full_model = SimpleNestedModel(with_fsdp=False, process_group=process_group, embedding_size=embedding_size)
+    full_model_state_dict = full_model.state_dict()
+    assert set(full_model_state_dict.keys()) == set(consolidated_checkpoint.keys())
+    for k in full_model_state_dict.keys():
+        assert consolidated_checkpoint[k].shape == full_model_state_dict[k].shape
+
+    # Verify that the checkpoint can be loaded by a FSDP model
+    loaded_model = SimpleNestedModel(with_fsdp=True, process_group=process_group, embedding_size=embedding_size).cuda()
+    loaded_model = FullyShardedDataParallel(loaded_model, process_group=process_group)
+    loaded_model.load_state_dict(consolidated_checkpoint)
+    for m in loaded_model.modules():
+        if isinstance(m, FullyShardedDataParallel):
+            m._reset_lazy_init()
+
+    # Verify that the model saved and the model loaded give the same results
+    with torch.no_grad():
+        before_checkpoint_loss = criterion(model(input), target).item()
+        after_checkpoint_loss = criterion(loaded_model(input), target).item()
+        assert before_checkpoint_loss == after_checkpoint_loss
+
+
+@skip_if_single_gpu
+@pytest.mark.parametrize("embedding_size", [128, 129])
+def test_consolidation(embedding_size: int):
+    import torch.multiprocessing as mp
+
+    world_size = 2
+    with in_temporary_directory():
+        with temp_files_ctx(num=1) as temp_files:
+            mp.spawn(_worker, (temp_files[0], world_size, embedding_size), nprocs=world_size)


### PR DESCRIPTION
## What does this PR do?

Completes the PR https://github.com/facebookresearch/fairscale/pull/682 of @sshleifer (*) with more meta-data to save in order to reconstruct the full weights from the sharded weights in an offline manner (without having to instantiate a FSDP model).

This PR also add an algorithm that implements the consolidation of the weights from sharded weights without having to instantiate a FSDP model nor allocate any GPU. It works for both `flatten_parameter=True` and `flatten_parameter=False`.

(*) I do not have the permissions on the repo, so I could not push on the original PR and had to create a new one.

CC: @sshleifer  @myleott @min-xu-ai 

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
