### PR TITLE
[chore] Fix broken main due to updated github URL requirements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ commands:
        - run:
            name: Setup pyenv
            command: |
-             git clone git://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+             git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
              pyenv update
              pyenv install -f <<parameters.version>>
              pyenv global <<parameters.version>>


### PR DESCRIPTION
## What does this PR do?
We are unable to git clone pyenv due to updated security settings as mentioned [here](https://github.blog/2021-09-01-improving-git-protocol-security-github/#git-protocol-troubleshooting). This did not fail on the feature branch so it is definitely worrisome. Perhaps I merged it into main after the Nov 2nd deadline mentioned above?

The failed test is the flaky test we have been seeing recently. Updating to the latest nightly does not seem to have helped.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
