### PR TITLE
[fix] auto_wrap: support wrapping based on wrapper_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## NEXT - TBD
 ### Fixed
+- wrap: support wrapping based on `wrapper_config` [#685]
 - FSDP: fix extra process groups being created by default. Old behavior can cause excessive GPU memory usage. [#678]
 - FSDP: fix forward pass not overlapping compute and allgather [#671]
 - FSDP: improved frozen weight support [#657]

--- a/fairscale/nn/__init__.py
+++ b/fairscale/nn/__init__.py
@@ -10,6 +10,6 @@ from .data_parallel import FullyShardedDataParallel, ShardedDataParallel
 from .misc import FlattenParamsWrapper
 from .moe import MOELayer, Top2Gate
 from .pipe import Pipe, PipeRPCWrapper
-from .wrap import auto_wrap, default_auto_wrap_policy, enable_wrap, wrap
+from .wrap import auto_wrap, config_auto_wrap_policy, default_auto_wrap_policy, enable_wrap, wrap
 
 __all__: List[str] = []

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2054,8 +2054,6 @@ def auto_wrap_bn(
 
     # Wrap it.
     with (
-        enable_wrap(config_auto_wrap_policy, wrapper_cls=FullyShardedDataParallel)
-        if wrap_it
-        else contextlib.suppress()
+        enable_wrap(config_auto_wrap_policy, wrapper_cls=FullyShardedDataParallel) if wrap_it else contextlib.suppress()
     ):
         return auto_wrap(module)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -23,7 +23,7 @@ from torch.nn import Parameter
 import torch.nn.functional as F
 
 from fairscale.nn.misc import FlattenParamsWrapper
-from fairscale.nn.wrap import auto_wrap, default_auto_wrap_policy, enable_wrap
+from fairscale.nn.wrap import auto_wrap, config_auto_wrap_policy, enable_wrap
 from fairscale.utils.containers import apply_to_tensors
 from fairscale.utils.parallel import (
     chunk_and_pad,
@@ -2054,10 +2054,7 @@ def auto_wrap_bn(
 
     # Wrap it.
     with (
-        enable_wrap(
-            functools.partial(default_auto_wrap_policy, min_num_params=0, wrap_configured=True),
-            wrapper_cls=FullyShardedDataParallel,
-        )
+        enable_wrap(config_auto_wrap_policy, wrapper_cls=FullyShardedDataParallel)
         if wrap_it
         else contextlib.suppress()
     ):

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1886,7 +1886,10 @@ def auto_wrap_bn(
 
     # Wrap it.
     with (
-        enable_wrap(functools.partial(default_auto_wrap_policy, min_num_params=0), wrapper_cls=FullyShardedDataParallel)
+        enable_wrap(
+            functools.partial(default_auto_wrap_policy, min_num_params=0, wrap_configured=True),
+            wrapper_cls=FullyShardedDataParallel,
+        )
         if wrap_it
         else contextlib.suppress()
     ):

--- a/fairscale/nn/wrap/__init__.py
+++ b/fairscale/nn/wrap/__init__.py
@@ -5,6 +5,6 @@
 
 from typing import List
 
-from .auto_wrap import auto_wrap, default_auto_wrap_policy, enable_wrap, wrap
+from .auto_wrap import auto_wrap, config_auto_wrap_policy, default_auto_wrap_policy, enable_wrap, wrap
 
 __all__: List[str] = []

--- a/fairscale/nn/wrap/auto_wrap.py
+++ b/fairscale/nn/wrap/auto_wrap.py
@@ -17,7 +17,7 @@ def default_auto_wrap_policy(
     min_num_params: int = int(1e8),
     force_leaf_modules: Optional[Set[Type[nn.Module]]] = None,
     exclude_wrap_modules: Optional[Set[Type[nn.Module]]] = None,
-    wrap_configured: bool = True,
+    wrap_configured: bool = False,
 ) -> bool:
     """Default policy function for :func:`auto_wrap`.
 

--- a/stubs/torch/nn/modules/module.pyi
+++ b/stubs/torch/nn/modules/module.pyi
@@ -111,3 +111,6 @@ class Module(Generic[T_co]):
 
     # This is added torchgpipe
     training: bool
+
+    # Added by auto_wrap.py.
+    wrapper_config: dict

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
@@ -76,7 +76,6 @@ def _create_model(
     if with_sync_bn:
         model = nn.SyncBatchNorm.convert_sync_batchnorm(model)
         fsdp_config = {
-            "wrapper_cls": FSDP,
             "mixed_precision": False,
             "flatten_parameters": False,
             "reshard_after_forward": False,


### PR DESCRIPTION
- user can use this to avoid assert if auto_wrap is used multiple times on a module
- user can traverse the modules multiple times and assign a wrapper_config
  to the module and then use auto_wrap once to wrap them

fix #649
fix #585

## What does this PR do?
Fixes # (issue).

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
