### PR TITLE
[perf] SyncBatchNorm: avoid 2nd set of all_reduce when wrapped by checkpoint_wrapper

### DIFF
--- a/fairscale/experimental/nn/sync_batchnorm.py
+++ b/fairscale/experimental/nn/sync_batchnorm.py
@@ -124,6 +124,11 @@ class SyncBatchNorm(torch.nn.BatchNorm2d):
         self.disable_patch_batchnorm = True
 
     def forward(self, input: Tensor) -> Tensor:  # type: ignore
+        # There are 3 modes this is being called:
+        # 1. not wrapped (and there is only a single phase)
+        # 2. wrapped and in checkpointing phase
+        # 3. wrapped and in recomputing phase
+
         if not dist.is_initialized() or not self.training:
             return super().forward(input)
 

--- a/fairscale/nn/checkpoint/__init__.py
+++ b/fairscale/nn/checkpoint/__init__.py
@@ -5,6 +5,6 @@
 
 from typing import List
 
-from .checkpoint_activations import checkpoint_wrapper
+from .checkpoint_activations import checkpoint_wrapper, is_checkpointing, is_recomputing
 
 __all__: List[str] = []

--- a/fairscale/nn/checkpoint/checkpoint_activations.py
+++ b/fairscale/nn/checkpoint/checkpoint_activations.py
@@ -5,6 +5,7 @@
 
 from contextlib import contextmanager
 import functools
+import threading
 from typing import Any, Dict, Generator, Optional, Tuple
 import weakref
 
@@ -16,6 +17,71 @@ import torch.utils.checkpoint as torch_checkpoint
 from fairscale.utils.containers import pack_kwargs, split_non_tensors, unpack_kwargs, unpack_non_tensors
 
 from .checkpoint_utils import dec_counter, inc_counter, init_counter, patch_batchnorm
+
+
+class ThreadLocal(threading.local):
+    def __init__(self) -> None:
+        self.is_checkpointing = False
+        self.is_recomputing = False
+
+
+thread_local = ThreadLocal()
+
+
+@contextmanager
+def enable_checkpointing() -> Generator[None, None, None]:
+    """Makes :func:`is_checkpointing` return :data:`True` within a context."""
+    orig = thread_local.is_checkpointing
+    thread_local.is_checkpointing = True
+    try:
+        yield
+    finally:
+        thread_local.is_checkpointing = orig
+
+
+@contextmanager
+def enable_recomputing() -> Generator[None, None, None]:
+    """Makes :func:`is_recomputing` return :data:`True` within a context."""
+    orig = thread_local.is_recomputing
+    thread_local.is_recomputing = True
+    try:
+        yield
+    finally:
+        thread_local.is_recomputing = orig
+
+
+def is_checkpointing() -> bool:
+    """Whether the current forward propagation is under checkpointing.
+
+    Returns:
+        bool: :data:`True` if it's under checkpointing.
+
+    """
+    return thread_local.is_checkpointing
+
+
+def is_recomputing() -> bool:
+    """Whether the current forward propagation is under checkpoint
+    recomputation. Use this to prevent duplicated side-effects at forward
+    propagation::
+
+        class Counter(nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.counter = 0
+
+            def forward(self, input):
+                if not is_recomputing():
+                    self.counter += 1
+                return input
+
+    Returns:
+        bool: :data:`True` if it's under checkpoint recomputation.
+
+    .. see also:: :ref:`Detecting Recomputation`
+
+    """
+    return thread_local.is_recomputing
 
 
 def checkpoint_wrapper(
@@ -174,7 +240,7 @@ class CheckpointFunction(torch.autograd.Function):
         ctx.save_for_backward(*tensor_inputs)
         ctx.packed_non_tensor_inputs = packed_non_tensor_inputs
 
-        with torch.no_grad():
+        with torch.no_grad(), enable_checkpointing():
             unpacked_args, unpacked_kwargs = unpack_kwargs(kwarg_keys, args)
             outputs = run_function(*unpacked_args, **unpacked_kwargs)
             the_module = unpacked_args[0]
@@ -207,7 +273,7 @@ class CheckpointFunction(torch.autograd.Function):
         # Set the states to what it used to be before the forward pass.
         set_rng_state(ctx.fwd_rng_state)
 
-        with torch.enable_grad(), autocast(ctx.had_autocast_in_fwd):
+        with torch.enable_grad(), enable_recomputing(), autocast(ctx.had_autocast_in_fwd):
             unpacked_args, unpacked_kwargs = unpack_kwargs(ctx.kwarg_keys, inputs)
             outputs = ctx.run_function(*unpacked_args, **unpacked_kwargs)
             tensor_outputs, _ = split_non_tensors(outputs)

--- a/fairscale/nn/checkpoint/checkpoint_activations.py
+++ b/fairscale/nn/checkpoint/checkpoint_activations.py
@@ -19,6 +19,8 @@ from fairscale.utils.containers import pack_kwargs, split_non_tensors, unpack_kw
 from .checkpoint_utils import dec_counter, inc_counter, init_counter, patch_batchnorm
 
 
+# https://docs.python.org/3/library/threading.html#thread-local-data
+# Manage the checkpoint context with thread-local data.
 class ThreadLocal(threading.local):
     def __init__(self) -> None:
         self.is_checkpointing = False
@@ -77,9 +79,6 @@ def is_recomputing() -> bool:
 
     Returns:
         bool: :data:`True` if it's under checkpoint recomputation.
-
-    .. see also:: :ref:`Detecting Recomputation`
-
     """
     return thread_local.is_recomputing
 

--- a/fairscale/nn/checkpoint/checkpoint_utils.py
+++ b/fairscale/nn/checkpoint/checkpoint_utils.py
@@ -42,7 +42,7 @@ def patch_batchnorm(module: nn.Module) -> List:
     hooks = []
     for name, child in module.named_modules():
         # _BatchNorm is base for bn1d, bn2d, bn3d and sync_bn, apex_sync_bn, etc.
-        if isinstance(child, _BatchNorm):
+        if isinstance(child, _BatchNorm) and not hasattr(child, "disable_patch_batchnorm"):
             # Register the pre/post hooks.
             pre_handle = child.register_forward_pre_hook(pre_forward)
             post_handle = child.register_forward_hook(post_forward)


### PR DESCRIPTION


This change also ensure that we calculate running_{mean,var} correctly
when wrapped.

## What does this PR do?
Fixes # (issue).

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
