### PR TITLE
[fix] FSDP intra-backwards gradient accumulation.

### DIFF
--- a/fairscale/nn/checkpoint/checkpoint_utils.py
+++ b/fairscale/nn/checkpoint/checkpoint_utils.py
@@ -48,28 +48,3 @@ def patch_batchnorm(module: nn.Module) -> List:
             post_handle = child.register_forward_hook(post_forward)
             hooks += [pre_handle, post_handle]
     return hooks
-
-
-def init_counter(module: nn.Module) -> None:
-    """Add a checkpoint forward pass counter to a module and all its child FSDP modules.
-
-       ``inc_counter`` and ``dec_counter`` are used together with this to maintain counters
-       for FSDP to use in case of multiple forward pass and checkpoint being used at the same time.
-    """
-    for mod in module.modules():
-        mod._checkpoint_fwd_counter = 0
-
-
-def _add_counter(module: nn.Module, value: int) -> None:
-    if not hasattr(module, "_checkpoint_fwd_counter"):
-        return
-    for mod in module.modules():
-        mod._checkpoint_fwd_counter += value
-
-
-def inc_counter(module: nn.Module) -> None:
-    _add_counter(module, 1)
-
-
-def dec_counter(module: nn.Module) -> None:
-    _add_counter(module, -1)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1213,6 +1213,7 @@ class FullyShardedDataParallel(nn.Module):
             # extra forward pass for re-computation.
             if self.training_state == TrainingState.IDLE:
                 self.training_state = TrainingState.BACKWARD_PRE
+            self.assert_state([TrainingState.BACKWARD_PRE, TrainingState.BACKWARD_POST])
 
         def _register_hook(t: torch.Tensor) -> torch.Tensor:
             if t.requires_grad:

--- a/stubs/torch/nn/modules/module.pyi
+++ b/stubs/torch/nn/modules/module.pyi
@@ -106,9 +106,6 @@ class Module(Generic[T_co]):
 
     def extra_repr(self) -> str: ...
 
-    # This is added by checkpoint_wrapper
-    _checkpoint_fwd_counter: int
-
     # This is added torchgpipe
     training: bool
 

--- a/tests/experimental/nn/test_sync_batchnorm.py
+++ b/tests/experimental/nn/test_sync_batchnorm.py
@@ -106,7 +106,7 @@ def parity3d_checkpoint_syncbn():
     x = torch.randn(4, 3, 4, 4, 4).cuda() * rank
     torch_bn = torch.nn.SyncBatchNorm(3).cuda()
     fs_bn = SyncBatchNorm(3).cuda()
-    fs_bn = checkpoint_wrapper(fs_bn, maintain_forward_counter=True)
+    fs_bn = checkpoint_wrapper(fs_bn)
     check_parity_ddp(torch_bn, fs_bn, x)
 
 


### PR DESCRIPTION
Ensure gradient reduction accumulates into the unsharded gradient tensor
within a backwards pass. This matters when an FSDP module is called
multiple times within a forward pass, and reduction is _not_ deferred
using activation checkpoint forward counters, bucketing or some other
mechanism.

## What does this PR do?
Fixes #780.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
