### PR TITLE
[feat] set requires_grad of output tensors of checkpointed modules properly

### DIFF
--- a/tests/nn/checkpoint/test_checkpoint_activations.py
+++ b/tests/nn/checkpoint/test_checkpoint_activations.py
@@ -11,6 +11,7 @@ import torch.nn as nn
 from torch.utils.checkpoint import checkpoint as torch_checkpoint_wrapper
 
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper, disable_checkpointing
+from fairscale.nn.misc import FlattenParamsWrapper
 from fairscale.nn.misc import checkpoint_wrapper as deprecated_checkpoint_wrapper
 from fairscale.utils import torch_version
 from fairscale.utils.testing import skip_if_no_cuda
@@ -272,7 +273,7 @@ def test_deprecated_path():
 
 @skip_if_no_cuda
 def test_list_input():
-    """ Test checkpointing with input argument type being a list.
+    """Test checkpointing with input argument type being a list.
 
     Note: Testing shows that PyTorch's torch.utils.checkpoint function does not pass this test.
     """
@@ -306,7 +307,7 @@ def test_list_input():
 
 
 def test_checkpoint_disabling():
-    """ Test to check new disable_checkpoint() API added to checkpoint_wrapper."""
+    """Test to check new disable_checkpoint() API added to checkpoint_wrapper."""
 
     class TestModel(nn.Module):
         def __init__(self):
@@ -339,3 +340,121 @@ def test_checkpoint_disabling():
         # Backward. cnt remains same as checkpointing is disabled
         y.backward()
     assert model2.cnt == 1
+
+
+def test_checkpoint_requires_grad():
+    """Test to check checkpointing when outputs do not require gradient."""
+
+    class TestModel(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cnt = 0
+            self.linear = nn.Linear(2, 2)
+
+        def forward(self, x):
+            self.cnt += 1
+            return self.linear(x)
+
+    x = torch.rand(4, 2)
+    model = nn.Sequential(
+        checkpoint_wrapper(TestModel()),
+        checkpoint_wrapper(TestModel()),
+        checkpoint_wrapper(TestModel()),
+        checkpoint_wrapper(TestModel()),
+    )
+    model[0].requires_grad_(False)
+    model[1].requires_grad_(False)
+    model[2].requires_grad_(False)
+
+    y = model(x)
+    y = y.sum()
+    y.backward()
+
+    # Since only last model needs grad, we only run forward twice for it
+    assert model[0].cnt == 1
+    assert model[1].cnt == 1
+    assert model[2].cnt == 1
+    assert model[3].cnt == 2
+
+    # Now test with first model needing grad
+    model = nn.Sequential(
+        checkpoint_wrapper(TestModel()),
+        checkpoint_wrapper(TestModel()),
+        checkpoint_wrapper(TestModel()),
+        checkpoint_wrapper(TestModel()),
+    )
+    model[0].requires_grad_(True)
+    model[1].requires_grad_(False)
+    model[2].requires_grad_(False)
+
+    y = model(x)
+    y = y.sum()
+    y.backward()
+
+    # Since first model needs grad, all models need grad, so we run forward twice for all
+    assert model[0].cnt == 2
+    assert model[1].cnt == 2
+    assert model[2].cnt == 2
+    assert model[3].cnt == 2
+
+    # Stress test with multiple inputs/outputs, of which some are not Tensor
+    class TestModel2(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cnt = 0
+            self.linear = nn.Linear(2, 2)
+
+        def forward(self, x, y, z):
+            self.cnt += 1
+            z = z + [self.cnt]
+            return self.linear(x + y), z, ["hi"]
+
+    model1 = checkpoint_wrapper(TestModel())
+    model2 = checkpoint_wrapper(TestModel())
+    model3 = checkpoint_wrapper(TestModel2())
+    model4 = checkpoint_wrapper(TestModel())
+    model1.requires_grad_(False)
+    model2.requires_grad_(False)
+
+    y = model4(model3(model1(x), model2(x), ["bye"])[0])
+    y = y.sum()
+    y.backward()
+
+    assert model1.cnt == 1
+    assert model2.cnt == 1
+    assert model3.cnt == 2
+    assert model4.cnt == 2
+
+    model1 = checkpoint_wrapper(TestModel())
+    model2 = checkpoint_wrapper(TestModel())
+    model3 = checkpoint_wrapper(TestModel2())
+    model4 = checkpoint_wrapper(TestModel())
+    model2.requires_grad_(False)
+
+    y = model4(model3(model1(x), model2(x), ["bye"])[0])
+    y = y.sum()
+    y.backward()
+
+    assert model1.cnt == 2
+    assert model2.cnt == 1
+    assert model3.cnt == 2
+    assert model4.cnt == 2
+
+    # Test flattened pararameters
+    model = nn.Sequential(
+        FlattenParamsWrapper(checkpoint_wrapper(TestModel())),
+        FlattenParamsWrapper(checkpoint_wrapper(TestModel())),
+        FlattenParamsWrapper(checkpoint_wrapper(TestModel())),
+        FlattenParamsWrapper(checkpoint_wrapper(TestModel())),
+    )
+    model[0].requires_grad_(False)
+    model[1].requires_grad_(False)
+
+    y = model(x)
+    y = y.sum()
+    y.backward()
+
+    assert model[0].cnt == 1
+    assert model[1].cnt == 1
+    assert model[2].cnt == 2
+    assert model[3].cnt == 2


### PR DESCRIPTION
Before this commit, output tensors of checkpointed modules always
require grad, even if they shouldn't. This commit makes it so that
the outputs of checkpointed modules only require grad if either
the input requires grad or if the parameters require grad.
To achieve this, this commit also adds a new _unflattened_param_views
attribute to modules being flattened. This allows the checkpointing
to still access the parameters and check if gradients need to be
computed.

## What does this PR do?

This enables users to use the checkpoint wrapper on modules even if no outputs require gradients. Previously, the blocker was that the backward pass will still trigger even if the module does not need gradients, causing an assertion to fail. This is because currently the checkpoint wrapper makes the output always require gradients, so autograd will always call backward, even if the outputs don't actually need gradients.

To fix this, this PR adds a feature to compute if outputs need gradients in the forward pass by checking if the module's parameters need gradients OR if the inputs need gradients. If the output does not need gradient, then it is detached to not need gradients. 

To achieve this, this PR also adds a new feature in FlattenParamsWrapper to keep track of the param views into the flattened params. This is so the checkpointing can still check if the module's parameters need gradients even when deleted by FlattenParamsWrapper.

*Testing*

Added a new unit test to test that backward pass is not triggered for modules not needing gradients (by counting number of times forward pass ran). 


## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
