### PR TITLE
[fix] Update golden data for account for the speed regression

### DIFF
--- a/benchmarks/golden_configs/oss_mnist.py
+++ b/benchmarks/golden_configs/oss_mnist.py
@@ -7,7 +7,7 @@
 def get_golden_real_stats():
 
     return {
-        "reference_speed": 660,
+        "reference_speed": 578,
         "reference_memory": 945,
         "reference_loss": 0.026,
     }


### PR DESCRIPTION
## What does this PR do?
I updated the golden data for OSS to account for the speed regression seen due to the bumped up PyTorch version to 1.9.

This PR is needed to fix FairScale's **main** branch.

Opened an [issue](https://github.com/facebookresearch/fairscale/issues/824) to track this.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
