### PR TITLE
[Draft for discussion] Provide shard views on the original parameters

### DIFF
--- a/tests/nn/data_parallel/test_fsdp_parameter_views.py
+++ b/tests/nn/data_parallel/test_fsdp_parameter_views.py
@@ -1,0 +1,117 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+import pytest
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+import torch.nn as nn
+import torch.optim as optim
+
+from fairscale.nn import FullyShardedDataParallel
+from fairscale.utils.testing import in_temporary_directory, skip_if_single_gpu, temp_files_ctx
+
+
+def _check_split_worker(gpu_id: int, sync_file: str, world_size: int, flatten_parameters: bool):
+    torch.manual_seed(0)
+    torch.cuda.set_device(gpu_id)
+    torch.distributed.init_process_group(
+        backend="nccl", init_method=f"file://{sync_file}", world_size=world_size, rank=gpu_id,
+    )
+
+    # Non recursive test
+    model = FullyShardedDataParallel(
+        nn.Sequential(nn.Linear(2, 1, bias=False), nn.Linear(1, 3, bias=False)),
+        flatten_parameters=flatten_parameters
+    )
+    named_parameters = [(name, p.shape) for name, p in model.named_shard_view_parameters()]
+    if flatten_parameters:
+        if gpu_id == 0:
+            assert named_parameters == [("0.weight", torch.Size([2])), ("1.weight", torch.Size([1]))]
+        if gpu_id == 1:
+            assert named_parameters == [("1.weight", torch.Size([2]))]
+    else:
+        if gpu_id == 0:
+            assert named_parameters == [("0.weight", torch.Size([1])), ("1.weight", torch.Size([2]))]
+        if gpu_id == 1:
+            assert named_parameters == [("0.weight", torch.Size([1])), ("1.weight", torch.Size([1]))]
+
+    # Wait before next next
+    dist.barrier()
+
+    # Recursive test
+    model = nn.Sequential(
+        FullyShardedDataParallel(
+            nn.Sequential(nn.Linear(1, 1, bias=False), nn.Linear(1, 1, bias=False)),
+            flatten_parameters=flatten_parameters
+        ),
+        nn.Linear(1, 3, bias=False),
+    )
+    model = FullyShardedDataParallel(model, flatten_parameters=flatten_parameters)
+    named_parameters = [(name, p.shape) for name, p in model.named_shard_view_parameters()]
+    if flatten_parameters:
+        if gpu_id == 0:
+            assert named_parameters == [("1.weight", torch.Size([2])), ("0.0.weight", torch.Size([1]))]
+        if gpu_id == 1:
+            assert named_parameters == [("1.weight", torch.Size([1])), ("0.1.weight", torch.Size([1]))]
+    else:
+        if gpu_id == 0:
+            assert named_parameters == [("1.weight", torch.Size([2])), ("0.0.weight", torch.Size([1])), ("0.1.weight", torch.Size([1]))]
+        if gpu_id == 1:
+            assert named_parameters == [("1.weight", torch.Size([1])), ("0.0.weight", torch.Size([0])), ("0.1.weight", torch.Size([0]))]
+
+
+@skip_if_single_gpu
+@pytest.mark.parametrize("flatten_parameters", [True, False])
+def test_named_parameters_splitting(flatten_parameters: bool):
+    world_size = 2
+    with in_temporary_directory():
+        with temp_files_ctx(num=1) as temp_files:
+            mp.spawn(_check_split_worker, (temp_files[0], world_size, flatten_parameters), nprocs=world_size)
+
+
+def _train_worker(gpu_id: int, sync_file: str, world_size: int, flatten_parameters: bool):
+    torch.manual_seed(0)
+    torch.cuda.set_device(gpu_id)
+    torch.distributed.init_process_group(
+        backend="nccl", init_method=f"file://{sync_file}", world_size=world_size, rank=gpu_id,
+    )
+
+    batch_size = 4
+    fake_inputs = torch.randn(size=(batch_size, 2)).cuda(gpu_id)
+    fake_targets = torch.zeros(size=(batch_size, 3)).cuda(gpu_id)
+    criterion = nn.MSELoss()
+
+    model = FullyShardedDataParallel(
+        nn.Sequential(nn.Linear(2, 1, bias=False), nn.Linear(1, 3, bias=False)),
+        flatten_parameters=flatten_parameters
+    )
+
+    # optimizer = optim.SGD(model.shard_view_parameters(), lr=1e-2)
+
+    num_epoch = 1
+    for epoch in range(num_epoch):
+        out = model(fake_inputs)
+        loss = criterion(out, fake_targets)
+        # optimizer.zero_grad()
+        loss.backward()
+        print(loss.item())
+        # optimizer.step()
+
+    for p in model.shard_view_parameters():
+        print("VIEW:", p)
+        print("VIEW GRAD:", p.grad)
+
+    for p in model.parameters():
+        print("PARAM:", p.data)
+        print("GRAD:", p.grad)
+
+
+@skip_if_single_gpu
+@pytest.mark.parametrize("flatten_parameters", [True, False])
+def test_named_parameters_based_training(flatten_parameters: bool):
+    world_size = 2
+    with in_temporary_directory():
+        with temp_files_ctx(num=1) as temp_files:
+            mp.spawn(_train_worker, (temp_files[0], world_size, flatten_parameters), nprocs=world_size)


### PR DESCRIPTION
## What does this PR do?

CC: @prigoyal @min-xu-ai @myleott 

Offer a solution to https://github.com/facebookresearch/fairscale/issues/644.

The PR provides a new function `named_shard_view_parameters` in `FullyShardedDataParallel` which:
- unbundles the `flat_params` for `flatten_parameters=True`
- removes the padding in the parameters for `flatten_parameters=False`

The goal is to have the ability to call `optim.SGD(model.named_shard_view_parameters(), ....)` in order to, for instance, apply some different norm-based adaptative learning rate (such as LARC) without having to:
- being forced to use `flatten_parameters=False`
- worry about the influence of padding even with `flatten_parameters=False`

## Remaining issues (to discuss)

### Views are no compatible with optimizers

Offering the view is not so hard, but the "views" are currently unusable for the optimiser: views are created by selecting a part of the `flat_param` and these operations are recorded by the autograd engine:
- the views are not leaves: this will trigger assertions in all optimizers
- because they are not leaves, their `grad` parameter is not kept: so optimisers cannot work with them

### Accessible views are not the same across GPUs

In addition to the issue above, there is an interesting side effect with `flatten_parameters=True`: based on how the sharding works, views will not be similar in all shards!

For instance, if the following model is ran on 2 GPUs:

```
a = nn.Linear(2, 1, bias=False)  # parameter size is 2
b = nn.Linear(1, 3, bias=False)  # parameter size is 3
model = FullyShardedDataParallel(
    nn.Sequential(a, b),
    flatten_parameters=True
)
```

In the above model, the parameters of "a" and "b" are fused into flat_param of size 5, then divided in 2 (size 3 and size 2):

- Shard at rank 0 will contain the full parameters for `a` (size 2) and the start of parameter `b` (size 1)
- Shard at rank 1 will contain the remaining of parameter `b` (remaining size 2)

And so if we call the method `named_shard_view_parameters`, the outputs will be:
- Rank 0: [("0.weight", torch.Size([2])), ("1.weight", torch.Size([1]))]
- Rank 1: [("1.weight", torch.Size([2]))]

This makes working with the view rather challenging !

## Potential solutions

To deal with the leaf issue, we would need to create a wrapper around the tensor that selects a subpart of it and forwards its call to the wrapped tensor (to get the `grad` and `is_leaf` for instance). This is doable.

But I think we need to discuss this issue all together (@prigoyal, @min-xu-ai, @myleott) because even if it works, I am not sure the feature is so easy to work with (cf my remarks above on each shard having different views)

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
