### PR TITLE
[Fix] - Finiteness check for all tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [0.4.4] - TBD
+
+### Fixed
+- inf/nan check on all gradient tensors in ShardedGradScaler [#890]
+
 ### Added
 
 ### Changed

--- a/fairscale/optim/grad_scaler.py
+++ b/fairscale/optim/grad_scaler.py
@@ -156,7 +156,7 @@ class ShardedGradScaler(TorchGradScaler):
         assert found_inf.numel() == 1, "found_inf must be a 1-element tensor."
 
         expected_device = grads[0].device
-        for tensor in grads[0]:
+        for tensor in grads:
             try:
                 assert tensor.device == expected_device, "grads must be on the same device"
             except AssertionError:


### PR DESCRIPTION
## What does this PR do?

Fixes a bug in the ShardedGradScaler. Initially only the first tensor in the gradient was check for inf/nan. This has been modified to make sure all tensors are checked for inf/nan now.


## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [x] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [x] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
