### PR TITLE
use ModuleLst for submodules

### DIFF
--- a/fairscale/experimental/nn/distributed_pipeline/graph.py
+++ b/fairscale/experimental/nn/distributed_pipeline/graph.py
@@ -20,7 +20,7 @@ class MultiInputSequential(nn.Module):
 
     def __init__(self, *modules: nn.Module) -> None:
         super().__init__()
-        self.modules_list = modules
+        self.modules_list = nn.ModuleList(modules)
 
     def forward(self, *inputs: Tuple[Tensor]) -> Tensor:  # type: ignore
         input = self.modules_list[0](*inputs)


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in MultiInputSequential where submodules parameters are not listed with parameters() method.