### PR TITLE
[FSDP] Add an arg for FSDP __init__

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -205,11 +205,10 @@ class FullyShardedDataParallel(nn.Module):
             memory but slows training. This is only relevant when resharding
             individual layers.
         disable_reshard_on_root (bool, Optional):
-            if ``True``, reshard_after_forward will be set to False if the module is a FSDP root module.
-            It helps to improve the performance by setting disable_reshard_on_root to True if a FSDP root
-            module is the root of the entire modules.
-            For that case, we do not reshard full parameters of FSDP modules since those parameters are needed
-            immediately for the backward pass.
+            If ``True``, ``reshard_after_forward`` will be set to ``False`` if the module is a
+            FSDP root module to improve performance.
+            If ``False``, the performance will be lower, but it is needed because ....
+            Default: True.
         mixed_precision (bool, Optional):
             if ``True``, inputs, activations and gradients will be kept in FP16;
             computation and communication will occur in FP16; and a (sharded)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -206,8 +206,13 @@ class FullyShardedDataParallel(nn.Module):
             individual layers.
         disable_reshard_on_root (bool, Optional):
             If ``True``, ``reshard_after_forward`` will be set to ``False`` if the module is a
-            FSDP root module to improve performance.
-            If ``False``, the performance will be lower, but it is needed because ....
+            FSDP root module to improve performance. For some cases, we do not reshard the full
+            parameters of an FSDP root module since those parameters are needed immediately for the
+            backward pass.
+            If ``False``, the performance will be lower, but it is needed because it helps to
+            save memory. Consider a case that an FSDP root module is a submodule of a model.
+            Backward pass may not start immediate after the FSDP root module finishes its forward.
+            So, reshard the parameters for the FSDP root modules can help to save memory in this case.
             Default: True.
         mixed_precision (bool, Optional):
             if ``True``, inputs, activations and gradients will be kept in FP16;

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -205,10 +205,11 @@ class FullyShardedDataParallel(nn.Module):
             memory but slows training. This is only relevant when resharding
             individual layers.
         disable_reshard_on_root (bool, Optional):
-            if ``True``, reshard_after_forward will be set to False if the module is a root.
-            For some cases, the full parameters of root do not need to be sharded in order to
-            improve performance. It is because the parameters are needed immediately
-            for the backward pass.
+            if ``True``, reshard_after_forward will be set to False if the module is a FSDP root module.
+            It helps to improve the performance by setting disable_reshard_on_root to True if a FSDP root
+            module is the root of the entire modules.
+            For that case, we do not reshard full parameters of FSDP modules since those parameters are needed
+            immediately for the backward pass.
         mixed_precision (bool, Optional):
             if ``True``, inputs, activations and gradients will be kept in FP16;
             computation and communication will occur in FP16; and a (sharded)


### PR DESCRIPTION
Add an arg, disable_reshard_on_root, for FSDP __init__ to handle the following issue
https://github.com/facebookresearch/fairscale/issues/878
For some cases (models wrapped by autowrap), the parameters (of root modules) needs to be sharded, and reshard_after_forward should not be set to False.
"disable_reshard_on_root" is for users to choose whether to force reshard_after_forward of root modules to be False or not.

## What does this PR do?
Fixes [# 878](https://github.com/facebookresearch/fairscale/issues/878).

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
