### PR TITLE
[OSS] Capture default device when refreshing the params

### DIFF
--- a/fairscale/optim/oss.py
+++ b/fairscale/optim/oss.py
@@ -462,10 +462,12 @@ class OSS(Optimizer):
         of some parameters changed.
         """
 
+        # Make sure that we capture the current default device
+        self._default_device = list(self._per_device_params.keys())[0]
+
         # Create the optim which will work on the param shard
         if not hasattr(self, "optim"):
             self._clear_cache()
-            self._default_device = list(self._per_device_params.keys())[0]
             self.optim = self._optim_constructor(self.partition_parameters()[self.rank], **self._optim_defaults)
             OSS._sync_param_groups(self.optim.param_groups, self.param_groups)
 

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -151,6 +151,9 @@ class TestSingleRank(unittest.TestCase):
         # Check that OSS detects that the device changed
         o.step()
 
+        # Check that the default device has been updated
+        assert o._default_device.type == DEVICE
+
     def test_step_with_extra_inner_key(self):
         class SGDWithNewKey(torch.optim.SGD):
             # Dummy optimizer which adds a new key to the param groups


### PR DESCRIPTION
## What does this PR do?
Fixes #781, which would happen if the users wrap the optimizer before the model is moved to GPU.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
