### PR TITLE
[FSDP] Move final backward callback queueing to pre-backward hook of root instance

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1005,7 +1005,7 @@ class FullyShardedDataParallel(nn.Module):
         # If final backward callback is queued, the callback should be finished
         # and the state was reset to be IDLE.
         # This should be asserted at the beginning of forward pass in the root instance only.
-        # For children instances, if they are checkpointed, state will not be reset as
+        # For children instances, if they are checkpointed, state will not be reset to
         # IDLE after each inner forward/backward.
         self.assert_state(TrainingState.IDLE)
         # Check if the root instance is being checkpointed. It doesn't make sense to

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1005,8 +1005,11 @@ class FullyShardedDataParallel(nn.Module):
             return
         # No FullyShardedDataParallel instance wraps this, else _is_root would be set to False.
         self._is_root = True
-        # Do not allow to checkpoint root instance and run forward multiple times.
-        assert getattr(self, "_checkpoint_fwd_counter", 0) == 0
+        # Check if the root instance is being checkpointed. It doesn't make sense to
+        # checkpoint the root instance since it won't save GPU memory.
+        assert (
+            getattr(self, "_checkpoint_fwd_counter", 0) == 0
+        ), "Is the root FSDP module wrapping an activation checkpointed module? If so, please remove that."
         # As the root, we now set all children instances to False and
         # give them a closure to try to queue a wait_for_post_backward.
         self.children_share_process_group = True

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1130,7 +1130,7 @@ class FullyShardedDataParallel(nn.Module):
         there are trainable parameters inside of it or not.
         """
         assert self._is_root
-        return (any(p.requires_grad for p in m.parameters())
+        return (any(p.requires_grad for p in self.parameters())
                 and self._require_backward_grad_sync)
 
     def _register_pre_backward_hooks(self, outputs: Any) -> Any:

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1004,6 +1004,9 @@ class FullyShardedDataParallel(nn.Module):
         # If final backward callback is never been queued, state should be IDLE.
         # If final backward callback is queued, the callback should be finished
         # and the state was reset to be IDLE.
+        # This should be asserted at the beginning of forward pass in the root instance only.
+        # For children instances, if they are checkpointed, state will not be reset as
+        # IDLE after each inner forward/backward.
         self.assert_state(TrainingState.IDLE)
         # Check if the root instance is being checkpointed. It doesn't make sense to
         # checkpoint the root instance since it won't save GPU memory.

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1130,8 +1130,7 @@ class FullyShardedDataParallel(nn.Module):
         there are trainable parameters inside of it or not.
         """
         assert self._is_root
-        return (any(p.requires_grad for p in self.parameters())
-                and self._require_backward_grad_sync)
+        return any(p.requires_grad for p in self.parameters()) and self._require_backward_grad_sync
 
     def _register_pre_backward_hooks(self, outputs: Any) -> Any:
         """Register pre-backward hook to run before the wrapped module's
@@ -1152,7 +1151,7 @@ class FullyShardedDataParallel(nn.Module):
             assert self._post_backward_callback_fired
             # Reset flag if require final backwward callback to be fired,
             # this helps checking whether post backward callback was fired later on
-            if self._require_final_backward():
+            if self._require_final_backward:
                 self._post_backward_callback_fired = False
 
         def _pre_backward_hook(*unused: Any) -> None:

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1122,19 +1122,22 @@ class FullyShardedDataParallel(nn.Module):
 
         return outputs
 
-    def _checkpoint_module_last_backward_call(self):
+    def _checkpoint_module_last_backward_call(self) -> bool:
         # If this is a checkpointed FSDP module, e.g. checkpoint(FSDP(module)),
         # we check if the following counter reaches 0. If it is, it is the last
         # inner backward call for this FSDP module.
-        if (hasattr(self._fsdp_wrapped_module, "_checkpoint_fwd_counter")
-            and self._fsdp_wrapped_module._checkpoint_fwd_counter != 0):
+        if (
+            hasattr(self._fsdp_wrapped_module, "_checkpoint_fwd_counter")
+            and self._fsdp_wrapped_module._checkpoint_fwd_counter != 0
+        ):
             return False
         return True
 
-    def _require_final_backward(self):
+    def _require_final_backward(self) -> bool:
         assert self._is_root
         for m in self.modules():  # includes self
-            if (isinstance(m, FullyShardedDataParallel)
+            if (
+                isinstance(m, FullyShardedDataParallel)
                 and any(p.requires_grad for p in m.parameters())
                 and self._require_backward_grad_sync
             ):

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -591,12 +591,15 @@ class NestedWrappedModule(nn.Module):
         )
 
         # Wrap all modules triggers a corner case where root FSDP doesn't have any params.
+        # Test it with checkpoint_wrapper as well to validate final backward callback
+        # is queued correctly when root FSDP does not have any params and every layer is
+        # wrapped as FSDP(checkpoint(module)).
         if wrap_everything:
             self.module = nn.Sequential(
-                _maybe_wrap(nn.Linear(8, 4)),
-                _maybe_wrap(nn.Linear(4, 16)),
-                _maybe_wrap(nn.Linear(16, 4)),
-                _maybe_wrap(nn.Linear(4, 8)),
+                _maybe_wrap(checkpoint_wrapper(nn.Linear(8, 4))),
+                _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 16))),
+                _maybe_wrap(checkpoint_wrapper(nn.Linear(16, 4))),
+                _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 8))),
             )
 
     def get_input(self, device):

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -279,6 +279,12 @@ class TestComparisonToPyTorchDDP(DistributedTest):
         spawn_and_init(test_fn)
 
     @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
+    def test_nested_all_wrapped_model_checkpoint(self, config):
+        model_fn = functools.partial(NestedWrappedModule, wrap_everything=True, checkpoint=True)
+        test_fn = functools.partial(self._test_identical_outputs, model_fn, config)
+        spawn_and_init(test_fn)
+
+    @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
     def test_transformer_parameterized(self, config):
         # Test every combination of these options:
         spawn_and_init(functools.partial(self._test_identical_outputs, TransformerWithSharedParams, config))
@@ -571,7 +577,7 @@ class TransformerWithSharedParams(nn.Module):
 
 
 class NestedWrappedModule(nn.Module):
-    def __init__(self, group, wrapper_config, wrap_everything=False):
+    def __init__(self, group, wrapper_config, wrap_everything=False, checkpoint=False):
         super().__init__()
         self.rank = group.rank()
         self.world_size = group.size()
@@ -595,12 +601,20 @@ class NestedWrappedModule(nn.Module):
         # is queued correctly when root FSDP does not have any params and every layer is
         # wrapped as FSDP(checkpoint(module)).
         if wrap_everything:
-            self.module = nn.Sequential(
-                _maybe_wrap(checkpoint_wrapper(nn.Linear(8, 4))),
-                _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 16))),
-                _maybe_wrap(checkpoint_wrapper(nn.Linear(16, 4))),
-                _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 8))),
-            )
+            if checkpoint:
+                self.module = nn.Sequential(
+                    _maybe_wrap(checkpoint_wrapper(nn.Linear(8, 4))),
+                    _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 16))),
+                    _maybe_wrap(checkpoint_wrapper(nn.Linear(16, 4))),
+                    _maybe_wrap(checkpoint_wrapper(nn.Linear(4, 8))),
+                )
+            else:
+                self.module = nn.Sequential(
+                    _maybe_wrap(nn.Linear(8, 4)),
+                    _maybe_wrap(nn.Linear(4, 16)),
+                    _maybe_wrap(nn.Linear(16, 4)),
+                    _maybe_wrap(nn.Linear(4, 8)),
+                )
 
     def get_input(self, device):
         torch.manual_seed(1 + self.rank)  # keep everything deterministic


### PR DESCRIPTION
### Summary:

- Move final backward callback queueing to pre-backward hook of root FSDP instance,
so that it is always attached to the outer most backward call of all the modules and fired
after all inner/re-entrant backward calls are completed.

- Added flags to check final backward callback is fired when final
backward callback is required.

- If root FSDP is checkpointed and called multiple times in forward,
checkpointer counter is used to make sure final backward callback is queued 
inside the last inner backward call as well.

### Test Plan:
 unit tests, without this diff, for modified test case `test_nested_all_wrapped_model`, it will fail with following errors as final backward callback is attached to the inner backward call of checkpointed module

```python
dist init r=0, world=1
Asserting FSDP instance is: FullyShardedDataParallel(
  world_size=1, flatten_parameters=True, mixed_precision=True, 
  (_fsdp_wrapped_module): FlattenParamsWrapper(
    (_fpw_module): Linear(in_features=8, out_features=4, bias=True)
  )
)
ERROR: expected to be in states [<TrainingState.BACKWARD_POST: 4>] but current state is TrainingState.IDLE
--------------------------------------------------------- Captured stderr call ----------------------------------------------------------
/home/yanlizhao/venv2/lib/python3.8/site-packages/torch/utils/checkpoint.py:25: UserWarning: None of the inputs have requires_grad=True. Gradients will be None
  warnings.warn("None of the inputs have requires_grad=True. Gradients will be None")
  File "/home/yanlizhao/venv2/lib/python3.8/site-packages/torch/autograd/function.py", line 87, in apply
    return self._forward_cls.backward(self, *args)  # type: ignore[attr-defined]
  File "/home/yanlizhao/fairscale/fairscale/nn/checkpoint/checkpoint_activations.py", line 311, in backward
    torch.autograd.backward(outputs_with_grad, args_with_grad)
  File "/home/yanlizhao/venv2/lib/python3.8/site-packages/torch/autograd/__init__.py", line 147, in backward
    Variable._execution_engine.run_backward(
  File "/home/yanlizhao/venv2/lib/python3.8/site-packages/torch/autograd/grad_mode.py", line 28, in decorate_context
    return func(*args, **kwargs)
  File "/home/yanlizhao/fairscale/fairscale/nn/data_parallel/fully_sharded_data_parallel.py", line 1408, in _wait_for_post_backward
    m.assert_state(TrainingState.BACKWARD_POST)
  File "/home/yanlizhao/fairscale/fairscale/nn/data_parallel/fully_sharded_data_parallel.py", line 1739, in assert_state
    traceback.print_stack()
```