### PR TITLE
[perf] SyncBatchNorm: fix torch version check when deciding whether t…

### DIFF
--- a/fairscale/experimental/nn/sync_batchnorm.py
+++ b/fairscale/experimental/nn/sync_batchnorm.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 from fairscale.nn.checkpoint import is_checkpointing, is_recomputing
+from fairscale.utils import torch_version
 
 
 def _forward(input: Tensor, affine: bool, mean: Tensor, invstd: Tensor, weight: Tensor, bias: Tensor) -> Tensor:
@@ -45,7 +46,7 @@ def _calculate_stats(input: Tensor, eps: float, process_group: ProcessGroup) -> 
     return mean, var, invstd, total_count
 
 
-if torch.__version__.split(".")[:2] >= ["1", "7"]:
+if torch_version() >= [1, 7]:
     _forward = torch.jit.script(_forward)  # type: ignore
     _track_running_stats = torch.jit.script(_track_running_stats)  # type: ignore
 

--- a/fairscale/utils/__init__.py
+++ b/fairscale/utils/__init__.py
@@ -5,4 +5,10 @@
 
 from typing import List
 
+import torch
+
 __all__: List[str] = []
+
+
+def torch_version() -> List[int]:
+    return [int(x) for x in torch.__version__.split(".")[:2]]


### PR DESCRIPTION
…o jit

Fixes issues where torch 1.10 (current HEAD) gets worse performance
than 1.8.1.

Before:

<class 'fairscale.experimental.nn.sync_batchnorm.SyncBatchNorm'>
Elapsed time is  0.46404361724853516
Elapsed time is  0.4587404727935791
Elapsed time is  0.44591188430786133
Elapsed time is  0.4754750728607178
Elapsed time is  0.47217249870300293
Elapsed time is  0.4853706359863281
Elapsed time is  0.4719529151916504
Elapsed time is  0.49368715286254883

After:

<class 'fairscale.experimental.nn.sync_batchnorm.SyncBatchNorm'>
Elapsed time is  0.4039032459259033
Elapsed time is  0.38921689987182617
Elapsed time is  0.4004709720611572
Elapsed time is  0.41199398040771484
Elapsed time is  0.41601991653442383
Elapsed time is  0.4001126289367676
Elapsed time is  0.4244246482849121
Elapsed time is  0.41317176818847656

## What does this PR do?
Fixes # (issue).

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
