### PR TITLE
Fix pytorch version check

### DIFF
--- a/fairscale/experimental/nn/distributed_pipeline/pipeline.py
+++ b/fairscale/experimental/nn/distributed_pipeline/pipeline.py
@@ -11,6 +11,7 @@ from torch import Tensor, nn
 from torch.distributed import rpc
 
 from fairscale.nn.pipe import microbatch
+from fairscale.utils import torch_version
 
 from .data import DataConsumer
 from .graph import Node, PipelineModulesGraph
@@ -20,7 +21,7 @@ Device = Union[torch.device, int, str]
 
 
 def check_pytorch_version() -> None:
-    if list(map(int, torch.__version__.split("+")[0].split(".")[:2])) < [1, 9]:
+    if torch_version() < (1, 9, 0):
         raise Exception("DistributedPipeline requires PyTorch version 1.9 or higher")
 
 

--- a/fairscale/experimental/nn/sync_batchnorm.py
+++ b/fairscale/experimental/nn/sync_batchnorm.py
@@ -11,6 +11,7 @@ import torch.distributed as dist
 from torch.distributed import ProcessGroup
 
 from fairscale.nn.checkpoint import is_checkpointing, is_recomputing
+from fairscale.utils import torch_version
 
 
 def _forward(input: Tensor, affine: bool, mean: Tensor, invstd: Tensor, weight: Tensor, bias: Tensor) -> Tensor:
@@ -45,7 +46,7 @@ def _calculate_stats(input: Tensor, eps: float, process_group: ProcessGroup) -> 
     return mean, var, invstd, total_count
 
 
-if torch.__version__.split(".")[:2] >= ["1", "7"]:
+if torch_version()[:2] >= (1, 7):
     _forward = torch.jit.script(_forward)  # type: ignore
     _track_running_stats = torch.jit.script(_track_running_stats)  # type: ignore
 

--- a/fairscale/nn/pipe/pipe.py
+++ b/fairscale/nn/pipe/pipe.py
@@ -27,6 +27,8 @@ from torch import Tensor, nn
 import torch.autograd
 import torch.cuda
 
+from fairscale.utils import torch_version
+
 from . import microbatch
 from .batchnorm import DeferredBatchNorm
 from .pipeline import Pipeline
@@ -256,7 +258,7 @@ class Pipe(Module):
     ) -> None:
         super().__init__()
 
-        if torch.__version__.split(".")[:2] >= ["1", "8"]:
+        if torch_version()[:2] >= (1, 8):
             warnings.warn(
                 "fairscale.nn.Pipe has been upstreamed to PyTorch as torch.distributed.pipeline.sync.Pipe. "
                 "It is now deprecated and will be removed in a future version of fairscale. "

--- a/fairscale/utils/__init__.py
+++ b/fairscale/utils/__init__.py
@@ -3,6 +3,4 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
-from typing import List
-
-__all__: List[str] = []
+from .version import *

--- a/fairscale/utils/testing.py
+++ b/fairscale/utils/testing.py
@@ -51,6 +51,7 @@ import torch.nn as nn
 
 from fairscale.nn.model_parallel import destroy_model_parallel, initialize_model_parallel
 from fairscale.nn.model_parallel.random import model_parallel_cuda_manual_seed
+from fairscale.utils import torch_version
 
 if TYPE_CHECKING:
     Base = nn.Module[Tensor]
@@ -103,23 +104,6 @@ def set_random_seed(seed: int) -> None:
     numpy.random.seed(seed)
     torch.manual_seed(seed)
     model_parallel_cuda_manual_seed(seed)
-
-
-def torch_version() -> Tuple[int, ...]:
-    numbering = torch.__version__.split("+")[0].split(".")[:3]
-
-    # Catch torch version if run against internal pre-releases, like `1.8.0a0fb`,
-    if not numbering[2].isnumeric():
-        # Two options here:
-        # - either skip this version (minor number check is not relevant)
-        # - or check that our codebase is not broken by this ongoing development.
-
-        # Assuming that we're interested in the second usecase more than the first,
-        # return the pre-release or dev numbering
-        logging.warning(f"Pytorch pre-release version {torch.__version__} - assuming intent to test it")
-        numbering[2] = "0"
-
-    return tuple(int(n) for n in numbering)
 
 
 # Global variable to cache the results from the first nvidia-smi execution.

--- a/fairscale/utils/version.py
+++ b/fairscale/utils/version.py
@@ -1,0 +1,29 @@
+# Copyright (c) Facebook, Inc. and its affiliates. All rights reserved.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import logging
+import re
+from typing import List, Tuple
+
+import torch
+
+__all__: List[str] = ["torch_version"]
+
+
+def torch_version(version: str = torch.__version__) -> Tuple[int, ...]:
+    numbering = re.search(r"^(\d+).(\d+).(\d+)([^\+]*)(\+\S*)?$", version)
+    if not numbering:
+        return tuple()
+    # Catch torch version if run against internal pre-releases, like `1.8.0a0fb`,
+    if numbering.group(4):
+        # Two options here:
+        # - either skip this version (minor number check is not relevant)
+        # - or check that our codebase is not broken by this ongoing development.
+
+        # Assuming that we're interested in the second use-case more than the first,
+        # return the pre-release or dev numbering
+        logging.warning(f"Pytorch pre-release version {version} - assuming intent to test it")
+
+    return tuple(int(numbering.group(n)) for n in range(1, 4))

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -7,6 +7,7 @@ tests/utils/test_reduce_scatter_bucketer.py
 tests/utils/test_containers.py
 tests/utils/test_parallel.py
 tests/utils/test_state_dict.py
+tests/utils/test_version.py
 tests/nn/checkpoint/test_checkpoint_activations.py
 tests/nn/checkpoint/test_checkpoint_activations_norm.py
 tests/nn/misc/test_grad_bucket.py

--- a/tests/experimental/nn/test_auto_shard.py
+++ b/tests/experimental/nn/test_auto_shard.py
@@ -14,7 +14,7 @@ import torch
 import torch.nn
 import torch.nn as nn
 
-from fairscale.utils.testing import torch_version
+from fairscale.utils import torch_version
 
 
 class PositionalEncoding(nn.Module):

--- a/tests/experimental/nn/test_multiprocess_pipe.py
+++ b/tests/experimental/nn/test_multiprocess_pipe.py
@@ -21,7 +21,7 @@ import torch.multiprocessing as mp
 import torch.nn as nn
 
 from fairscale.experimental.nn.distributed_pipeline import DistributedLoss, DistributedPipeline, PipelineModulesGraph
-from fairscale.utils.testing import torch_version
+from fairscale.utils import torch_version
 
 CPU_DEVICES = ["worker0/cpu", "worker1/cpu"]
 GPU_DEVICES = ["worker0/cuda:0", "worker1/cuda:1"]

--- a/tests/experimental/nn/test_offload.py
+++ b/tests/experimental/nn/test_offload.py
@@ -15,7 +15,8 @@ import pytest
 import torch
 
 from fairscale.experimental.nn.offload import OffloadModel
-from fairscale.utils.testing import skip_if_no_cuda, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import skip_if_no_cuda
 
 if torch_version() >= (1, 8, 0):
     from fairscale.experimental.nn.auto_shard import shard_model

--- a/tests/nn/checkpoint/test_checkpoint_activations.py
+++ b/tests/nn/checkpoint/test_checkpoint_activations.py
@@ -12,7 +12,8 @@ from torch.utils.checkpoint import checkpoint as torch_checkpoint_wrapper
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
 from fairscale.nn.misc import checkpoint_wrapper as deprecated_checkpoint_wrapper
-from fairscale.utils.testing import skip_if_no_cuda, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import skip_if_no_cuda
 
 
 def get_cuda_mem_allocated():

--- a/tests/nn/checkpoint/test_checkpoint_activations_norm.py
+++ b/tests/nn/checkpoint/test_checkpoint_activations_norm.py
@@ -15,7 +15,8 @@ from torch.nn import BatchNorm2d, LayerNorm, Linear, Sequential
 from torch.optim import SGD
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
-from fairscale.utils.testing import objects_are_equal, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import objects_are_equal
 
 NORM_TYPES = [LayerNorm, BatchNorm2d]
 MP_TYPES = ["fp32", "fp16", "call_half"]

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -19,6 +19,7 @@ import torch.distributed
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel, TrainingState
+from fairscale.utils import torch_version
 from fairscale.utils.testing import (
     DeviceAndTypeCheckModule,
     DummyProcessGroup,
@@ -26,7 +27,6 @@ from fairscale.utils.testing import (
     get_cycles_per_ms,
     objects_are_equal,
     spawn_for_all_world_sizes,
-    torch_version,
 )
 
 # How to use remote-pdb: https://gist.github.com/sshleifer/9d43351957179c13606e015b072927d4

--- a/tests/nn/data_parallel/test_fsdp_input.py
+++ b/tests/nn/data_parallel/test_fsdp_input.py
@@ -18,7 +18,8 @@ from torch.optim import SGD
 
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import TrainingState
-from fairscale.utils.testing import dist_init, rmf, skip_if_no_cuda, teardown, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, rmf, skip_if_no_cuda, teardown
 
 
 # A fixture to get tempfiles and ensure they are cleaned up.

--- a/tests/nn/data_parallel/test_fsdp_memory.py
+++ b/tests/nn/data_parallel/test_fsdp_memory.py
@@ -21,15 +21,9 @@ import torch.optim as optim
 from fairscale.nn import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import auto_wrap_bn
+from fairscale.utils import torch_version
 from fairscale.utils.parallel import get_process_group_cached
-from fairscale.utils.testing import (
-    dist_init,
-    dump_all_tensors,
-    skip_if_single_gpu,
-    teardown,
-    temp_files_ctx,
-    torch_version,
-)
+from fairscale.utils.testing import dist_init, dump_all_tensors, skip_if_single_gpu, teardown, temp_files_ctx
 
 
 def to_fsdp(module, fsdp_config):

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward.py
@@ -19,7 +19,8 @@ from torch.optim import SGD
 
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import TrainingState
-from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown
 
 
 def _test_func(rank, world_size, fsdp_config, tempfile_name, unused):

--- a/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_forward_checkpoint.py
@@ -24,7 +24,8 @@ from fairscale.nn import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import auto_wrap_bn
 from fairscale.nn.wrap import enable_wrap, wrap
-from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, temp_files_ctx, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, temp_files_ctx
 
 
 class Model(nn.Module):

--- a/tests/nn/data_parallel/test_fsdp_multiple_wrapping.py
+++ b/tests/nn/data_parallel/test_fsdp_multiple_wrapping.py
@@ -19,7 +19,8 @@ from torch.optim import SGD
 
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import TrainingState
-from fairscale.utils.testing import dist_init, skip_if_no_cuda, teardown, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, skip_if_no_cuda, teardown
 
 
 def _test_func(rank, world_size, fsdp_config, tempfile_name, unused):

--- a/tests/nn/data_parallel/test_fsdp_overlap.py
+++ b/tests/nn/data_parallel/test_fsdp_overlap.py
@@ -21,14 +21,8 @@ import torch.nn as nn
 
 from fairscale.nn import enable_wrap, wrap
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
-from fairscale.utils.testing import (
-    dist_init,
-    get_cycles_per_ms,
-    skip_if_single_gpu,
-    teardown,
-    temp_files_ctx,
-    torch_version,
-)
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, get_cycles_per_ms, skip_if_single_gpu, teardown, temp_files_ctx
 
 
 class Layer(nn.Module):

--- a/tests/nn/data_parallel/test_fsdp_regnet.py
+++ b/tests/nn/data_parallel/test_fsdp_regnet.py
@@ -36,6 +36,7 @@ from torch.optim import SGD
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel import TrainingState, auto_wrap_bn
 from fairscale.optim.grad_scaler import ShardedGradScaler
+from fairscale.utils import torch_version
 from fairscale.utils.testing import (
     dist_init,
     objects_are_equal,
@@ -44,7 +45,6 @@ from fairscale.utils.testing import (
     state_dict_norm,
     teardown,
     torch_cuda_version,
-    torch_version,
 )
 
 # Const test params.

--- a/tests/nn/data_parallel/test_fsdp_uneven.py
+++ b/tests/nn/data_parallel/test_fsdp_uneven.py
@@ -20,7 +20,8 @@ from torch.optim import SGD
 
 from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
 from fairscale.nn.data_parallel.fully_sharded_data_parallel import TrainingState
-from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown
 
 
 def _test_func(rank, world_size, model, fsdp_config, tempfile_name, unused, test_case):

--- a/tests/nn/data_parallel/test_fsdp_with_checkpoint_wrapper.py
+++ b/tests/nn/data_parallel/test_fsdp_with_checkpoint_wrapper.py
@@ -13,7 +13,8 @@ import torch.multiprocessing as mp
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel
-from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, temp_files_ctx, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import dist_init, skip_if_single_gpu, teardown, temp_files_ctx
 
 
 @skip_if_single_gpu

--- a/tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py
+++ b/tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py
@@ -22,13 +22,8 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 from fairscale.nn.data_parallel import ShardedDataParallel
 from fairscale.optim import OSS
 from fairscale.optim.grad_scaler import ShardedGradScaler
-from fairscale.utils.testing import (
-    check_same_model_params,
-    skip_if_no_cuda,
-    skip_if_single_gpu,
-    temp_files_ctx,
-    torch_version,
-)
+from fairscale.utils import torch_version
+from fairscale.utils.testing import check_same_model_params, skip_if_no_cuda, skip_if_single_gpu, temp_files_ctx
 
 """
 Check that ShardedDDP gets the same results as DDP in a variety of scenarii

--- a/tests/nn/moe/test_moe_layer.py
+++ b/tests/nn/moe/test_moe_layer.py
@@ -12,7 +12,7 @@ import torch.distributed as dist
 import torch.multiprocessing as mp
 
 from fairscale.nn import MOELayer, Top2Gate
-from fairscale.utils.testing import torch_version
+from fairscale.utils import torch_version
 
 pytestmark = pytest.mark.skipif(
     not (torch.cuda.is_available() and torch_version() >= (1, 8, 0)), reason="cuda and torch>=1.8.0 required"

--- a/tests/nn/pipe_process/test_pipe.py
+++ b/tests/nn/pipe_process/test_pipe.py
@@ -29,7 +29,8 @@ from torch import nn
 from fairscale.nn.model_parallel.initialize import get_pipeline_parallel_group
 from fairscale.nn.pipe import AsyncPipe
 from fairscale.nn.pipe.types import LazyModule
-from fairscale.utils.testing import get_worker_map, torch_spawn, torch_version
+from fairscale.utils import torch_version
+from fairscale.utils.testing import get_worker_map, torch_spawn
 
 
 @torch_spawn([2])

--- a/tests/nn/pipe_process/test_rpc.py
+++ b/tests/nn/pipe_process/test_rpc.py
@@ -8,6 +8,7 @@ from torch.distributed import rpc
 
 from fairscale.nn.model_parallel.initialize import get_pipeline_parallel_group
 from fairscale.nn.pipe import PipeRPCWrapper
+from fairscale.utils import torch_version
 from fairscale.utils.testing import get_worker_map, torch_spawn
 
 
@@ -242,7 +243,7 @@ def rpc_multiple_tensors():
 @pytest.mark.skipif("OMPI_COMM_WORLD_RANK" in os.environ, reason="no mpi")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="cuda required")
 # TODO(msb) Fix this
-@pytest.mark.skipif(torch.__version__.split("+")[0].split(".") >= ["1", "8", "0"], reason="disabled for torch 1.8.0")
+@pytest.mark.skipif(torch_version() >= (1, 8, 0), reason="disabled for torch 1.8.0")
 def construct_only_rank_zero():
     model = [nn.Linear(10, 10), nn.ReLU()]
     if torch.distributed.get_rank() == 0:

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -23,13 +23,13 @@ from torch.nn.parallel import DistributedDataParallel as DDP
 
 import fairscale.optim as optim
 import fairscale.utils as utils
+from fairscale.utils import torch_version
 from fairscale.utils.testing import (
     check_same_model_params,
     check_same_models_across_ranks,
     skip_if_no_cuda,
     skip_if_py39_no_cuda,
     skip_if_single_gpu,
-    torch_version,
 )
 
 BACKEND = dist.Backend.NCCL if torch.cuda.is_available() else dist.Backend.GLOO  # type: ignore

--- a/tests/utils/test_reduce_scatter_bucketer.py
+++ b/tests/utils/test_reduce_scatter_bucketer.py
@@ -12,6 +12,7 @@ from unittest import mock
 from parameterized import parameterized
 import torch
 
+from fairscale.utils import torch_version
 from fairscale.utils.reduce_scatter_bucketer import ReduceScatterBucketer
 from fairscale.utils.testing import dist_init, spawn_for_all_world_sizes
 
@@ -28,8 +29,7 @@ CONFIG_OPTIONS = [
 class TestReduceScatterBucketer(unittest.TestCase):
     # TODO(sshleifer): check if possible to reuse `DistributedTest, spawn_and_init`.
     def setUp(self):
-        major, minor = torch.__version__.split(".")[:2]
-        major, minor = int(major), int(minor)
+        major, minor, _ = torch_version()
         if major < 1 or (major == 1 and minor < 6):
             raise unittest.SkipTest("Need pytorch version >= 1.6 due to reduce_scatter")
         if not torch.cuda.is_available():

--- a/tests/utils/test_version.py
+++ b/tests/utils/test_version.py
@@ -1,0 +1,10 @@
+from fairscale.utils import torch_version
+
+
+def test_torch_version():
+    assert torch_version("") == tuple()
+    assert torch_version("bad format") == tuple()
+    assert torch_version("1.9.0") == (1, 9, 0)
+    assert torch_version("1.10.0a0+gitbc6fc3e") == (1, 10, 0)
+    assert torch_version("1.7.0+cu102") == (1, 7, 0)
+    assert torch_version("1.10.0a0+fb") == (1, 10, 0)


### PR DESCRIPTION
The purpose of this PR is to get rid of code like `torch.__version__.split("+")[0].split(".")[:2] < ["1", "9"]` which will produce wrong behavior when pytorch version reaches 2 digits numbers like "1.10.0".

1. `fairscale.utils.testing.torch_version` moved to `fairscale.utils.torch_version`
2. `torch_version` reimplemented with regex parsing