### PR TITLE
[benchmarks]Add an MOE benchmark

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,12 +156,6 @@ run_pipe_benchmark: &run_pipe_benchmark
       command: |
         python benchmarks/pipe.py
 
-run_moee_benchmark: &run_moe_benchmark
-  - run:
-      name: Run MOE Benchmark
-      command: |
-        python benchmarks/moe.py
-
 run_oss_benchmark: &run_oss_benchmark
   - run:
       name: Run OSS Benchmark
@@ -486,8 +480,6 @@ jobs:
       - <<: *install_repo
 
       - <<: *run_pipe_benchmark
-
-      - <<: *run_moe_benchmark
 
       - <<: *run_offload_benchmark
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,6 +156,12 @@ run_pipe_benchmark: &run_pipe_benchmark
       command: |
         python benchmarks/pipe.py
 
+run_moee_benchmark: &run_moe_benchmark
+  - run:
+      name: Run MOE Benchmark
+      command: |
+        python benchmarks/moe.py
+
 run_oss_benchmark: &run_oss_benchmark
   - run:
       name: Run OSS Benchmark
@@ -480,6 +486,8 @@ jobs:
       - <<: *install_repo
 
       - <<: *run_pipe_benchmark
+
+      - <<: *run_moe_benchmark
 
       - <<: *run_offload_benchmark
 

--- a/benchmarks/datasets/wikitext2_data.py
+++ b/benchmarks/datasets/wikitext2_data.py
@@ -3,6 +3,7 @@
 # This source code is licensed under the BSD license found in the
 # LICENSE file in the root directory of this source tree.
 
+from collections import namedtuple
 from distutils.version import LooseVersion
 import io
 import operator
@@ -34,8 +35,6 @@ def _batchify(data, batch_size):
 
 def _get_total_batch_size(benchmark_config, model_specs):
     return model_specs["seq_len"] * benchmark_config["batch_size"]
-
-from collections import namedtuple
 
 DatasetsInfo = namedtuple('DataSetsInfo', ['ntokens', 'train_dataset', 'valid_dataset', 'test_dataset'])
 

--- a/benchmarks/datasets/wikitext2_data.py
+++ b/benchmarks/datasets/wikitext2_data.py
@@ -36,7 +36,8 @@ def _batchify(data, batch_size):
 def _get_total_batch_size(benchmark_config, model_specs):
     return model_specs["seq_len"] * benchmark_config["batch_size"]
 
-DatasetsInfo = namedtuple('DataSetsInfo', ['ntokens', 'train_dataset', 'valid_dataset', 'test_dataset'])
+
+DatasetsInfo = namedtuple("DataSetsInfo", ["ntokens", "train_dataset", "valid_dataset", "test_dataset"])
 
 
 def get_real_datasets():
@@ -59,39 +60,39 @@ def get_real_datasets():
 
 def get_dataloaders(datasets_info, benchmark_config, model_specs, num_replicas=1, rank=0):
     ntokens, train_dataset, valid_dataset, test_dataset = datasets_info
+
     def batchify(data):
         batch_size = benchmark_config["batch_size"]
         return _batchify(data, batch_size)
 
     total_batch_size = _get_total_batch_size(benchmark_config, model_specs)
     train_dataloader = DataLoader(
-            train_dataset,
-            sampler=DistributedSampler(train_dataset, num_replicas=num_replicas, rank=rank),
-            batch_size=total_batch_size,
-            collate_fn=batchify)
+        train_dataset,
+        sampler=DistributedSampler(train_dataset, num_replicas=num_replicas, rank=rank),
+        batch_size=total_batch_size,
+        collate_fn=batchify,
+    )
     valid_dataloader = DataLoader(
-            valid_dataset,
-            sampler=DistributedSampler(valid_dataset, num_replicas=num_replicas, rank=rank),
-            batch_size=total_batch_size,
-            collate_fn=batchify)
+        valid_dataset,
+        sampler=DistributedSampler(valid_dataset, num_replicas=num_replicas, rank=rank),
+        batch_size=total_batch_size,
+        collate_fn=batchify,
+    )
     test_dataloader = DataLoader(
-            test_dataset,
-            sampler=DistributedSampler(test_dataset, num_replicas=num_replicas, rank=rank),
-            batch_size=total_batch_size,
-            collate_fn=batchify)
+        test_dataset,
+        sampler=DistributedSampler(test_dataset, num_replicas=num_replicas, rank=rank),
+        batch_size=total_batch_size,
+        collate_fn=batchify,
+    )
     return train_dataloader, valid_dataloader, test_dataloader
-
 
 
 def get_real_dataloaders(args, benchmark_config, model_specs, num_replicas=1, rank=0):
     """Return real dataloaders for training, testing and validation."""
     dataset_info = get_real_datasets()
     train_dataloader, valid_dataloader, test_dataloader = get_dataloaders(
-            dataset_info,
-            benchmark_config,
-            model_specs,
-            num_replicas,
-            rank)
+        dataset_info, benchmark_config, model_specs, num_replicas, rank
+    )
     return dataset_info.ntokens, train_dataloader, valid_dataloder, test_dataloader
 
 
@@ -103,9 +104,4 @@ def get_synthetic_datasets():
 
 def get_synthetic_dataloaders(args, benchmark_config, model_specs, num_replicas=1, rank=0):
     """Return synthetic dataloaders for training, testing and validation."""
-    return get_dataloaders(
-            get_synthetic_datasets(),
-            benchmark_config,
-            model_specs,
-            num_replicas,
-            rank)
+    return get_dataloaders(get_synthetic_datasets(), benchmark_config, model_specs, num_replicas, rank)

--- a/benchmarks/datasets/wikitext2_data.py
+++ b/benchmarks/datasets/wikitext2_data.py
@@ -86,13 +86,13 @@ def get_dataloaders(datasets_info, benchmark_config, model_specs, num_replicas=1
 def get_real_dataloaders(args, benchmark_config, model_specs, num_replicas=1, rank=0):
     """Return real dataloaders for training, testing and validation."""
     dataset_info = get_real_datasets()
-    x, y, z = get_dataloaders(
+    train_dataloader, valid_dataloader, test_dataloader = get_dataloaders(
             dataset_info,
             benchmark_config,
             model_specs,
             num_replicas,
             rank)
-    return dataset_info.ntokens, x, y, z
+    return dataset_info.ntokens, train_dataloader, valid_dataloder, test_dataloader
 
 
 def get_synthetic_datasets():
@@ -103,7 +103,7 @@ def get_synthetic_datasets():
 
 def get_synthetic_dataloaders(args, benchmark_config, model_specs, num_replicas=1, rank=0):
     """Return synthetic dataloaders for training, testing and validation."""
-    return get_dataladers(
+    return get_dataloaders(
             get_synthetic_datasets(),
             benchmark_config,
             model_specs,

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -114,7 +114,7 @@ class MOE:
             "scaler": GradScaler(),
             "clip_value": 0.05,
             "num_decoder_layers": 20,
-            "seq_len": 32,
+            "seq_len": 33,  # (seq_len - 1) needs to be divisible by num_local_experts
             "is_moe": True,
             "num_local_experts": 2,
         }

--- a/benchmarks/golden_configs/lm_wikitext2.py
+++ b/benchmarks/golden_configs/lm_wikitext2.py
@@ -100,3 +100,29 @@ class Pipe:
     def get_golden_synthetic_stats():
         # TODO(anj-s): Add support for synthetic regression benchmarks
         raise NotImplementedError("Synthetic data benchmarks are not supported.")
+
+
+class MOE:
+    def get_model_config():
+        return {
+            "vocab_size": 10000,
+            "ninp": 1024,  # embedding dimension
+            "nhid": 4096,  # the dimension of the feedforward network model in nn.TransformerEncoder
+            "nhead": 32,  # the number of heads in the multiheadattention models
+            "dropout": 0,
+            "initrange": 0.1,
+            "scaler": GradScaler(),
+            "clip_value": 0.05,
+            "num_decoder_layers": 20,
+            "seq_len": 32,
+            "is_moe": True,
+            "num_local_experts": 2,
+        }
+
+    def get_benchmark_config():
+        return {
+            "epochs": 1,
+            "lr": 0.001,  # learning rate
+            "batch_size": 32,
+            "criterion": nn.CrossEntropyLoss(),
+        }

--- a/benchmarks/models/transformer_lm.py
+++ b/benchmarks/models/transformer_lm.py
@@ -7,6 +7,8 @@ import math
 
 import torch
 import torch.nn as nn
+from fairscale.nn.moe.moe_layer import MOELayer
+from fairscale.nn.moe.top2gate import Top2Gate
 
 
 # TODO(anj-s): Identify if we need this initialization logic for the below wrapped layers.
@@ -42,11 +44,120 @@ class PositionalEncodingLayer(nn.Module):
         return self.dropout(x)
 
 
-class TransformerDecoderLayer(nn.TransformerEncoderLayer):
-    """TransformerDecoder layer which inherits from nn.TransformerEncoderLayer."""
+class FeedForwardLayer(nn.Module):
+    """FeedForward layer for a given Transformer model."""
 
-    def __init__(self, ninp, nhead, nhid, dropout):
-        super().__init__(ninp, nhead, nhid, dropout)
+    def __init__(self, d_model, dim_feedforward, activation, dropout) -> None:
+        super(FeedForwardLayer, self).__init__()
+        self.linear1 = nn.Linear(d_model, dim_feedforward)
+        self.activation = activation
+        self.dropout1 = nn.Dropout(dropout)
+        self.linear2 = nn.Linear(dim_feedforward, d_model)
+        self.dropout2 = nn.Dropout(dropout)
+
+    def forward(self, x):
+        return self.dropout2(self.linear2(self.dropout1(self.activation(self.linear1(x)))))
+
+
+# Forked from https://pytorch.org/docs/stable/_modules/torch/nn/modules/transformer.html#TransformerEncoderLayer.
+# Parameters is_moe and num_local_experts are added.
+class TransformerEncoderLayer(nn.Module):
+    r"""TransformerEncoderLayer is made up of self-attn and feedforward network.
+    This standard encoder layer is based on the paper "Attention Is All You Need".
+    Ashish Vaswani, Noam Shazeer, Niki Parmar, Jakob Uszkoreit, Llion Jones, Aidan N Gomez,
+    Lukasz Kaiser, and Illia Polosukhin. 2017. Attention is all you need. In Advances in
+    Neural Information Processing Systems, pages 6000-6010. Users may modify or implement
+    in a different way during application.
+
+    Args:
+        d_model: the number of expected features in the input (required).
+        nhead: the number of heads in the multiheadattention models (required).
+        dim_feedforward: the dimension of the feedforward network model (default=2048).
+        dropout: the dropout value (default=0.1).
+        activation: the activation function of the intermediate layer, can be a string
+            ("relu" or "gelu") or a unary callable. Default: relu
+        layer_norm_eps: the eps value in layer normalization components (default=1e-5).
+        norm_first: if ``True``, layer norm is done prior to attention and feedforward
+            operations, respectivaly. Otherwise it's done after. Default: ``False`` (after).
+        is_moe: if ``True``, the feedforward layer will have MOE enabled.
+        num_local_experts: number of local experts for MOE.
+
+
+    Examples::
+        >>> encoder_layer = nn.TransformerEncoderLayer(d_model=512, nhead=8)
+        >>> src = torch.rand(10, 32, 512)
+        >>> out = encoder_layer(src)
+    """
+    __constants__ = ['norm_first']
+
+    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1, activation=nn.ReLU(),
+                 layer_norm_eps=1e-5, norm_first=False,
+                 is_moe=False, num_local_experts=1):
+        super(TransformerEncoderLayer, self).__init__()
+        self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
+        self.norm_first = norm_first
+        self.norm1 = nn.LayerNorm(d_model, eps=layer_norm_eps)
+        self.norm2 = nn.LayerNorm(d_model, eps=layer_norm_eps)
+        self.dropout = nn.Dropout(dropout)
+
+        self.is_moe = is_moe
+        if is_moe:
+            world_size = 1 if not torch.distributed.is_initialized() else torch.distributed.get_world_size()
+            num_global_experts = num_local_experts * world_size
+            self.gate = Top2Gate(d_model, num_global_experts)
+            experts = nn.ModuleList(
+                    [FeedForwardLayer(d_model, dim_feedforward, activation, dropout) for _ in range(num_local_experts)])
+            self.moe_layer = MOELayer(self.gate, experts)
+        else:
+            self.ff_block = FeedForwardLayer(d_model, dim_feedforward, activation, dropout)
+
+
+    def forward(self, src, src_mask = None, src_key_padding_mask = None):
+        r"""Pass the input through the encoder layer.
+
+        Args:
+            src: the sequence to the encoder layer (required).
+            src_mask: the mask for the src sequence (optional).
+            src_key_padding_mask: the mask for the src keys per batch (optional).
+
+        Shape:
+            see the docs in Transformer class.
+        """
+
+        # see Fig. 1 of https://arxiv.org/pdf/2002.04745v1.pdf
+
+        x = src
+        if self.norm_first:
+            x = x + self._sa_block(self.norm1(x), src_mask, src_key_padding_mask)
+            x = x + self._ff_block(self.norm2(x))
+        else:
+            x = self.norm1(x + self._sa_block(x, src_mask, src_key_padding_mask))
+            x = self.norm2(x + self._ff_block(x))
+
+        return x
+
+
+    # self-attention block
+    def _sa_block(self, x, attn_mask, key_padding_mask):
+        x = self.self_attn(x, x, x,
+                           attn_mask=attn_mask,
+                           key_padding_mask=key_padding_mask,
+                           need_weights=False)[0]
+        return self.dropout(x)
+
+    # feed forward block
+    def _ff_block(self, x):
+        if self.is_moe:
+            return self.moe_layer(x)
+        else:
+            return self.ff_block(x)
+
+
+class TransformerDecoderLayer(TransformerEncoderLayer):
+    """TransformerDecoder layer which inherits from TransformerEncoderLayer."""
+
+    def __init__(self, ninp, nhead, nhid, dropout, is_moe=False, num_local_experts=1):
+        super().__init__(ninp, nhead, nhid, dropout, is_moe=is_moe, num_local_experts=num_local_experts)
         self.src_mask = None
 
     def _generate_square_subsequent_mask(self, sz):
@@ -78,13 +189,13 @@ class LinearLayer(nn.Linear):
 class TransformerLM(nn.Sequential):
     """A GPT-2 based nn.Sequential language model."""
 
-    def __init__(self, ntokens, ninp, nhead, nhid, dropout, initrange, ndecoder):
+    def __init__(self, ntokens, ninp, nhead, nhid, dropout, initrange, ndecoder, is_moe=False, num_local_experts=1):
         layers = [
             EmbeddingLayer(ntokens, ninp, initrange),
             PositionalEncodingLayer(ninp, dropout),
         ]
         for _ in range(ndecoder):
-            layers.append(TransformerDecoderLayer(ninp, nhead, nhid, dropout))
+            layers.append(TransformerDecoderLayer(ninp, nhead, nhid, dropout, is_moe, num_local_experts))
 
         layers.append(LinearLayer(ninp, ntokens, initrange))
         super(TransformerLM, self).__init__(*layers)

--- a/benchmarks/models/transformer_lm.py
+++ b/benchmarks/models/transformer_lm.py
@@ -7,6 +7,7 @@ import math
 
 import torch
 import torch.nn as nn
+
 from fairscale.nn.moe.moe_layer import MOELayer
 from fairscale.nn.moe.top2gate import Top2Gate
 
@@ -88,11 +89,20 @@ class TransformerEncoderLayer(nn.Module):
         >>> src = torch.rand(10, 32, 512)
         >>> out = encoder_layer(src)
     """
-    __constants__ = ['norm_first']
+    __constants__ = ["norm_first"]
 
-    def __init__(self, d_model, nhead, dim_feedforward=2048, dropout=0.1, activation=nn.ReLU(),
-                 layer_norm_eps=1e-5, norm_first=False,
-                 is_moe=False, num_local_experts=1):
+    def __init__(
+        self,
+        d_model,
+        nhead,
+        dim_feedforward=2048,
+        dropout=0.1,
+        activation=nn.ReLU(),
+        layer_norm_eps=1e-5,
+        norm_first=False,
+        is_moe=False,
+        num_local_experts=1,
+    ):
         super(TransformerEncoderLayer, self).__init__()
         self.self_attn = nn.MultiheadAttention(d_model, nhead, dropout=dropout)
         self.norm_first = norm_first
@@ -106,13 +116,13 @@ class TransformerEncoderLayer(nn.Module):
             num_global_experts = num_local_experts * world_size
             self.gate = Top2Gate(d_model, num_global_experts)
             experts = nn.ModuleList(
-                    [FeedForwardLayer(d_model, dim_feedforward, activation, dropout) for _ in range(num_local_experts)])
+                [FeedForwardLayer(d_model, dim_feedforward, activation, dropout) for _ in range(num_local_experts)]
+            )
             self.moe_layer = MOELayer(self.gate, experts)
         else:
             self.ff_block = FeedForwardLayer(d_model, dim_feedforward, activation, dropout)
 
-
-    def forward(self, src, src_mask = None, src_key_padding_mask = None):
+    def forward(self, src, src_mask=None, src_key_padding_mask=None):
         r"""Pass the input through the encoder layer.
 
         Args:
@@ -136,13 +146,9 @@ class TransformerEncoderLayer(nn.Module):
 
         return x
 
-
     # self-attention block
     def _sa_block(self, x, attn_mask, key_padding_mask):
-        x = self.self_attn(x, x, x,
-                           attn_mask=attn_mask,
-                           key_padding_mask=key_padding_mask,
-                           need_weights=False)[0]
+        x = self.self_attn(x, x, x, attn_mask=attn_mask, key_padding_mask=key_padding_mask, need_weights=False)[0]
         return self.dropout(x)
 
     # feed forward block

--- a/benchmarks/models/transformer_lm.py
+++ b/benchmarks/models/transformer_lm.py
@@ -102,9 +102,7 @@ class TransformerEncoderLayer(nn.Module):
 
         self.is_moe = is_moe
         if is_moe:
-            if not torch.distributed.is_initialized():
-                raise AssertionError('torch.distriubted is not initialized.')
-            world_size = torch.distributed.get_world_size()
+            world_size = 1 if not torch.distributed.is_initialized() else torch.distributed.get_world_size()
             num_global_experts = num_local_experts * world_size
             self.gate = Top2Gate(d_model, num_global_experts)
             experts = nn.ModuleList(

--- a/benchmarks/models/transformer_lm.py
+++ b/benchmarks/models/transformer_lm.py
@@ -102,7 +102,9 @@ class TransformerEncoderLayer(nn.Module):
 
         self.is_moe = is_moe
         if is_moe:
-            world_size = 1 if not torch.distributed.is_initialized() else torch.distributed.get_world_size()
+            if not torch.distributed.is_initialized():
+                raise AssertionError('torch.distriubted is not initialized.')
+            world_size = torch.distributed.get_world_size()
             num_global_experts = num_local_experts * world_size
             self.gate = Top2Gate(d_model, num_global_experts)
             experts = nn.ModuleList(

--- a/benchmarks/moe.py
+++ b/benchmarks/moe.py
@@ -86,11 +86,10 @@ def train(rank, world_size, benchmark_config, model_specs, args):
         target = target.to(device)
         try:
             output = model(source.to(device))
+            loss = criterion(output.view(-1, vocab_size), target.view(-1))
+            loss.backward()
         except Exception as e:
             raise RuntimeError(f"training failed on {torch.distributed.get_rank()}") from e
-
-        loss = criterion(output.view(-1, vocab_size), target.view(-1))
-        loss.backward()
 
         torch.nn.utils.clip_grad_value_(model.parameters(), model_specs["clip_value"])
         optimizer.step()

--- a/benchmarks/moe.py
+++ b/benchmarks/moe.py
@@ -1,0 +1,120 @@
+import argparse
+import utils
+import logging
+import math
+import time
+
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+
+from benchmarks.golden_configs.lm_wikitext2 import MOE as MOEConfig
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+MPI_PORT = 29500
+
+def benchmark_single_process(config_class, args):
+    """Benchmark a given model using a single process and multiple devices."""
+
+    world_size = torch.cuda.device_count() if torch.cuda.is_available() else 1
+    assert world_size > 0
+    benchmark_config = utils.create_benchmark_config(args.model_name, config_class)
+    model_specs = utils.get_model_specs(args.model_name, config_class)
+
+    mp.spawn(train,
+        args=(world_size, benchmark_config, model_specs, args),
+        nprocs=world_size,
+        join=True)
+
+
+def train(rank, world_size, benchmark_config, model_specs, args):
+    logger = mp.log_to_stderr()
+    logger.setLevel(logging.DEBUG if args.debug else logging.INFO)
+    utils.init_random_seed(rank)
+
+    init_method_pgroup = "tcp://localhost:{}".format(MPI_PORT)
+    torch.distributed.init_process_group(
+            backend="gloo", rank=rank, world_size=world_size, init_method=init_method_pgroup)
+    logger.info("train, rank={}".format(rank))
+    device = torch.device("cuda", rank) if torch.cuda.is_available() else torch.device("cpu")
+
+    criterion = benchmark_config["criterion"]
+
+    model_config = utils.create_model_config(
+            args, benchmark_config=benchmark_config, model_specs=model_specs, device=device)
+    # vocab_size may change in create_model_config() due to input data
+    vocab_size = model_specs["vocab_size"]
+    model = model_config["model"]
+    model.train()
+    optimizer = model_config["optimizer"]
+    optimizer = optimizer(model.parameters())
+    group = model.group if hasattr(model, "group") else None
+    utils.log_number_of_parameters(model)
+
+    total_loss = 0.0
+    word_counter = 0
+    total_tokens = 0
+    total_tokens_per_log_interval = 0
+    bptt = 2
+
+    total_elapsed = 0.0
+
+    model = DDP(model, device_ids=[rank], output_device=rank, broadcast_buffers=False)
+    lm_dataloader, _, _ = utils.get_data_loader(model_config["dataset_info"], args, benchmark_config, model_specs, num_replicas=world_size, rank=rank)
+
+    for i, batch in enumerate(lm_dataloader):
+        if i == 1:
+            epoch_start_time = time.time()
+
+        if args.max_batch and i > args.max_batch:
+            break
+
+        if i > 0:
+            total_tokens += batch.numel()
+
+        start_time = time.time()
+        optimizer.zero_grad()
+        batch = batch.to(device)
+        try:
+            output = model(batch)
+        except Exception as e:
+            raise RuntimeError(f"training failed on {torch.distributed.get_rank()}") from e
+
+        loss = criterion(output.view(-1, vocab_size), batch.view(-1))
+        loss.backward()
+
+        torch.nn.utils.clip_grad_value_(model.parameters(), model_specs["clip_value"])
+        optimizer.step()
+
+        elapsed = time.time() - start_time
+        total_elapsed += elapsed
+        total_loss += loss.item()
+        log_interval = 1
+        total_tokens_per_log_interval += batch.numel()
+        if i % log_interval == 0 and i > 0:
+            cur_loss = total_loss / log_interval
+            logger.debug(
+                "| batch {:5d} | wps {:5.2f} | loss {:5.2f} | ppl {:8.2f}".format(
+                    i, total_tokens_per_log_interval / elapsed, cur_loss, math.exp(cur_loss)
+                )
+            )
+            total_tokens_per_log_interval = 0
+            total_loss = 0
+
+    wps = total_tokens / total_elapsed
+
+    logger.debug("rank {}, wps: {}".format(rank, wps))
+    logger.debug(
+        "Peak allocated bytes on cuda:{}: {:1d}".format(
+            dist.get_rank(), torch.cuda.memory_stats(dist.get_rank())["allocated_bytes.all.peak"]
+        )
+    )
+
+
+if __name__ == "__main__":
+    args = utils.init_args()
+    logging.basicConfig(level=logging.INFO if not args.debug else logging.DEBUG)
+
+    logging.info(f"Running single process benchmark with args: {args}")
+    benchmark_single_process(MOEConfig, args)
+

--- a/benchmarks/pipe.py
+++ b/benchmarks/pipe.py
@@ -13,13 +13,12 @@ import torch
 import torch.distributed as dist
 from torch.distributed import rpc
 from torch.nn.parallel import DistributedDataParallel as DDP
+import utils
 
 from benchmarks.golden_configs.lm_wikitext2 import Pipe as lm_wikitext2
 from fairscale.nn import Pipe
 from fairscale.nn.model_parallel import initialize_model_parallel
 from fairscale.utils.testing import dist_init
-
-import utils
 
 MPI_PORT = 29500
 RPC_PORT = 29501

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -8,7 +8,7 @@ from functools import reduce
 import logging
 import operator
 
-import datasets.wikitext2_data as wt2d
+import datasets.wikitext2_data as wikitext2_data
 from models import transformer_lm
 import numpy as np
 import torch
@@ -146,11 +146,11 @@ def log_number_of_parameters(model):
 def get_dataset_info(args):
     assert args.model_name == "lm"
     if args.use_synthetic_data:
-        return wt2d.get_synthetic_datasets()
+        return wikitext2_data.get_synthetic_datasets()
     else:
-        return wt2d.get_real_datasets()
+        return wikitext2_data.get_real_datasets()
 
 
 def get_data_loader(dataset_info, args, benchmark_config, model_specs, num_replicas=1, rank=0):
-    return wt2d.get_dataloaders(dataset_info, benchmark_config, model_specs, num_replicas, rank)
+    return wikitext2_data.get_dataloaders(dataset_info, benchmark_config, model_specs, num_replicas, rank)
 

--- a/benchmarks/utils.py
+++ b/benchmarks/utils.py
@@ -1,0 +1,156 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# This source code is licensed under the BSD license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+from functools import reduce
+import logging
+import operator
+
+import datasets.wikitext2_data as wt2d
+from models import transformer_lm
+import numpy as np
+import torch
+from torch.optim import Adam
+
+
+def init_random_seed(seed: int):
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed(seed)
+    np.random.seed(seed)
+
+
+def init_args():
+    parser = argparse.ArgumentParser(description="benchmark")
+    parser.add_argument("--host", "-o", type=str, default="localhost", help="hostname")
+    parser.add_argument("--chunks", type=int, default=1, help="number of microbatches per batch")
+    parser.add_argument("--batch-size", type=int, default=8, help="size of a batch")
+    parser.add_argument(
+        "--checkpoint", default="never", choices=["always", "except_last", "never"], help="Checkpointing strategy for pipe"
+    )
+    parser.add_argument(
+        "--lazy-construction", action="store_true", default=False, help="Number of decoder layers in the model"
+    )
+    parser.add_argument("--max-batch", type=int, default=4, help="Max number of batches")
+    parser.add_argument("--use_synthetic_data", action="store_true", help="Uses synthetic data for running benchmarks.")
+    parser.add_argument("--dry_run", action="store_true", help="Run a sample training run without regression testing.")
+    parser.add_argument(
+        # TODO(anj-s): In the process of adding more models and hence the requirement for a flag.
+        "--model_name",
+        default="lm",
+        help="Language Model(LM) used to benchmark nn.pipe.",
+    )
+    parser.add_argument("--debug", action="store_true", default=False, help="Display additional debug information")
+    args = parser.parse_args()
+    return args
+
+
+def create_benchmark_config(model_name, config_class):
+    """Return a dict with configurations required for benchmarking `model_name` model."""
+
+    if model_name == "lm":
+        return config_class.get_benchmark_config()
+    else:
+        raise RuntimeError("Unrecognized args.model_mame " % args.model_name)
+
+def get_model_specs(model_name, config_class):
+    """Return a dict with configurations required for configuring `model_name` model."""
+
+    if model_name == "lm":
+        return config_class.get_model_config()
+    else:
+        raise RuntimeError("Unrecognized args.model_mame " % model_name)
+
+def create_model_config(args, benchmark_config=None, model_specs=None, device=None):
+    """Return a dict with the given model, dataset and optimizer."""
+
+    if not device:
+        device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+    dataset_info = get_dataset_info(args)
+    assert model_specs is not None
+    model_specs["vocab_size"] = dataset_info.ntokens
+    model, optimizer = get_model_and_optimizer(args, device, benchmark_config, model_specs)
+    return {
+        "model": model,
+        "optimizer": optimizer,
+        "dataset_info": dataset_info,
+    }
+
+
+def get_model_and_optimizer(args, device, benchmark_config, model_config):
+    """Return instantiated model and optimizer function."""
+
+    if args.model_name == "lm":
+        model = get_lm_model(args, device, model_config)
+
+    lr = benchmark_config["lr"]
+
+    def make_adam(params):
+        return Adam(params, lr=lr)
+
+    optimizer = make_adam
+    return model, optimizer
+
+
+def get_lm_model(args, device, config):
+    """Get language model(based on GPT-2) used for sequence prediction."""
+
+    ninp = config["ninp"]
+    nhead = config["nhead"]
+    initrange = config["initrange"]
+    dropout = config["dropout"]
+    vocab_size = config["vocab_size"]
+    nhid = config["nhid"]
+    ndecoder = config["num_decoder_layers"]
+    is_moe = config.get("is_moe", False)
+    num_local_experts = config.get("num_local_experts", 1)
+
+    if args.lazy_construction:
+        layers = [
+            LazyModule(lambda: transformer_lm.EmbeddingLayer(vocab_size, ninp, initrange)),
+            LazyModule(lambda: transformer_lm.PositionalEncodingLayer(ninp, dropout)),
+        ]
+        for _ in range(ndecoder):
+            layers.append(LazyModule(
+                lambda: transformer_lm.TransformerDecoderLayer(ninp, nhead, nhid, dropout, is_moe, num_local_experts)))
+
+        layers.append(LazyModule(lambda: transformer_lm.LinearLayer(ninp, vocab_size, initrange)))
+        model = layers
+    else:
+        model = transformer_lm.TransformerLM(
+                vocab_size, ninp, nhead, nhid, dropout, initrange, ndecoder, is_moe, num_local_experts).to(device)
+
+    return model
+
+
+def log_number_of_parameters(model):
+
+    num_params = reduce(operator.add, (reduce(operator.mul, x.size()) for x in model.parameters()))
+    if hasattr(model, "group"):
+        total = torch.Tensor([num_params])
+        if torch.cuda.is_available():
+            total = total.cuda()
+        torch.distributed.all_reduce(total, group=model.group)
+        logging.debug(
+            f"training model, #params = {num_params}, group: {model.group.rank()}, grank:"
+            f" {torch.distributed.get_rank()}, sizes {model.group.size()}"
+        )
+        torch.distributed.barrier()
+        if model.group.rank() == 0:
+            logging.debug(f"total #prams = {total.item()}")
+    else:
+        logging.debug(f"training model, #params = {num_params}")
+
+
+def get_dataset_info(args):
+    assert args.model_name == "lm"
+    if args.use_synthetic_data:
+        return wt2d.get_synthetic_datasets()
+    else:
+        return wt2d.get_real_datasets()
+
+
+def get_data_loader(dataset_info, args, benchmark_config, model_specs, num_replicas=1, rank=0):
+    return wt2d.get_dataloaders(dataset_info, benchmark_config, model_specs, num_replicas, rank)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ use_parentheses = true
 skip_glob = ["build/*", "stubs/*"]
 # Don't split "import" and "from".
 force_sort_within_sections = true
-known_third_party = ["benchmark_dataset", "datasets", "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "torch", "torchtext", "torchvision"]
+known_third_party = ["benchmark_dataset", "datasets", "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "torch", "torchtext", "torchvision", "utils"]


### PR DESCRIPTION
## What does this PR do?
This PR adds an DDP / model parallelism benchmark based on MOE layers. This includes:

* Adding an MOE layer (with Top2Gate) to the FastForwardLayer in the TransformerLM model;
* Adding a new benchmark moe.py for the MOE model;
* Extracting util functions to utils.py so that pipe.py and moe.py can share;
* Updating data_loader APIs to support sharding;

Remaining work items:

* For now, each DDP process initializes its own dataset and dataloader, hence the data file is downloaded / unzipped in each process. This can be optimized by moving dataset initialization before DDP processes start.
* For now, the test is bottlenecked by CPU instead of GPU (CPU utilization is ~130% per process / CPU core from "top" while GPU utilization is ~40% per card from "nvidia-smi"). Need to further investigate CPU side bottleneck or increase model param size to move the bottleneck to GPU, so that we could use the benchmark to further optimize GPU performance.

Test result:
```
python benchmarks/moe.py --debug --use_synthetic_data
INFO:root:Running single process benchmark with args: Namespace(host='localhost', chunks=1, batch_size=8, checkpoint='never', lazy_construction=False, max_batch=4, use_synthetic_data=True, dry_run=False, model_name='lm', debug=True)
[INFO/SpawnProcess-1] train, rank=0
[INFO/SpawnProcess-2] train, rank=1
[DEBUG/SpawnProcess-1] training model, #params = 440370960
[DEBUG/SpawnProcess-2] training model, #params = 440370960
[DEBUG/SpawnProcess-2] | batch     1 | wps 1763.53 | loss 21.89 | ppl 3204289915.85
[DEBUG/SpawnProcess-1] | batch     1 | wps 1761.57 | loss 22.05 | ppl 3768126586.15
[DEBUG/SpawnProcess-2] | batch     2 | wps 920.07 | loss 10.83 | ppl 50587.46
[DEBUG/SpawnProcess-1] | batch     2 | wps 914.25 | loss 10.87 | ppl 52769.10
[DEBUG/SpawnProcess-1] | batch     3 | wps 895.16 | loss 10.60 | ppl 40016.83
[DEBUG/SpawnProcess-2] | batch     3 | wps 888.35 | loss 10.55 | ppl 38240.56
[DEBUG/SpawnProcess-2] | batch     4 | wps 903.29 | loss 10.43 | ppl 33739.80
[DEBUG/SpawnProcess-1] | batch     4 | wps 897.48 | loss 10.29 | ppl 29328.61
[DEBUG/SpawnProcess-2] rank 1, wps: 715.3793181560217
[DEBUG/SpawnProcess-1] rank 0, wps: 713.7006510171764
[DEBUG/SpawnProcess-2] Peak allocated bytes on cuda:1: 11361703936
[DEBUG/SpawnProcess-1] Peak allocated bytes on cuda:0: 11361712128
[INFO/SpawnProcess-1] process shutting down
[DEBUG/SpawnProcess-1] running all "atexit" finalizers with priority >= 0
[DEBUG/SpawnProcess-1] running the remaining "atexit" finalizers
[INFO/SpawnProcess-1] process exiting with exitcode 0
[INFO/SpawnProcess-2] process shutting down
[DEBUG/SpawnProcess-2] running all "atexit" finalizers with priority >= 0
[DEBUG/SpawnProcess-2] running the remaining "atexit" finalizers
[INFO/SpawnProcess-2] process exiting with exitcode 0
```

Model size (per GPU):
* model size without MOE: #params = 272414480
* model size with MOE: #params = 440370960

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
