### PR TITLE
Fix shared params and MoE logic

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1576,7 +1576,7 @@ class FullyShardedDataParallel(nn.Module):
                     src_param_path = _clean_path(mpath_src + "." + src_name if mpath_src else src_name)
                     dst_param_path = _clean_path(mpath_dst + "." + dst_name if mpath_dst else dst_name)
                     shared_param_info.append((src_param_path, dst_param_path))
-                metadata["shared_param_info"] =  shared_param_info
+                metadata["shared_param_info"] = shared_param_info
 
                 for i, p in enumerate(m.params):
                     if i < m._num_flatten_params:
@@ -1654,7 +1654,8 @@ class FullyShardedDataParallel(nn.Module):
                         "padding_of_backing"
                     ]
                     shards.append(_unpad(shard, pad))
-                    if metadata["no_broadcast_optim_state"]: break
+                    if metadata["no_broadcast_optim_state"]:
+                        break
                 full_param = torch.cat(shards, dim=0)
                 # (Potentially), split the full param and create original params.
                 names, shapes, numels, _ = v.values()
@@ -1664,7 +1665,7 @@ class FullyShardedDataParallel(nn.Module):
                     consolidated_weights[out_state_dict_key] = t.view(s)
 
         # copy shared parameters
-        for src_path, dest_path in metadata['shared_param_info']:
+        for src_path, dest_path in metadata["shared_param_info"]:
             consolidated_weights[dest_path] = consolidated_weights[src_path]
 
         # Deal with the buffers, which are not parameters and are not sharded by FSDP

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -76,6 +76,7 @@ class FlatParameter(nn.Parameter):
         # These are set by FPW class below, not by this class itself.
         self._param_infos: List[Tuple[str, nn.Module, str]] = []
         self._shared_param_infos: List[Tuple[str, str, nn.Module, str, nn.Module, str]] = []
+
     def get_param_views(self, external_data: Optional[Tensor] = None) -> Iterator[Tensor]:
         """ Return a generator of views that map to the original parameters. """
         # Note, self.data could be sharded, so its numel is <= to the sum.
@@ -242,7 +243,9 @@ class FlattenParamsWrapper(nn.Module):
 
     def _init_flatten_params(
         self, p_set: Set[Tuple[nn.Module, str]]
-    ) -> Tuple[List[nn.Parameter], List[Tuple[str, nn.Module, str]], List[Tuple[nn.Module, str, nn.Module, str]]]:
+    ) -> Tuple[
+        List[nn.Parameter], List[Tuple[str, nn.Module, str]], List[Tuple[str, str, nn.Module, str, nn.Module, str]]
+    ]:
         """ Build metadata for need-to-be-flatten parameters and returns a list
             contains the need-to-be-flatten parameters.
 
@@ -255,7 +258,7 @@ class FlattenParamsWrapper(nn.Module):
                 to be flattened. There could be shared params in this set.
         """
         param_infos = []
-        shared_param_memo: Dict[nn.Parameter, Tuple[nn.Module, str]] = {}
+        shared_param_memo: Dict[nn.Parameter, Tuple[str, nn.Module, str]] = {}
         shared_param_infos = []
         params = []
         for module_name, m in self.named_modules():
@@ -280,7 +283,7 @@ class FlattenParamsWrapper(nn.Module):
         return chain(*[p._param_infos for p in self.flat_params])
 
     @property
-    def _shared_param_infos(self) -> Iterator[Tuple[nn.Module, str, nn.Module, str]]:
+    def _shared_param_infos(self) -> Iterator[Tuple[str, str, nn.Module, str, nn.Module, str]]:
         return chain(*[p._shared_param_infos for p in self.flat_params])
 
     def _flatten_params(self, flat_params: List[FlatParameter]) -> None:

--- a/tests/nn/data_parallel/test_fsdp_metadata.py
+++ b/tests/nn/data_parallel/test_fsdp_metadata.py
@@ -2,14 +2,23 @@
 #
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
+import functools
+import os
+import tempfile
+
+from parameterized import parameterized
 import pytest
 import torch
 import torch.distributed as dist
 import torch.multiprocessing as mp
 import torch.nn as nn
+from torch.optim import Adam
 
 from fairscale.nn import FullyShardedDataParallel
 from fairscale.utils.testing import in_temporary_directory, skip_if_single_gpu, temp_files_ctx
+from tests.nn.data_parallel.test_fsdp import DistributedTest, MixtureOfExperts, rename_test, spawn_and_init
+
+USE_TEMPFILE = True  # False for debugging
 
 
 class ConvolutionalModel(nn.Module):
@@ -145,3 +154,64 @@ def test_consolidation(embedding_size: int, flatten_parameters: bool):
     with in_temporary_directory():
         with temp_files_ctx(num=1) as temp_files:
             mp.spawn(_worker, (temp_files[0], world_size, embedding_size, flatten_parameters), nprocs=world_size)
+
+
+@skip_if_single_gpu
+class TestConsolidatedWeights(DistributedTest):
+    @parameterized.expand(
+        [[True], [False]], name_func=rename_test,
+    )
+    def test_consolidate_weights(self, transformer):
+        config = {"mixed_precision": True, "flatten_parameters": True, "compute_dtype": torch.float32}
+        world_size = min(torch.cuda.device_count(), 4)
+        if USE_TEMPFILE:
+            with tempfile.TemporaryDirectory() as d:
+                paths = [os.path.join(d, f"checkpoint_{rank}.pt") for rank in range(world_size)]
+                test_fn = functools.partial(
+                    self._test_consolidate_weights, config, transformer=transformer, paths=paths
+                )
+                spawn_and_init(test_fn, world_sizes=[world_size])
+        else:
+            paths = [f"checkpoint_{rank}.pt" for rank in range(world_size)]
+            test_fn = functools.partial(self._test_consolidate_weights, config, transformer=transformer, paths=paths)
+            spawn_and_init(test_fn, world_sizes=[world_size])
+
+    @classmethod
+    def _test_consolidate_weights(self, config, rank, group, paths=None, transformer=False):
+        """FSDP.gather_full_optim_state_dict() should return something very similar to optimizer.state_dict()"""
+        # Establish reference behavior.
+
+        if transformer:
+            fsdp = self.get_wrapped_model(group, config=config).cuda()
+        else:
+            fsdp = FullyShardedDataParallel(MixtureOfExperts(group, wrapper_config=config)).cuda()
+
+        optim = Adam(fsdp.parameters(), lr=0.01,)
+        optim.zero_grad()
+        with torch.cuda.amp.autocast(enabled=True):
+            x = fsdp.module.get_input(torch.device("cuda"))
+            output = fsdp(*x)
+            loss = fsdp.module.get_loss(x, output).to("cuda")
+            fsdp.module.run_backward(loss)
+            optim.step()
+
+        # each worker saves a checkpoint with local_state_dict
+        cp_data = {
+            "weights": {k: v.cpu() for k, v in fsdp.local_state_dict().items()},
+            "meta": fsdp.local_metadata_dict(),
+        }
+        torch.save(cp_data, paths[fsdp.rank])
+        full_model_state_dict = fsdp.state_dict()
+        torch.distributed.barrier()
+        if fsdp.rank > 0:
+            return
+        all_checkpoints = [torch.load(p) for p in paths]
+        consolidated_checkpoint = FullyShardedDataParallel.consolidate_shard_weights(
+            shard_weights=[c["weights"] for c in all_checkpoints], shard_metadata=[c["meta"] for c in all_checkpoints],
+        )
+        full_model_extra = set(full_model_state_dict).difference(set(consolidated_checkpoint))
+        consolidated_extra = set(consolidated_checkpoint).difference(set(full_model_state_dict))
+        msg = f"full model extra keys: {full_model_extra}, consolidated extra {consolidated_extra}"
+        for k in full_model_state_dict.keys():
+            assert consolidated_checkpoint[k].shape == full_model_state_dict[k].shape
+        assert set(full_model_state_dict.keys()) == set(consolidated_checkpoint.keys()), msg


### PR DESCRIPTION
### Previously

- reconstructed checkpoints would not have the shared parameter. This is different behavior. than `state_dict`.
- fsdp instances with `no_broadcast_optim_state` would still have weights concatenated from all shards. This is different behavior. than `state_dict`. 


### Now
- Behavior in aforementioned cases matches state_dict + test coverage
- we store a few more strings in `FPW._shared_param_info` so that we can easily copy shared parameters to the correct path. I'm fine for this logic to be moved to `FPW.shared_param_paths` or some such.
- 

[1/Aside] `no_broadcast_optim_state` is a bad name now, since we also don't want to broacast weights for these instances. IMO, the flag should be called `is_expert_group` since there is one use case: MoE.