### PR TITLE
[feat] support eval in mevo

### DIFF
--- a/fairscale/experimental/nn/mevo.py
+++ b/fairscale/experimental/nn/mevo.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 
 
-from typing import Any, Tuple
+from typing import Any, Optional, Tuple
 
 import torch
 from torch import nn
@@ -430,7 +430,14 @@ class MemoryEfficientVocabOutput(nn.Module):  # AKA. MEVO
         # nlprob, then sum over all tokens.
         return -prob.sum()
 
-    def forward(self, input: torch.Tensor, target: torch.Tensor) -> torch.Tensor:  # type: ignore
+    def eval_forward(self, input: torch.Tensor) -> torch.Tensor:
+        """Eval time forward that doesn't fuse the softmax and NLL Loss kernels."""
+        return torch.matmul(input, self.proj_weight.T)
+
+    def forward(self, input: torch.Tensor, target: Optional[torch.Tensor]) -> torch.Tensor:  # type: ignore
+        if not self.training and target is None:
+            return self.eval_forward(input)
+
         if DEBUG and dist.is_initialized() and dist.get_rank() == 0:
             cur_mem = round(torch.cuda.memory_allocated() / 1024 / 1024)
             mem = round(torch.cuda.max_memory_allocated() / 1024 / 1024)

--- a/tests/experimental/nn/test_mevo.py
+++ b/tests/experimental/nn/test_mevo.py
@@ -28,6 +28,17 @@ _dense_grad = {}  # type: ignore
 
 
 @skip_if_no_cuda
+def test_mevo_eval():
+    """Test eval mode without target tensor"""
+    weight = torch.nn.Linear(3, 4).cuda().weight
+    input = torch.rand(1, 5, 3).cuda()
+    k = MEVO(weight)
+    k.eval()
+    out = k(input, None)
+    assert out.shape == (1, 5, 4)
+
+
+@skip_if_no_cuda
 def test_mevo():
     """Test the MEVO kernel by itself."""
     torch.random.manual_seed(os.getpid())


### PR DESCRIPTION
- During eval, we will fallback to just output projection without fusing
- added unit test to ensure the shape is correct

## What does this PR do?
Fixes # (issue).

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
