### PR TITLE
Add installation instructions through conda

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ FairScale was designed with the following values in mind:
 
 ## Installation
 
-To install FairScale, please see the following [instructions](https://github.com/facebookresearch/fairscale/blob/main/docs/source/installation_instructions.rst). You should be able to install a pip package or
-build directly from source.
+To install FairScale, please see the following [instructions](https://github.com/facebookresearch/fairscale/blob/main/docs/source/installation_instructions.rst).
+You should be able to install a package with pip or conda, or build directly from source.
 
 ## Getting Started
 The full [documentation](https://fairscale.readthedocs.io/) contains instructions for getting started, deep dives and tutorials about the various FairScale APIs.

--- a/docs/source/installation_instructions.rst
+++ b/docs/source/installation_instructions.rst
@@ -41,5 +41,5 @@ Installing from source
     # -e signified dev mode since e stands for editable
     pip install -e .
 
-
-Note: If either of the above fails, add `--no-build-isolation` to the `pip install` command (this could be a problem with recent versions of pip).
+Note: If either of the above fails, add ``--no-build-isolation`` to the ``pip install``
+command (this could be a problem with recent versions of pip).

--- a/docs/source/installation_instructions.rst
+++ b/docs/source/installation_instructions.rst
@@ -19,6 +19,17 @@ Installing the pip package (stable)
 	pip install fairscale
 
 
+Installing with conda
+~~~~~~~~~~~~~~~~~~~~~
+
+Fairscale is packaged by conda-forge (see `here <https://github.com/conda-forge/fairscale-feedstock>`_)
+for both linux & osx, with GPU-enabled builds available on linux.
+
+.. code-block:: bash
+
+	conda install -c conda-forge fairscale
+
+
 Installing from source
 ~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/source/installation_instructions.rst
+++ b/docs/source/installation_instructions.rst
@@ -1,21 +1,26 @@
 Installing FairScale
 ====================
 
-Installing FairScale is extremely simple with pre-built binaries(pip) that we provide. You can also build
+Installing FairScale is extremely simple with pre-built binaries (pip) that we provide. You can also build
 from source using the instructions below.
 
-### Requirements
+
+Requirements
+~~~~~~~~~~~~
 
 * PyTorch>= 1.8.1
 
-### Installing the pip package (stable)
+
+Installing the pip package (stable)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 
 	pip install fairscale
 
 
-### Installing from source
+Installing from source
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: bash
 

--- a/docs/source/installation_instructions.rst
+++ b/docs/source/installation_instructions.rst
@@ -41,5 +41,8 @@ Installing from source
     # -e signified dev mode since e stands for editable
     pip install -e .
 
+To build with GPU-support enabled, be sure to set ``BUILD_CUDA_EXTENSIONS=1``
+as well as an appropriate ``TORCH_CUDA_ARCH_LIST``.
+
 Note: If either of the above fails, add ``--no-build-isolation`` to the ``pip install``
 command (this could be a problem with recent versions of pip).


### PR DESCRIPTION
Since merging https://github.com/conda-forge/fairscale-feedstock/pull/2, conda-forge now has fairscale-packages also with GPU support, which I think is good enough to let people know also "officially" through the installation instructions here. :)

While editing the docs, I saw that the formatting of https://github.com/facebookresearch/fairscale/blob/main/docs/source/installation_instructions.rst didn't really work (rst vs. md), so I added some cosmetic touch-ups as I went, as well as the key insight I needed to arrive at for building the GPU packages from source (things fail without setting `TORCH_CUDA_ARCH_LIST`).