### PR TITLE
[fix] [FSDP] making sure we use full params for multiple backwards within an iteration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,10 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
         be set in the post backward hook. Modified the assert to account for the fact that the root
         FSDP module can have child modules with params that require grad and it can contain params
         that don't require grad and hence can fail the previous assert. [#761]
+- FSDP: Fixed a bug when multiple backward pass is called within an iteration, parameters' sharding
+        state might be incorrect. [#775]
 
 ### Added
 - FSDP: Added support for returning the original names of parameters when `named_parameters` is called on
-        the module. To retrieve the orginal names of the parameters along with the params, you need to 
+        the module. To retrieve the orginal names of the parameters along with the params, you need to
         call `named_parameters` under the `summon_full_params` context when using flattened params or original
         params. If you are using original params (i.e flatten_params=False), calling `named_parameters` outside
         of the `summon_full_params` context will still return the original param names along with the local shards. [#755]


### PR DESCRIPTION
This is a bug exposed by work of #744, by pytorch 1.10 nightly.

@zhaojuanmao, you may want to pick up this fix in your branch. It happens regardless of flatten or not. It is triggered by model that does checkpointing and multiple fwd passes.

## What does this PR do?
See comments in the code for more details.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
  - Debugging wasn't too fun since it is a lot of prints. It took hours. Wishing there is a better way.
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
