### PR TITLE
Adding missing imports in docstring

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -111,7 +111,7 @@ class FullyShardedDataParallel(nn.Module):
     across the forward pass. For example::
 
         import torch
-        from fairscale.nn.auto_wrap import enable_wrap, auto_wrap
+        from fairscale.nn.auto_wrap import enable_wrap, auto_wrap, wrap
         from fairscale.nn.data_parallel import FullyShardedDataParallel as FSDP
         fsdp_params = dict(wrapper_cls=FSDP, mixed_precision=True, flatten_parameters=True)
         with enable_wrap(**fsdp_params):


### PR DESCRIPTION
`wrap` from `auto_wrap` is used in the docstring example, but was missed in the imports.

```python
self.l1 = wrap(torch.nn.Linear(5, 5))
```
