### PR TITLE
[docs][fix] Update example to use offload_model

### DIFF
--- a/docs/source/tutorials/offload_model.rst
+++ b/docs/source/tutorials/offload_model.rst
@@ -75,7 +75,7 @@ of slices that the model should be sharded into. By default activation checkpoin
         optimizer.zero_grad()
         inputs = batch_inputs.reshape(-1, num_inputs * num_inputs)
         with torch.cuda.amp.autocast():
-            output = model(inputs)
+            output = offload_model(inputs)
             loss = criterion(output, target=batch_outputs)
             loss.backward()
         optimizer.step()


### PR DESCRIPTION
## What does this PR do?
We are using model(inputs) instead of offload_model(inputs) which is incorrect.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/master/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/master/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
