### PR TITLE
[fix]Remove numpy requirement for install and add it only for tests

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -19,3 +19,6 @@ parameterized >= 0.8.1
 
 # For torch.cuda.list_gpu_processes()
 pynvml == 8.0.4
+
+# For mypy typing
+numpy >= 1.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 # FairScale should only depends on torch, not things higher level than torch.
 torch >= 1.6.0
-numpy >= 1.21


### PR DESCRIPTION
## What does this PR do?
Adding a numpy requirement breaks fairseq as per this [comment](https://github.com/facebookresearch/fairscale/pull/731#issuecomment-869976994). Still debugging the RC for the numpy version change that users saw. 

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
