### PR TITLE
[fix] Add the latest numpy version to requirements.txt

### DIFF
--- a/fairscale/optim/adascale.py
+++ b/fairscale/optim/adascale.py
@@ -533,7 +533,7 @@ class AdaScale(Optimizer):
                 continue
             # must be a np array, extend it with the right value and check the shape.
             val = 1 if name == "grad_sqr_avg" else 0
-            self._state[name] = np.append(self._state[name], val)
+            self._state[name] = np.append(self._state[name], val)  # type: ignore
             assert self._state[name].shape == (len(self._optimizer.param_groups),)
 
     def zero_grad(self) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 # FairScale should only depends on torch, not things higher level than torch.
 torch >= 1.6.0
+numpy >= 1.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 # FairScale should only depends on torch, not things higher level than torch.
 torch >= 1.6.0
-numpy >= 1.21

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,7 +42,6 @@ exclude = build,*.pyi,.git
 [mypy]
 mypy_path = ./stubs/
 follow_imports = normal
-plugins = numpy.typing.mypy_plugin
 
 # This project must be strictly typed.
 [mypy-fairscale.*]

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ exclude = build,*.pyi,.git
 [mypy]
 mypy_path = ./stubs/
 follow_imports = normal
+plugins = numpy.typing.mypy_plugin
 
 # This project must be strictly typed.
 [mypy-fairscale.*]


### PR DESCRIPTION
## What does this PR do?
Certain PRs (looks like forks) are running into mypy errors due to a bumped up numpy version that is being pulled in. 
* Bumped up numpy to >=1.21 as a temporary fix. We ideally don't want to have any other dependency other than PyTorch.
* Since np.append is untyped to begin with I did not see any fix other than adding an ignore. Maybe I am missing something? 
* I am still debugging how we are pulling in numpy 1.21 for PRs that are opened outside of the fairscale repo. PRs within the repo are using numpy 1.20. I tried invalidating the cache but that did not make a difference. PRs on different forks don't share a cache with the repo  according to [circleci](https://circleci.com/docs/2.0/caching/#caching-and-open-source). Maybe we want to consider that in the future.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
