### PR TITLE
[feature] Add the low level SSD APIs

### DIFF
--- a/fairscale/experimental/nn/ssd_offload.py
+++ b/fairscale/experimental/nn/ssd_offload.py
@@ -143,8 +143,8 @@ class SsdTensorHandle(torch.Tensor):
         self.tensor = tensor
 
     def to_tensor(self) -> torch.Tensor:
-        """Returns the tensor represented by the SsdTensorHandle object. 
-        
+        """Returns the tensor represented by the SsdTensorHandle object.
+
         If the tensor is on disk, it is copied into the tensor attribute and returned.
         """
         if self.tensor is not None:
@@ -184,7 +184,7 @@ class SsdTensorHandle(torch.Tensor):
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore
         """Intercepts all operations performed on this handle object. 
-        
+
         Before any operation, the tensor attribute is unwrapped from the handle 
         and used in the operation. We maintain a refernce to the tensor and its current 
         versions to track if modifications have been made. If we detect changes to the 

--- a/fairscale/experimental/nn/ssd_offload.py
+++ b/fairscale/experimental/nn/ssd_offload.py
@@ -8,8 +8,7 @@ from __future__ import annotations
 from functools import reduce
 import io
 import os
-import pickle
-from typing import IO, Any, BinaryIO, Callable, Dict, Iterator, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple
 
 import numpy as np
 import torch

--- a/tests/ci_test_list_2.txt
+++ b/tests/ci_test_list_2.txt
@@ -47,3 +47,4 @@ tests/experimental/nn/test_offload.py
 tests/experimental/nn/test_auto_shard.py
 tests/experimental/optim/test_dynamic_loss_scaler.py
 tests/experimental/tooling/test_layer_memory_tracker.py
+tests/experimental/nn/test_ssd_offload.py

--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -7,8 +7,6 @@
 Testing SsdBuffer and SsdTensorHandle modules.
 """
 
-import filecmp
-import os
 import tempfile
 
 import numpy as np

--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -1,0 +1,170 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+"""
+Testing SsdBuffer and SsdTensorHandle modules.
+"""
+
+import filecmp
+import os
+import tempfile
+
+import numpy as np
+import pytest
+import torch
+
+import fairscale.experimental.nn.ssd_offload as so
+from fairscale.utils import torch_version
+
+# Note: We need the nightly version for SSD offload to work. Hence I am checking for the next PyTorch release.
+pytestmark = pytest.mark.skipif(torch_version() < (1, 11, 0), reason="requires torch version >= 1.11.0")
+
+
+def _init():
+    torch.manual_seed(0)
+    np.random.seed(0)
+
+
+def test_write_read():
+    _init()
+
+    with tempfile.NamedTemporaryFile() as f:
+        ref_tensor = torch.rand((128), dtype=torch.float32)
+        test_tensor = torch.zeros_like(ref_tensor)
+        assert not torch.equal(ref_tensor, test_tensor)
+        so.write(ref_tensor, f.name)
+        so.read(test_tensor, f.name)
+        assert torch.equal(ref_tensor, test_tensor)
+
+
+def test_ssd_handle_dispatch_fwd():
+    with tempfile.NamedTemporaryFile() as f:
+        orig_tensor = torch.randn((128))
+        ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
+        ssd_handle.set_file_params(f.name, 0)
+        ssd_handle.to_file(release_tensor_after_write=True)
+
+        assert torch.equal(ssd_handle.to_tensor(), orig_tensor)
+
+        # This should trigger the torch_dispatch code and write
+        # back the results to the file
+        ssd_handle.add_(1)
+        plus1_tensor = orig_tensor.add(1)
+        assert torch.equal(ssd_handle.to_tensor(), plus1_tensor)
+
+
+def test_ssd_handle_dispatch_bwd():
+    with tempfile.NamedTemporaryFile() as f:
+        orig_tensor = torch.randn((4, 4), requires_grad=True)
+        orig_copy = orig_tensor.clone().detach().requires_grad_(True)
+        ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
+        ssd_handle.set_file_params(f.name, 0)
+        ssd_handle.to_file(release_tensor_after_write=True)
+
+        assert torch.equal(ssd_handle.to_tensor(), orig_tensor)
+
+        y1 = ssd_handle + 1
+        y2 = orig_copy + 1
+        y1.sum().backward()
+        y2.sum().backward()
+
+        # TODO: PJ/ASenable assert once Tensor._make_subclass can properly define the tensor's shape
+        # assert torch.equal(ssd_handle.grad, orig_copy.grad)
+
+
+def test_ssd_buffer_basic():
+    _init()
+    with tempfile.NamedTemporaryFile() as f:
+        refa_tensor = torch.rand((128), dtype=torch.float32)
+        refb_tensor = torch.rand((128), dtype=torch.float32)
+        refc_tensor = torch.rand((128), dtype=torch.float32)
+        ssd_buf = so.SsdBuffer(1024, f.name)
+
+        hdl_a = ssd_buf.insert(refa_tensor)
+        hdl_b = ssd_buf.insert(refb_tensor)
+        hdl_c = ssd_buf.insert(refc_tensor)
+
+        assert hdl_a.is_available()
+        assert hdl_b.is_available()
+        assert hdl_c.is_available()
+
+        assert torch.equal(refa_tensor, hdl_a.get_tensor())
+        assert torch.equal(refb_tensor, hdl_b.get_tensor())
+        assert torch.equal(refc_tensor, hdl_c.get_tensor())
+
+        tensors = ssd_buf.get_tensors()
+        assert hdl_a is tensors[0]
+        assert hdl_b is tensors[1]
+        assert hdl_c is tensors[2]
+
+        # test read_into_tensor when handle.is_available()
+        b_tensor_copy1 = torch.empty_like(refb_tensor)
+        hdl_b.copy_into_tensor(b_tensor_copy1)
+        assert torch.equal(refb_tensor, b_tensor_copy1)
+
+        # remove references so memory will be cleaned up
+        buffer = None
+
+        ssd_buf.to_disk()
+
+        assert hdl_a.filename == f.name
+        assert hdl_b.filename == f.name
+        assert hdl_c.filename == f.name
+
+        assert hdl_a.offset == 0
+        assert hdl_b.offset == 128
+        assert hdl_c.offset == 256
+
+        assert not hdl_a.is_available()
+        assert not hdl_b.is_available()
+        assert not hdl_c.is_available()
+
+        # test read_into_tensor when !handle.is_available()
+        b_tensor_copy2 = torch.empty_like(refb_tensor)
+        hdl_b.copy_into_tensor(b_tensor_copy2)
+        assert torch.equal(refb_tensor, b_tensor_copy2)
+
+        ssd_buf.from_disk(384)
+
+        assert hdl_a.is_available()
+        assert hdl_b.is_available()
+        assert hdl_c.is_available()
+
+        assert torch.equal(refa_tensor, hdl_a.get_tensor())
+        assert torch.equal(refb_tensor, hdl_b.get_tensor())
+        assert torch.equal(refc_tensor, hdl_c.get_tensor())
+
+
+def test_ssd_buffer_too_small_from_disk():
+    _init()
+    with tempfile.NamedTemporaryFile() as f:
+        refa_tensor = torch.rand((128), dtype=torch.float32)
+        ssd_buf = so.SsdBuffer(128, f.name)
+        hdl_a = ssd_buf.insert(refa_tensor)
+        ssd_buf.to_disk()
+
+        with pytest.raises(RuntimeError):
+            ssd_buf.from_disk(127)
+
+
+def test_ssd_buffer_null_buffer():
+    _init()
+    with tempfile.NamedTemporaryFile() as f:
+        refa_tensor = torch.rand((128), dtype=torch.float32)
+        ssd_buf = so.SsdBuffer(128, f.name)
+        hdl_a = ssd_buf.insert(refa_tensor)
+        ssd_buf.to_disk()
+
+        with pytest.raises(AssertionError):
+            ssd_buf.to_disk()
+
+        with pytest.raises(AssertionError):
+            hdl_a = ssd_buf.insert(refa_tensor)
+
+        with pytest.raises(AssertionError):
+            ssd_buf.can_alloc(128)
+
+        with pytest.raises(AssertionError):
+            hdl = ssd_buf.allocate(128)


### PR DESCRIPTION
## What does this PR do?
Adds the low level SSD APIs required for representing a tensor, reading/writing to/from memory/disk. These will be used in a future PR to implement SSD offload with FSDP.

The two main concepts here are SsdTensorHandle and SsdBuffer. The SsdTensorHandle represents a tensor that can be in memory or on disk. There are APIs to enable us to set the right metadata (memory offset, file offset, file params etc.). The SsdBuffer consists of a list of SsdTensorHandles and represents all the parameters in a module (as an example). We should be able to read all tensors to and from disk as part of the SsdBuffer.

Note: This PR is a join effort between @another-pjohnson  and @anj-s .

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
