### PR TITLE
[fix] Add option to wrap root module in auto_wrap

### DIFF
--- a/fairscale/nn/wrap/auto_wrap.py
+++ b/fairscale/nn/wrap/auto_wrap.py
@@ -18,7 +18,7 @@ def default_auto_wrap_policy(
     min_num_params: int = int(1e8),
     force_leaf_modules: Optional[Set[Type[nn.Module]]] = None,
     exclude_wrap_modules: Optional[Set[Type[nn.Module]]] = None,
-    skip_params_check_for_root: bool = True,
+    skip_params_check_for_root: bool = False,
 ) -> bool:
     """Default policy function for :func:`auto_wrap`.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ use_parentheses = true
 skip_glob = ["build/*", "stubs/*"]
 # Don't split "import" and "from".
 force_sort_within_sections = true
-known_third_party = ["benchmark_dataset", "datasets, "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "utils"]
+known_third_party = ["benchmark_dataset", "datasets", "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "utils"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ use_parentheses = true
 skip_glob = ["build/*", "stubs/*"]
 # Don't split "import" and "from".
 force_sort_within_sections = true
-known_third_party = ["benchmark_dataset", "datasets", "distutils", "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "utils"]
+known_third_party = ["benchmark_dataset", "datasets, "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "utils"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,4 +27,4 @@ use_parentheses = true
 skip_glob = ["build/*", "stubs/*"]
 # Don't split "import" and "from".
 force_sort_within_sections = true
-known_third_party = ["benchmark_dataset", "datasets", "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "utils"]
+known_third_party = ["benchmark_dataset", "datasets", "distutils", "golden_configs", "models", "numpy", "parameterized", "pytest", "recommonmark", "setuptools", "sklearn", "torch", "torchtext", "torchvision", "utils"]

--- a/tests/nn/wrap/test_wrap.py
+++ b/tests/nn/wrap/test_wrap.py
@@ -75,6 +75,21 @@ class TestAutoWrap(unittest.TestCase):
         assert isinstance(model[0], nn.Linear)
         assert isinstance(model[1], nn.Linear)
 
+    def test_auto_wrap_preset_exclude_wrap_include_root(self):
+        """
+        Test to ensure excluded modules are not wrapped, regardless if the total param size is greater than the
+        min_num_params.
+        """
+        with enable_wrap(
+            wrapper_cls=FSDP, process_group=self.process_group, flatten_parameters=False, wrap_root_module=True
+        ):
+            sequential = nn.ModuleList([nn.Linear(5, 5), nn.Linear(5, 5)])
+            my_auto_wrap_policy = functools.partial(default_auto_wrap_policy, min_num_params=40)
+            model = auto_wrap(sequential, auto_wrap_policy=my_auto_wrap_policy)
+        assert isinstance(model, FSDP)
+        assert isinstance(model[0], nn.Linear)
+        assert isinstance(model[1], nn.Linear)
+
     def test_auto_wrap_preset_exclude_wrap_include_children(self):
         """
         Test to ensure excluded modules are not wrapped, but children are if param size is greater than

--- a/tests/nn/wrap/test_wrap.py
+++ b/tests/nn/wrap/test_wrap.py
@@ -48,36 +48,35 @@ class TestAutoWrap(unittest.TestCase):
         """
         Test to ensure with auto wrap, we wrap child modules correctly based on the min_num_params.
         ``nn.Linear(5, 5)`` does not exceed the bucket size, but combined they do.
-        Root is also wrapped regardless of number of unwrapped params due to default_auto_wrap_policy
-        behavior.
+        Root is not wrapped given there are not enough unwrapped params left and skip_params_check_for_root
+        is not set.
         """
         with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group, flatten_parameters=False):
             sequential = nn.Sequential(nn.Linear(5, 5), nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5)))
             my_auto_wrap_policy = functools.partial(default_auto_wrap_policy, min_num_params=60)
-            model = auto_wrap(sequential, auto_wrap_policy=my_auto_wrap_policy)
-        assert isinstance(model, FSDP)
-        assert isinstance(model.module[0], nn.Linear)
-        assert isinstance(model.module[1], FSDP)
-        assert isinstance(model.module[1].module[0], nn.Linear)
-        assert isinstance(model.module[1].module[1], nn.Linear)
-
-    def test_auto_wrap_without_skip_root_checks(self):
-        """
-        Similar test as before but this time we set skip_params_check_for_root=False in the wrap policy.
-        Given the root doesn't have enough remaining params after some of the children are wrapped,
-        it doesn't get wrapped.
-        """
-        with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group, flatten_parameters=False):
-            sequential = nn.Sequential(nn.Linear(5, 5), nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5)))
-            my_auto_wrap_policy = functools.partial(
-                default_auto_wrap_policy, min_num_params=60, skip_params_check_for_root=False
-            )
             model = auto_wrap(sequential, auto_wrap_policy=my_auto_wrap_policy)
         assert isinstance(model, nn.Sequential)
         assert isinstance(model[0], nn.Linear)
         assert isinstance(model[1], FSDP)
         assert isinstance(model[1].module[0], nn.Linear)
         assert isinstance(model[1].module[1], nn.Linear)
+
+    def test_auto_wrap_skip_root_checks(self):
+        """
+        Similar test as before but this time we set skip_params_check_for_root=True in the wrap policy.
+        So in this case the root is wrapped even without enough remaining unwrapped params.
+        """
+        with enable_wrap(wrapper_cls=FSDP, process_group=self.process_group, flatten_parameters=False):
+            sequential = nn.Sequential(nn.Linear(5, 5), nn.Sequential(nn.Linear(5, 5), nn.Linear(5, 5)))
+            my_auto_wrap_policy = functools.partial(
+                default_auto_wrap_policy, min_num_params=60, skip_params_check_for_root=True
+            )
+            model = auto_wrap(sequential, auto_wrap_policy=my_auto_wrap_policy)
+        assert isinstance(model, FSDP)
+        assert isinstance(model.module[0], nn.Linear)
+        assert isinstance(model.module[1], FSDP)
+        assert isinstance(model.module[1].module[0], nn.Linear)
+        assert isinstance(model.module[1].module[1], nn.Linear)
 
     def test_auto_wrap_preset_exclude_wrap(self):
         """

--- a/tests/nn/wrap/test_wrap.py
+++ b/tests/nn/wrap/test_wrap.py
@@ -77,8 +77,8 @@ class TestAutoWrap(unittest.TestCase):
 
     def test_auto_wrap_preset_exclude_wrap_include_root(self):
         """
-        Test to ensure excluded modules are not wrapped, regardless if the total param size is greater than the
-        min_num_params.
+        Test to ensure excluded modules are not wrapped while root is still wrapped given wrap_root_module
+        is set explicitly.
         """
         with enable_wrap(
             wrapper_cls=FSDP, process_group=self.process_group, flatten_parameters=False, wrap_root_module=True


### PR DESCRIPTION
## What does this PR do?
Fixes # [791](https://github.com/facebookresearch/fairscale/issues/791).

The issue is that the root/outer module sometimes is not wrapped, depending on whether there are enough params left after children are covered by recursive wrapping: https://github.com/facebookresearch/fairscale/blob/main/fairscale/nn/wrap/auto_wrap.py#L299

So I've added a new input param to `default_auto_wrap_policy` to tell us if the current module is the root, and a new flag that allows us to wrap the root regardless of number of unwrapped params (flag is enabled by default).

Adjusted test-cases to show more clearly behavior with and without the new flag when there are not enough params left for root module. 
