### PR TITLE
Added warn_on_trainable_params_changed constructor parameter to allow the user to suppress the warning on trainable parameters changed

### DIFF
--- a/fairscale/nn/data_parallel/sharded_ddp.py
+++ b/fairscale/nn/data_parallel/sharded_ddp.py
@@ -63,6 +63,9 @@ class ShardedDataParallel(nn.Module):
         reduce_fp16 (bool):
             cast the grads to fp16 before reducing. Not needed if the model is already fp16, but will probably improve performance
             for multi node jobs using PyTorch AMP. The effect is similar to DDP's fp16_compress_hook_ and will also save some memory.
+        warn_on_trainable_params_changed (bool):
+            When set to False no warning will be logged whenever a parameter trainability change has been detected.
+            Default is True.
 
     .. _fp16_compress_hook: https://pytorch.org/docs/1.8.0/ddp_comm_hooks.html?highlight=fp16#torch.distributed.algorithms.ddp_comm_hooks.default_hooks.fp16_compress_hook
 


### PR DESCRIPTION
The default for the new parameter is True and thus the default behaviour is unchanged

## What does this PR do?
Fixes #874 (rather implements the feature request).

## Before submitting

- [X] Did you have fun?
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [X] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  Not approved to make a pull request, but I took the liberty to create the fix; if you want it you can have it!

- [X] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
