### PR TITLE
Make sure requires_grad of FlatParameter to be consistent with requires_grad of original parameters

### DIFF
--- a/benchmarks/datasets/wikitext2_data.py
+++ b/benchmarks/datasets/wikitext2_data.py
@@ -3,14 +3,21 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+from distutils.version import LooseVersion
 import io
+import operator
 import tempfile
 
 import torch
 from torch.utils.data import DataLoader
+import torchtext
 from torchtext.data.utils import get_tokenizer
 from torchtext.utils import download_from_url, extract_archive
-from torchtext.vocab import build_vocab_from_iterator
+
+if operator.ge(torchtext.__version__, LooseVersion("0.10.0")):
+    from torchtext.legacy.vocab import build_vocab_from_iterator
+else:
+    from torchtext.vocab import build_vocab_from_iterator
 
 
 def _batchify(data, batch_size):

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -184,7 +184,12 @@ class FlattenParamsWrapper(nn.Module):
         if not hasattr(self, "_param_infos"):
             assert flat_param is None
             params = self._init_flatten_params()
-            flat_param = FlatParameter(params)
+
+            assert (
+                len(set(p.requires_grad for p in params)) == 1
+            ), "expects all parameters in module to have same requires_grad"
+
+            flat_param = FlatParameter(params, params[0].requires_grad)
             self.param_numel = flat_param.numel()
 
         # flatten

--- a/tests/nn/data_parallel/test_fsdp_freezing_weights.py
+++ b/tests/nn/data_parallel/test_fsdp_freezing_weights.py
@@ -11,6 +11,7 @@
 
 
 from enum import Enum
+from itertools import product
 import tempfile
 
 import pytest
@@ -25,7 +26,7 @@ from fairscale.utils.testing import dist_init, objects_are_equal, rmf, skip_if_s
 
 
 class Model(nn.Module):
-    def __init__(self):
+    def __init__(self, with_fsdp, freeze_after_wrap_fsdp):
         super().__init__()
         self.trunk = nn.Sequential(
             nn.Conv2d(3, 64, kernel_size=3),
@@ -34,38 +35,41 @@ class Model(nn.Module):
             nn.Flatten(),
         )
         self.head = nn.Linear(64, 10)
-
-    def forward(self, x):
-        return self.head(self.trunk(x))
-
-
-class NestedTrunkModel(nn.Module):
-    def __init__(self, with_fsdp):
-        super().__init__()
-        self.trunk = nn.Sequential(self._create_block(3, 64, with_fsdp), self._create_block(64, 64, with_fsdp),)
-        self.head = nn.Sequential(nn.AdaptiveAvgPool2d(output_size=(1, 1)), nn.Flatten(), nn.Linear(64, 10),)
-        if with_fsdp:
+        if with_fsdp and freeze_after_wrap_fsdp:
             self.trunk = FSDP(self.trunk)
             self.head = FSDP(self.head)
 
     def forward(self, x):
         return self.head(self.trunk(x))
 
-    def _create_block(self, in_channels, out_channels, with_fsdp):
+
+class NestedTrunkModel(nn.Module):
+    def __init__(self, with_fsdp, freeze_after_wrap_fsdp):
+        super().__init__()
+        self.trunk = nn.Sequential(
+            self._create_block(3, 64, with_fsdp, freeze_after_wrap_fsdp),
+            self._create_block(64, 64, with_fsdp, freeze_after_wrap_fsdp),
+        )
+        self.head = nn.Sequential(nn.AdaptiveAvgPool2d(output_size=(1, 1)), nn.Flatten(), nn.Linear(64, 10),)
+        if with_fsdp and freeze_after_wrap_fsdp:
+            self.trunk = FSDP(self.trunk)
+            self.head = FSDP(self.head)
+
+    def forward(self, x):
+        return self.head(self.trunk(x))
+
+    def _create_block(self, in_channels, out_channels, with_fsdp, freeze_after_wrap_fsdp):
         block = nn.Sequential(nn.Conv2d(in_channels, out_channels, kernel_size=3), nn.ReLU(inplace=True),)
-        if with_fsdp:
+        if with_fsdp and freeze_after_wrap_fsdp:
             block = FSDP(block)
         return block
 
 
-def _create_model(with_fsdp, with_nested_trunk):
+def _create_model(with_fsdp, with_nested_trunk, freeze_after_wrap_fsdp):
     if with_nested_trunk:
-        model = NestedTrunkModel(with_fsdp)
+        model = NestedTrunkModel(with_fsdp, freeze_after_wrap_fsdp)
     else:
-        model = Model()
-        if with_fsdp:
-            model.trunk = FSDP(model.trunk)
-            model.head = FSDP(model.head)
+        model = Model(with_fsdp, freeze_after_wrap_fsdp)
     return model
 
 
@@ -80,6 +84,7 @@ def _distributed_worker(
     with_fsdp,
     with_nested_trunk,
     freezing_method,
+    freeze_after_wrap_fsdp,
     tempfile_name,
     unused,
     rank_0_output,
@@ -95,7 +100,7 @@ def _distributed_worker(
     torch.backends.cudnn.deterministic = True
     batch = torch.randn(size=(2, 3, 224, 224)).cuda()
 
-    model = _create_model(with_fsdp, with_nested_trunk)
+    model = _create_model(with_fsdp, with_nested_trunk, freeze_after_wrap_fsdp)
     model = model.cuda()
 
     # freezing the trunk using requires_grad.
@@ -104,6 +109,9 @@ def _distributed_worker(
             param.requires_grad = False
 
     if with_fsdp:
+        if not freeze_after_wrap_fsdp:
+            model.trunk = FSDP(model.trunk)
+            model.head = FSDP(model.head)
         model = FSDP(model)
     else:
         model = DistributedDataParallel(model, device_ids=[gpu_id])
@@ -142,7 +150,7 @@ def _distributed_worker(
 # A fixture to get tempfiles and ensure they are cleaned up.
 @pytest.fixture()
 def temp_files():
-    num = 9  # 1 DDP and 2 FSDP cases each needs 3 files.
+    num = 15  # 1 DDP and 4 FSDP cases each needs 3 files.
     files = [tempfile.mkstemp()[1] for _ in range(num)]
 
     yield tuple(files)
@@ -163,18 +171,20 @@ def test_freezing_weights(temp_files, nested_trunk):
     freezing_method = FreezingMethod.RequiresGrad
     mp.spawn(
         _distributed_worker,
-        (world_size, with_fsdp, with_nested_trunk, freezing_method) + temp_files[0:3] + (None,),
+        (world_size, with_fsdp, with_nested_trunk, freezing_method, True) + temp_files[0:3] + (None,),
         nprocs=world_size,
     )
     # FSDP, case 1 and 2.
     with_fsdp = True
     expected_state = torch.load(temp_files[2])
     temp_file_idx = 3
-    for freezing_method in [FreezingMethod.RequiresGrad, FreezingMethod.GradToNone]:
+    for freezing_method, freeze_after_wrap_fsdp in product(
+        [FreezingMethod.RequiresGrad, FreezingMethod.GradToNone], [True, False]
+    ):
         print(f"Testing FSDP with freezing method {freezing_method}")
         mp.spawn(
             _distributed_worker,
-            (world_size, with_fsdp, with_nested_trunk, freezing_method)
+            (world_size, with_fsdp, with_nested_trunk, freezing_method, freeze_after_wrap_fsdp)
             + temp_files[temp_file_idx : temp_file_idx + 3]
             + (expected_state,),
             nprocs=world_size,


### PR DESCRIPTION
While flatten original parameters to the FlatParameter, make sure requires_grad of original parameters are passed to FlatParameter. If requires_grad of original parameters are not consistent, assert errors.

