### PR TITLE
Enabling ssd_offload training basic tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Fixed a corner case of FSDP init order and losing one of the flags [#880]
+- FSDP: Adding basic training support for SSD Offload, it now only supports flattened parameters. It remains an experimental feature.
 
 ## [0.4.3] - 2021-11-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Fixed a corner case of FSDP init order and losing one of the flags [#880]
-- FSDP: Adding basic training support for SSD Offload, it now only supports flattened parameters. It remains an experimental feature.
+- FSDP: Adding basic training support for SSD Offload, it now only supports flattened parameters. Renamed OffloadConfig.ssd_filepath_dir to more generic OffloadConfig.dir. SSD Offload remains an experimental feature. [#887]
 
 ## [0.4.3] - 2021-11-18
 

--- a/fairscale/experimental/nn/ssd_offload.py
+++ b/fairscale/experimental/nn/ssd_offload.py
@@ -9,12 +9,10 @@ from enum import Enum, auto
 from functools import reduce
 import io
 import os
-import pickle
-from typing import IO, Any, BinaryIO, Callable, Iterator, List, Optional, Sequence, Tuple, Type, Union
+from typing import Any, Iterator, List, Optional, Sequence, Tuple, Type
 
 import numpy as np
 import torch
-from torch.serialization import DEFAULT_PROTOCOL as DEFAULT_PROTOCOL
 
 try:
     from torch.utils._pytree import tree_map
@@ -240,38 +238,6 @@ class SsdTensorHandle(torch.Tensor):
         return r
 
 
-# Classes supporting torch.save/load
-class TorchSaver:
-    def __init__(self) -> None:
-        self.pickle_module = DisableMemoizationPicklerModule
-
-    def save(
-        self, obj: Any, f: Union[str, os.PathLike, BinaryIO, IO[bytes]], pickle_protocol: int = DEFAULT_PROTOCOL
-    ) -> None:
-        torch.serialization.save(
-            obj, f, self.pickle_module, pickle_protocol=pickle_protocol, _use_new_zipfile_serialization=False
-        )
-
-
-class SsdParameter(torch.nn.Parameter, SsdTensorHandle):
-    @classmethod
-    def from_tensor(cls: Type[SsdParameter], tensor: SsdTensorHandle) -> SsdParameter:  # type: ignore
-        r = cls(tensor.shape, tensor.dtype, tensor.requires_grad)
-        r.tensor = tensor
-        return r
-
-    @staticmethod
-    def __new__(
-        cls: SsdParameter, shape: Tuple[int, ...], dtype: torch.dtype, requires_grad: bool = True
-    ) -> SsdParameter:
-        r = SsdTensorHandle._make_wrapper_subclass(cls, shape, dtype=dtype, requires_grad=requires_grad)  # type: ignore
-
-        return r
-
-    def __init__(self, shape: Tuple[int, ...], dtype: torch.dtype, requires_grad: bool = True) -> None:
-        super(SsdParameter, self).__init__(shape, dtype, requires_grad)  # type: ignore
-
-
 class SsdFlatParameter(torch.nn.Parameter, SsdTensorHandle):
     """A parameter that is initialized from a list of parameters and can be
     turned into a list of views as needed.
@@ -365,90 +331,3 @@ class SsdFlatParameter(torch.nn.Parameter, SsdTensorHandle):
             # Args to __setstate__
             (self._param_numels, self._param_shapes, self._param_infos, self._shared_param_infos),
         )
-
-
-class DisableMemoizationPicklerModule:
-    @classmethod
-    def Pickler(cls, data_buf: io.BytesIO, protocol: int) -> pickle.Pickler:
-        p = pickle.Pickler(data_buf, protocol)
-        p.fast = True
-        return p
-
-    @classmethod
-    def dump(cls, obj: Any, f: io.BytesIO, protocol: int) -> None:
-        pickle.dump(obj, f, protocol)
-
-
-class FileChunkingIterator:
-    """
-    chunk_size_bytes determines how large each chunk that we break the file
-    into. It is important to consider limiting the size because by when
-    python unpickles an object, by default it will read up to 1000 list
-    elements at a time. So memory usage while unpickling will be on the
-    order of O(min(file_size, 1000 * chunk_size_bytes)).
-    """
-
-    def __init__(self, filename: str, chunk_size_bytes: int = DEFAULT_CHUNK_SIZE) -> None:
-        self.filename = filename
-        self.file: Optional[Union[BinaryIO, IO[bytes]]] = None
-        self.chunk_size_bytes = chunk_size_bytes
-        self.num_chunks_read = 0
-
-    def __iter__(self) -> Iterator[bytes]:
-        self.file = io.open(self.filename, "rb", buffering=0)
-        self.num_chunks_read = 0
-        return self
-
-    def __next__(self) -> bytes:
-        assert self.file
-        next_chunk = self.file.read(self.chunk_size_bytes)
-
-        if len(next_chunk) == 0:
-            raise StopIteration
-        self.num_chunks_read += 1
-
-        return next_chunk
-
-
-class SsdTensor:
-    def __init__(self, shape: Tuple[int, ...], filename: str, dtype: torch.dtype = torch.float) -> None:
-        self.filename = filename
-        self.f: Optional[Union[BinaryIO, IO[bytes]]] = None
-        self.shape = shape
-        self.dtype = dtype
-
-    @classmethod
-    def __unpickle__(cls, shape: Tuple[int, ...], filename: str, dtype: torch.dtype) -> SsdTensor:
-        result = cls(shape, filename, dtype)
-        result.f = io.open(result.filename, "wb")
-        return result
-
-    @classmethod
-    def fromtensor(cls, tensor: torch.Tensor, filename: str) -> SsdTensor:
-        result = cls(tensor.shape, filename, tensor.dtype)
-        write(tensor, result.filename)
-        return result
-
-    def __reduce_ex__(self, protocol: int) -> Tuple[Callable, Any, Any, Any]:
-        # adding _2 to the filename is just a hack to prevent overwriting the original SsdTensor data
-        return (
-            type(self).__unpickle__,
-            (
-                self.shape,
-                self.filename + "_2",
-                self.dtype,
-            ),
-            None,
-            iter(FileChunkingIterator(self.filename)),
-        )
-
-    def append(self, item: bytes) -> None:
-        assert self.f
-        self.f.write(item)
-
-    def extend(self, items: List[bytes]) -> None:
-        for i in items:
-            self.append(i)
-
-
-torch_saver = TorchSaver()

--- a/fairscale/experimental/nn/ssd_offload.py
+++ b/fairscale/experimental/nn/ssd_offload.py
@@ -209,7 +209,7 @@ class SsdTensorHandle(torch.Tensor):
         else:
             read(tensor, self.filename, self.offset * tensor.element_size())
 
-    __torch_function__ = torch._C._disabled_torch_function_impl
+    __torch_function__ = torch._C._disabled_torch_function_impl  # type: ignore
 
     @classmethod
     def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -65,6 +65,7 @@ else:
 
 try:
     import fairscale.experimental.nn.ssd_offload as ssd_offload
+    from fairscale.experimental.nn.ssd_offload import SsdFlatParameter
 
     import_ssd_offload = True
 except ImportError:
@@ -109,9 +110,9 @@ class OffloadConfig:
     """Class for specifying all arguments related to offloading parameters."""
 
     # Offload type: currently only supports: "ssd_offload"
-    offload_type: str = None
+    offload_type: Optional[str] = None
     # Path to the directory for storing parameters offloaded to disk.
-    ssd_filepath_dir: str = None
+    ssd_directory: Optional[str] = None
 
 
 class FullyShardedDataParallel(nn.Module):
@@ -300,7 +301,7 @@ class FullyShardedDataParallel(nn.Module):
         force_input_to_fp32: bool = False,
         verbose: bool = False,
         cpu_offload: bool = False,
-        offload_config: OffloadConfig = None,
+        offload_config: Optional[OffloadConfig] = None,
     ):
         init_start = time.time()
         super().__init__()
@@ -335,6 +336,9 @@ class FullyShardedDataParallel(nn.Module):
         if self.fp32_reduce_scatter and not self.mixed_precision:
             raise ValueError("fp32_reduce_scatter requires mixed_precision=True")
 
+        if self.ssd_offload and not self.flatten_parameters:
+            raise ValueError("ssd_offload requires flatten_parameters=True")
+
         # skip validation if the process group was created above
         if process_group:
             validate_process_group(self.compute_device, self.process_group)
@@ -358,13 +362,14 @@ class FullyShardedDataParallel(nn.Module):
         # TODO(anj): Should we conditionally do this only if we have params?
         # TODO(anj): Figure out if we can allocate the buffer during sharding.
         self.buffer_size = sum(p.numel() for p in params)
+        self.ssd_directory = ""
         if self.ssd_offload:
             assert import_ssd_offload, "We need to import ssd_offload.py to enable the `ssd_offload` feature."
-            self.ssd_buffer_filepath_dir = (
-                offload_config.ssd_filepath_dir if offload_config.ssd_filepath_dir else tempfile.gettempdir()
+            self.ssd_directory = (
+                offload_config.ssd_directory
+                if (offload_config and offload_config.ssd_directory)
+                else tempfile.gettempdir()
             )
-            self.ssd_buffer_filename = tempfile.mkstemp(dir=self.ssd_buffer_filepath_dir)
-            self.ssd_buffer = ssd_offload.SsdBuffer(self.buffer_size, self.ssd_buffer_filename[1])
             self.move_grads_to_cpu = True
             self.move_params_to_cpu = True
 
@@ -379,7 +384,9 @@ class FullyShardedDataParallel(nn.Module):
             param_name_groups = [param_names]
         del param_names
 
-        self._fsdp_wrapped_module: nn.Module = FlattenParamsWrapper(module, param_list=to_be_flatten_params)
+        self._fsdp_wrapped_module: nn.Module = FlattenParamsWrapper(
+            module, param_list=to_be_flatten_params, ssd_offload=self.ssd_offload, ssd_directory=self.ssd_directory
+        )
         del module  # free original module in case it helps garbage collection
 
         # Now, in this FSDP wrapper class, we keep a list of to-be-flatten and not-to-be-flatten
@@ -676,13 +683,7 @@ class FullyShardedDataParallel(nn.Module):
 
             if not p._is_sharded:
                 if self.ssd_offload:
-                    # Insert tensor into the SSD buffer and free parameter storage.
-                    p._is_sharded = False
-                    self.numel_padded_per_param.append(0)
-                    p._shard_size = p.data.size()  # type: ignore
-                    p._handle = self.ssd_buffer.insert(p.data)  # type: ignore
-                    free_storage_(p.data)
-                    continue
+                    pass
                 else:
                     p._is_sharded = False
                     self.numel_padded_per_param.append(0)
@@ -691,14 +692,11 @@ class FullyShardedDataParallel(nn.Module):
 
             # Replace p.data with the relevant shard.
             if self.ssd_offload:
-                orig_data = p.data
-                p.data, num_padded = self._get_shard(p.data)
-                p._shard_size = p.data.size()  # type: ignore
-                # Insert tensor into the SSD buffer and free parameter storage.
-                p._handle = self.ssd_buffer.insert(p.data)  # type: ignore
-                del orig_data
+                assert isinstance(p, SsdFlatParameter)
+                sharded_tensor, num_padded = self._get_shard(p.data)
+                p.point_to_resized_tensor(sharded_tensor)
                 self.numel_padded_per_param.append(num_padded)
-                free_storage_(p.data)
+                p.to_file()
             else:
                 orig_data = p.data
                 p.data, num_padded = self._get_shard(p.data)
@@ -706,10 +704,6 @@ class FullyShardedDataParallel(nn.Module):
                 free_storage_(orig_data)
 
         assert len(self.numel_padded_per_param) == len(self.params)
-
-        # Move SSD buffer to disk.
-        if self.ssd_offload:
-            self.ssd_buffer.to_disk()
 
     def _get_shard(self, tensor: torch.Tensor) -> Tuple[torch.Tensor, int]:
         """Return the local shard of a full tensor."""
@@ -791,11 +785,6 @@ class FullyShardedDataParallel(nn.Module):
         """Returns an iterator over the module parameters, yielding all the parameters
         part of the model.
         """
-        # TODO(anj): Use `copy_into_tensor` in order to provide a copy of the
-        # parameters and not the actual parameters. Ideally we don't users to operate on
-        # actual params.
-        if self.ssd_offload:
-            self.ssd_buffer.from_disk(self.buffer_size)
 
         return super().parameters(recurse=recurse)
 
@@ -810,12 +799,6 @@ class FullyShardedDataParallel(nn.Module):
         If you want the full param to be returned, you should call this function
         under a `summon_full_params` context when using flattened or original params.
         """
-        # TODO(anj): Use `copy_into_tensor` in order to provide a copy of the
-        # parameters and not the actual parameters. Ideally we don't users to operate on
-        # actual params.
-        if self.ssd_offload:
-            self.ssd_buffer.from_disk(self.buffer_size)
-
         named_param = super().named_parameters(*args, **kwargs)
         for name, param in named_param:
             if (
@@ -923,10 +906,9 @@ class FullyShardedDataParallel(nn.Module):
 
     def _move_params_to_memory(self) -> None:
         """Move params from disk to CPU."""
-        self.ssd_buffer.from_disk(self.buffer_size)
-
-        for p, handle in zip(self.params, self.ssd_buffer.get_tensors()):
-            p.data = handle.get_tensor().view(p._shard_size)  # type: ignore
+        for p in self.params:
+            assert isinstance(p, SsdFlatParameter)
+            p.to_tensor()
 
     def _load_state_dict(
         self, state_dict: Union[Dict[str, torch.Tensor], "OrderedDict[str, torch.Tensor]"], strict: bool = True
@@ -1072,14 +1054,14 @@ class FullyShardedDataParallel(nn.Module):
                         if safe_to_free:
                             free_storage_(full_tensor)
                     self.has_full_params = False
-                    self._use_fp32_param_shard()
                     if self.ssd_offload:
                         # Store tensors in the SSD buffer and free param storage.
                         for p in self.params:
-                            p._shard_size = p.data.size()  # type: ignore
-                            p._handle = self.ssd_buffer.insert(p.data)  # type: ignore
-                            free_storage_(p.data)
-                        self.ssd_buffer.to_disk()
+                            assert isinstance(p, SsdFlatParameter)
+                            p.to_file()
+                        # self._use_fp32_param_shard()
+                    else:
+                        self._use_fp32_param_shard()
                     self.training_state = TrainingState.IDLE
 
     def _reset_lazy_init(self) -> None:
@@ -1153,6 +1135,7 @@ class FullyShardedDataParallel(nn.Module):
             return
 
         # A single shard of the parameters in full precision.
+        # PJ this will cause memory leakage with ssd
         p._fp32_shard = p.data
 
         if self.mixed_precision:
@@ -1167,7 +1150,7 @@ class FullyShardedDataParallel(nn.Module):
                 # We don't pin memory when using ssd_offload since that results in OOM when
                 # the memory requirements of a model are larger than host memory.
                 p._fp32_shard = p._fp32_shard.pin_memory()
-            p.data = p._fp32_shard
+                p.data = p._fp32_shard
 
         if self.move_params_to_cpu or self.mixed_precision:
 
@@ -1206,9 +1189,12 @@ class FullyShardedDataParallel(nn.Module):
             # shard in pinned memory so that we can do a non-blocking transfer.
             # This is only needed during training and not evaluation.
             if self.ssd_offload:
-                # We don't pin memory when using ssd_offload since that results in OOM when
-                # the memory requirements of a model are larger than host memory.
-                p._cpu_grad = torch.zeros_like(p.data, device="cpu")
+                assert isinstance(p, SsdFlatParameter)
+                # Gradients also need to be offloaded to SSD otherwise it can result in
+                # OOMs when the memory requirements of a model are larger than host memory.
+                p._cpu_grad = ssd_offload.SsdTensorHandle.from_tensor(torch.zeros_like(p.data, device="cpu"))
+                p._cpu_grad.set_file_params(p.filename + "_grad", 0)
+                p._cpu_grad.to_file()
             else:
                 p._cpu_grad = torch.zeros_like(p.data, device="cpu").pin_memory()
 
@@ -1298,9 +1284,6 @@ class FullyShardedDataParallel(nn.Module):
             self._streams["all_gather"].wait_stream(torch.cuda.current_stream())
 
     def forward(self, *args: Any, **kwargs: Any) -> torch.Tensor:
-        if self.ssd_offload:
-            self._move_params_to_memory()
-
         self._lazy_init()
 
         # Start of a forward pass.
@@ -1365,7 +1348,9 @@ class FullyShardedDataParallel(nn.Module):
     @torch.no_grad()
     def _free_ssd_offload(self) -> None:
         if self.ssd_offload:
-            self.ssd_buffer.to_disk()
+            for p in self.params:
+                assert isinstance(p, SsdFlatParameter)
+                p.to_file(permit_when_tensor_none=True)
 
     def _register_pre_backward_hooks(self, outputs: Any) -> Any:
         """Register pre-backward hook to run before the wrapped module's
@@ -1405,7 +1390,9 @@ class FullyShardedDataParallel(nn.Module):
             # Note, both ``self._rebuild_full_params`` and ``self._use_full_params`` are
             # idempotent.  So in case they are called unnecessarily, they don't incur much
             # overhead.
-            if self.ssd_offload or self.reshard_after_forward:
+            # PJ TODO: Revisit if this is still needed for ssd_offload
+            # if self.ssd_offload or self.reshard_after_forward:
+            if self.reshard_after_forward:
                 self._rebuild_full_params()
             else:
                 self._use_full_params()
@@ -1730,7 +1717,8 @@ class FullyShardedDataParallel(nn.Module):
         for m in self.modules():  # includes self
             if isinstance(m, FullyShardedDataParallel):
                 _finalize_parameters(m)
-                self._free_ssd_offload()
+                # PJ: I don't understand this, should it be m._free_ssd_offload?
+                m._free_ssd_offload()
                 m._pre_backward_hook_has_run = False
                 if any(p.requires_grad for p in m.parameters()):
                     # Check if the module has params and if any of them has
@@ -1808,12 +1796,9 @@ class FullyShardedDataParallel(nn.Module):
             p.data = p.data[: p._orig_size.numel()].view(p._orig_size)
 
         if self.ssd_offload:
-            self.ssd_buffer.from_disk(self.buffer_size)
-
-            # The params are on disk and need to be moved to the CPU.
-            for p, handle in zip(self.params, self.ssd_buffer.get_tensors()):
-                p._fp32_shard = handle.get_tensor().view(p._shard_size)  # type: ignore
-                p.data = p._fp32_shard
+            for p in self.params:
+                assert isinstance(p, SsdFlatParameter)
+                p.to_tensor()
 
             self.has_full_params = False
 

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1129,8 +1129,11 @@ class FullyShardedDataParallel(nn.Module):
             return
 
         # A single shard of the parameters in full precision.
-        # TODO: PJ - I believe this will cause memory leakage with ssd
-        #            investigate after PR #887 is merged
+        # TODO(another-pjohnson) - I believe this will cause memory leakage with ssd
+        #            p.data returns a pointer to a handle, and that handle has it's
+        #            ref count incremented by p._fp32_shard. So this tensor will
+        #            never be freed even if we do p.to_disk(). investigate after
+        #            PR #887 is merged
         p._fp32_shard = p.data
 
         if self.mixed_precision:

--- a/stubs/torch/serialization.pyi
+++ b/stubs/torch/serialization.pyi
@@ -1,5 +1,10 @@
-from typing import Any, BinaryIO, Union
+import os
+import pickle
+from typing import Any, BinaryIO, Callable, IO, Union
 
-def save(obj, f: Union[str, BinaryIO]) -> None: ...
+DEFAULT_PROTOCOL: int = 2
+
+def save(obj, f: Union[str, os.PathLike, BinaryIO, IO[bytes]],
+         pickle_module: Any=pickle, pickle_protocol: int=DEFAULT_PROTOCOL, _use_new_zipfile_serialization: bool=True) -> None: ...
 
 def load(f: Union[str, BinaryIO], map_location) -> Any: ...

--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -4,9 +4,11 @@
 # LICENSE file in the root directory of this source tree.
 
 """
-Testing SsdBuffer and SsdTensorHandle modules.
+Testing SsdFlatParameter and SsdTensorHandle modules.
 """
 
+import filecmp
+import os
 import tempfile
 
 import numpy as np
@@ -38,6 +40,8 @@ def test_write_read():
 
 
 def test_ssd_handle_dispatch_fwd():
+    _init()
+
     with tempfile.NamedTemporaryFile() as f:
         orig_tensor = torch.randn((128))
         ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
@@ -54,6 +58,8 @@ def test_ssd_handle_dispatch_fwd():
 
 
 def test_ssd_handle_dispatch_bwd():
+    _init()
+
     with tempfile.NamedTemporaryFile() as f:
         orig_tensor = torch.randn((4, 4), requires_grad=True)
         orig_copy = orig_tensor.clone().detach().requires_grad_(True)
@@ -68,98 +74,115 @@ def test_ssd_handle_dispatch_bwd():
         y1.sum().backward()
         y2.sum().backward()
 
-        # TODO: PJ/ASenable assert once Tensor._make_subclass can properly define the tensor's shape
-        # assert torch.equal(ssd_handle.grad, orig_copy.grad)
+        assert torch.equal(ssd_handle.grad, orig_copy.grad)
 
 
-def test_ssd_buffer_basic():
+def test_ssd_handle_train_simple():
+    _init()
+
+    with tempfile.NamedTemporaryFile() as f:
+        orig_tensor = torch.randn((4, 4), requires_grad=True)
+
+        with torch.no_grad():
+            orig_copy = torch.empty_like(orig_tensor)
+            orig_copy.copy_(orig_tensor)
+            orig_copy.requires_grad = True
+
+        ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
+        ssd_handle.set_file_params(f.name, 0)
+        ssd_handle.to_file(release_tensor_after_write=True)
+
+        assert torch.equal(ssd_handle.to_tensor(), orig_tensor)
+        optimizer_ssd = torch.optim.SGD([ssd_handle], lr=0.1)
+        optimizer_orig = torch.optim.SGD([orig_copy], lr=0.1)
+
+        y1 = ssd_handle + 1
+        optimizer_ssd.zero_grad()
+        y1.sum().backward()
+        optimizer_ssd.step()
+
+        y2 = orig_copy + 1
+        optimizer_orig.zero_grad()
+        y2.sum().backward()
+        optimizer_orig.step()
+
+        # make sure we are using the file version not the cached tensor
+        ssd_handle.point_to_file(f.name, 0)
+        assert torch.equal(ssd_handle.to_tensor(), orig_copy)
+
+
+def test_torch_save_load():
+    _init()
+    orig_file = tempfile.NamedTemporaryFile()
+    checkpoint_file = tempfile.NamedTemporaryFile()
+
+    # TENSOR_SHAPE = (1024, 1024, 1024)
+    # use smaller shape for unit tests
+    TENSOR_SHAPE = (1024, 1024)
+    ref_tensor = torch.rand(TENSOR_SHAPE, dtype=torch.float32)
+    ref_ssd_tensor = so.SsdTensor.fromtensor(ref_tensor, orig_file.name)
+    del ref_tensor
+    # after deleting ref_tensor, memory usage should be very low
+    # For save it shouldn't be more than 10x so.DEFAULT_CHUNK_SIZE
+    so.torch_saver.save(ref_ssd_tensor, checkpoint_file.name)
+    # below line saves file to orig_file.name+"_2"
+    # Memory usage here should be O(1000 * so.DEFAULT_CHUNK_SIZE)
+    # 1000x because that's how many elements the python unpickler
+    # will buffer before passing to the SsdTensor
+    test_ssd_tensor = torch.load(checkpoint_file)
+    assert filecmp.cmp(orig_file.name, orig_file.name + "_2", shallow=False)
+    os.unlink(orig_file.name + "_2")
+
+
+def test_ssd_param_train_simple():
     _init()
     with tempfile.NamedTemporaryFile() as f:
-        refa_tensor = torch.rand((128), dtype=torch.float32)
-        refb_tensor = torch.rand((128), dtype=torch.float32)
-        refc_tensor = torch.rand((128), dtype=torch.float32)
-        ssd_buf = so.SsdBuffer(1024, f.name)
+        orig_tensor = torch.randn((4, 4))
 
-        hdl_a = ssd_buf.insert(refa_tensor)
-        hdl_b = ssd_buf.insert(refb_tensor)
-        hdl_c = ssd_buf.insert(refc_tensor)
+        with torch.no_grad():
+            orig_copy = torch.empty_like(orig_tensor)
+            orig_copy.copy_(orig_tensor)
+            param = torch.nn.Parameter(orig_copy)
 
-        assert hdl_a.is_available()
-        assert hdl_b.is_available()
-        assert hdl_c.is_available()
+        ssd_param = so.SsdParameter(orig_tensor.shape, orig_tensor.dtype)
+        ssd_param.point_to_tensor(orig_copy)
+        ssd_param.set_file_params(f.name, 0)
+        ssd_param.to_file(release_tensor_after_write=True)
 
-        assert torch.equal(refa_tensor, hdl_a.get_tensor())
-        assert torch.equal(refb_tensor, hdl_b.get_tensor())
-        assert torch.equal(refc_tensor, hdl_c.get_tensor())
+        assert torch.equal(ssd_param.to_tensor(), orig_tensor)
+        optimizer_ssd = torch.optim.SGD([ssd_param], lr=0.1)
+        optimizer_orig = torch.optim.SGD([param], lr=0.1)
 
-        tensors = ssd_buf.get_tensors()
-        assert hdl_a is tensors[0]
-        assert hdl_b is tensors[1]
-        assert hdl_c is tensors[2]
+        y1 = ssd_param + 1
+        optimizer_ssd.zero_grad()
+        y1.sum().backward()
+        optimizer_ssd.step()
 
-        # test read_into_tensor when handle.is_available()
-        b_tensor_copy1 = torch.empty_like(refb_tensor)
-        hdl_b.copy_into_tensor(b_tensor_copy1)
-        assert torch.equal(refb_tensor, b_tensor_copy1)
+        y2 = param + 1
+        optimizer_orig.zero_grad()
+        y2.sum().backward()
+        optimizer_orig.step()
 
-        # remove references so memory will be cleaned up
-        buffer = None
-
-        ssd_buf.to_disk()
-
-        assert hdl_a.filename == f.name
-        assert hdl_b.filename == f.name
-        assert hdl_c.filename == f.name
-
-        assert hdl_a.offset == 0
-        assert hdl_b.offset == 128
-        assert hdl_c.offset == 256
-
-        assert not hdl_a.is_available()
-        assert not hdl_b.is_available()
-        assert not hdl_c.is_available()
-
-        # test read_into_tensor when !handle.is_available()
-        b_tensor_copy2 = torch.empty_like(refb_tensor)
-        hdl_b.copy_into_tensor(b_tensor_copy2)
-        assert torch.equal(refb_tensor, b_tensor_copy2)
-
-        ssd_buf.from_disk(384)
-
-        assert hdl_a.is_available()
-        assert hdl_b.is_available()
-        assert hdl_c.is_available()
-
-        assert torch.equal(refa_tensor, hdl_a.get_tensor())
-        assert torch.equal(refb_tensor, hdl_b.get_tensor())
-        assert torch.equal(refc_tensor, hdl_c.get_tensor())
+        # make sure we are using the file version not the cached tensor
+        ssd_param.point_to_file(f.name, 0)
+        assert torch.equal(ssd_param.to_tensor(), param)
 
 
-def test_ssd_buffer_too_small_from_disk():
+def test_ssd_flat_parameter_basic():
     _init()
     with tempfile.NamedTemporaryFile() as f:
-        refa_tensor = torch.rand((128), dtype=torch.float32)
-        ssd_buf = so.SsdBuffer(128, f.name)
-        hdl_a = ssd_buf.insert(refa_tensor)
-        ssd_buf.to_disk()
+        refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
+        refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
+        refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32))
+        ssd_flat_param = so.SsdFlatParameter([refa_param, refb_param, refc_param], f.name, False)
 
-        with pytest.raises(RuntimeError):
-            ssd_buf.from_disk(127)
+        param_views = list(ssd_flat_param.get_param_views())
 
+        assert refa_param.shape == param_views[0].shape
+        assert refb_param.shape == param_views[1].shape
+        assert refc_param.shape == param_views[2].shape
 
-def test_ssd_buffer_null_buffer():
-    _init()
-    with tempfile.NamedTemporaryFile() as f:
-        refa_tensor = torch.rand((128), dtype=torch.float32)
-        ssd_buf = so.SsdBuffer(128, f.name)
-        hdl_a = ssd_buf.insert(refa_tensor)
-        ssd_buf.to_disk()
-
-        with pytest.raises(AssertionError):
-            hdl_a = ssd_buf.insert(refa_tensor)
-
-        with pytest.raises(AssertionError):
-            ssd_buf.can_alloc(128)
-
-        with pytest.raises(AssertionError):
-            hdl = ssd_buf.allocate(128)
+        assert torch.equal(refa_param, param_views[0])
+        assert torch.equal(refb_param, param_views[1])
+        assert torch.equal(refc_param, param_views[2])
+        ssd_flat_param.to_file()

--- a/tests/nn/data_parallel/test_fsdp_offload.py
+++ b/tests/nn/data_parallel/test_fsdp_offload.py
@@ -123,6 +123,9 @@ class DistributedTest(unittest.TestCase):
 
 keys = ["reshard_after_forward", "mixed_precision", "flatten_parameters", "nested_wrapping"]
 CONFIG_OPTIONS = [[dict(zip(keys, config))] for config in itertools.product([True, False], repeat=len(keys))]
+CONFIG_OPTIONS_STATIC = [
+    [{"flatten_parameters": True, "mixed_precision": False, "nested_wrapping": False, "reshard_after_forward": False}]
+]
 
 
 def rename_test(testcase_func, param_num, param):
@@ -152,7 +155,7 @@ class TestSsdMemory(DistributedTest):
         time_keeper.print_time("CPU_MODEL", 1.0)
 
         with tempfile.TemporaryDirectory() as current_tempdir:
-            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_filepath_dir=current_tempdir)
+            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
 
             model = FullyShardedDataParallel(model, **config)
             time_keeper.print_time("FSDP_MODEL", 1.0)
@@ -223,7 +226,7 @@ class TestModuleProperties(DistributedTest):
 
         with tempfile.TemporaryDirectory() as current_tempdir:
             if config["ssd_offload"]:
-                config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_filepath_dir=current_tempdir)
+                config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
             del config["ssd_offload"]
 
             model = FullyShardedDataParallel(before_wrap_model, **config)
@@ -259,6 +262,46 @@ class TestSsdLoading(DistributedTest):
     @parameterized.expand(CONFIG, name_func=rename_test)
     def test_transformer_parameterized(self, config):
         spawn_and_init(functools.partial(self._test_identical_outputs_eval, TransformerWithSharedParams, config))
+
+    # @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
+    @parameterized.expand(CONFIG_OPTIONS_STATIC, name_func=rename_test)
+    def test_ssd_offloading_train_flatten_params_wrapper(self, config):
+        test_fn = functools.partial(self._test_ssd_offloading_train_flatten_params_wrapper, config=config)
+        spawn_and_init(test_fn)
+
+    @classmethod
+    def _test_ssd_offloading_train_flatten_params_wrapper(self, rank, group, config):
+        SIZE = 16 * 16
+        model = SimpleLinear(group, input_size=SIZE, output_size=SIZE, layers=4)
+
+        with tempfile.TemporaryDirectory() as current_tempdir:
+            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
+
+            nested_wrapping = config["nested_wrapping"]
+            del config["nested_wrapping"]
+
+            if nested_wrapping:
+                model = FullyShardedDataParallel(
+                    NestedWrappedModule(group, wrap_everything=True, wrapper_config=config)
+                )
+            else:
+                model = FullyShardedDataParallel(model, **config)
+            model_device = torch.device("cuda")
+            model.train()
+            optim = torch.optim.SGD(model.parameters(), lr=4, momentum=0.9)
+            # Inputs always cuda regardless of move_grads_cpu, or model.device
+            for i in range(10):
+                optim.zero_grad()
+                input = model.get_input(torch.device("cuda"))
+                output = model(*input)
+                loss = model.module.get_loss(input, output).to(model_device)
+                assert loss.dtype == torch.float32
+
+                model.module.run_backward(loss)
+                optim.step()
+
+            if isinstance(model, FullyShardedDataParallel):
+                model.assert_state(TrainingState.IDLE)
 
     @classmethod
     def _test_ssd_offload_eval(self, rank, group, config):

--- a/tests/nn/data_parallel/test_fsdp_offload.py
+++ b/tests/nn/data_parallel/test_fsdp_offload.py
@@ -154,7 +154,7 @@ class TestSsdMemory(DistributedTest):
         time_keeper.print_time("CPU_MODEL", 1.0)
 
         with tempfile.TemporaryDirectory() as current_tempdir:
-            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
+            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", dir=current_tempdir)
 
             model = FullyShardedDataParallel(model, **config)
             time_keeper.print_time("FSDP_MODEL", 1.0)
@@ -225,7 +225,7 @@ class TestModuleProperties(DistributedTest):
 
         with tempfile.TemporaryDirectory() as current_tempdir:
             if config["ssd_offload"]:
-                config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
+                config["offload_config"] = OffloadConfig(offload_type="ssd_offload", dir=current_tempdir)
                 # ssd offload only supports flatten_params ATM
                 config["flatten_parameters"] = True
             del config["ssd_offload"]
@@ -275,7 +275,7 @@ class TestSsdLoading(DistributedTest):
         model = SimpleLinear(group, input_size=SIZE, output_size=SIZE, layers=4)
 
         with tempfile.TemporaryDirectory() as current_tempdir:
-            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
+            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", dir=current_tempdir)
             config["flatten_parameters"] = True
 
             nested_wrapping = config["nested_wrapping"]
@@ -315,7 +315,7 @@ class TestSsdLoading(DistributedTest):
         config["flatten_parameters"] = True
 
         with tempfile.TemporaryDirectory() as current_tempdir:
-            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", ssd_directory=current_tempdir)
+            config["offload_config"] = OffloadConfig(offload_type="ssd_offload", dir=current_tempdir)
             if nested_wrapping:
                 model = FullyShardedDataParallel(
                     NestedWrappedModule(group, wrap_everything=True, wrapper_config=config)


### PR DESCRIPTION
## What does this PR do?
This PR completes the initial changes required to support training w/ ssd_offload enabled

 * Add SsdFlatParameter paralleling FlatParameter
 * Removing SsdBuffer and SsdTensorHandleView as SsdFlatParameter replaces the need for both of these.
 * Adding unit tests to fairscale/tests/experimental/nn/test_ssd_offload.py
 * Add full training test to fairscale/tests/nn/data_parallel/test_fsdp_offload.py


## Before submitting

- [ X] Did you have fun?
  - Make sure you had fun coding 🙃
- [ X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [X ] N/A
- [ ] Did you make sure to update the docs?
  - [ X] N/A
- [X ] Did you write any new necessary tests?
  - [X ] fairscale/tests/experimental/nn/test_ssd_offload.py
  - [ X] fairscale/tests/nn/data_parallel/test_fsdp_offload.py
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [X ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
