### PR TITLE
[fix][FSDP] Add support for saving optimizer state with expert replication 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - FSDP: Added skip_params_check_for_root flag to default_auto_wrap_policy which,
   if set, wraps the root module regardless of how many unwrapped params there were
   left after children were wrapped. [#930]
+- FSDP: Add support for saving optimizer state when using expert replicas with FSDP.
+  
 
 ## [0.4.5] - 2022-01-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   if set, wraps the root module regardless of how many unwrapped params there were
   left after children were wrapped. [#930]
 - FSDP: Add support for saving optimizer state when using expert replicas with FSDP.
-  
 
 ## [0.4.5] - 2022-01-14
 

--- a/fairscale/nn/data_parallel/fsdp_optim_utils.py
+++ b/fairscale/nn/data_parallel/fsdp_optim_utils.py
@@ -97,6 +97,7 @@ def _unflatten_optim_state(
     next_global_id = 0  # gets incremented
     pad_info = {id: [s[id][0] for s in world_pad_info] for id in combined_state}
     local_ids = [id for id in sorted(combined_state.keys())]
+
     # non_tensor_state refers to entries in sd[state][param_id] that are not tensors, like "step".
     # we check that these are identical across workers and then take the first
     non_tensor_state = [_extract_non_tensor_state(combined_state, id) for id in combined_state]
@@ -152,6 +153,7 @@ def _unflatten_optim_state(
                 global_id = local_to_global[local_id][0]
                 unflat_state[global_id][k] = flat_buffer
             unflat_state[global_id].update(singleton_state[local_id])
+
     return unflat_state, global_to_local_id
 
 

--- a/fairscale/nn/data_parallel/fsdp_optim_utils.py
+++ b/fairscale/nn/data_parallel/fsdp_optim_utils.py
@@ -97,7 +97,6 @@ def _unflatten_optim_state(
     next_global_id = 0  # gets incremented
     pad_info = {id: [s[id][0] for s in world_pad_info] for id in combined_state}
     local_ids = [id for id in sorted(combined_state.keys())]
-
     # non_tensor_state refers to entries in sd[state][param_id] that are not tensors, like "step".
     # we check that these are identical across workers and then take the first
     non_tensor_state = [_extract_non_tensor_state(combined_state, id) for id in combined_state]
@@ -153,7 +152,6 @@ def _unflatten_optim_state(
                 global_id = local_to_global[local_id][0]
                 unflat_state[global_id][k] = flat_buffer
             unflat_state[global_id].update(singleton_state[local_id])
-
     return unflat_state, global_to_local_id
 
 

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2240,6 +2240,8 @@ class FullyShardedDataParallel(nn.Module):
             non_shared_params = cast(FullyShardedDataParallel, self._fsdp_instances[k]).non_shared_params()
             non_shared_world_size = self._fsdp_instances[k].world_size
             non_shared_process_group = self._fsdp_instances[k].process_group
+            # This is the world size and process group of the FSDP submodule which can be
+            # different than the parent module.
             if non_shared_world_size != self.world_size:
                 world_size = non_shared_world_size
                 process_group = non_shared_process_group

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2304,7 +2304,6 @@ class FullyShardedDataParallel(nn.Module):
         assert len(sd["param_groups"]) == 1, "Param groups are not supported"
         # We use all_gather to consolidate OSD['state'] and broadcast to consolidate the other keys (like param_groups)
         state, singleton_state = self._gather_optim_state(sd.pop("state"))
-
         pad_info = self._broadcast_pad_info_to_r0()
         if self.rank != 0:
             return None

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2255,7 +2255,7 @@ class FullyShardedDataParallel(nn.Module):
             buffer = None  # for sharded tensors
             singleton_buffer = None  # for singleton tensors
             for buffer_name, t in v.items():
-               
+
                 if torch.is_tensor(t):
                     t = t.to(self.compute_device)
 
@@ -2386,8 +2386,7 @@ class FullyShardedDataParallel(nn.Module):
         if torch.distributed.get_rank() == 0:
             keys = full_optim_state_dict["state"][2]["exp_avg"]
             print(f"FSDP {keys.size()}")
-            
-            
+
         # get the portion of dict associated with the shard, in place
         for id, s in full_optim_state_dict["state"].items():
             for k, v in s.items():

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -774,7 +774,8 @@ class DummyDDP(nn.Module):
 
 
 class MixtureOfExperts(NestedWrappedModule):
-    def __init__(self, group, wrapper_config, checkpoint_act=False, delay_before_free_ms=0):
+    def __init__(self, group, wrapper_config, checkpoint_act=False, delay_before_free_ms=0,
+                 expert_group=None):
         super().__init__(group, wrapper_config)
         self.group = group
         self.delay_before_free_ms = delay_before_free_ms
@@ -800,9 +801,9 @@ class MixtureOfExperts(NestedWrappedModule):
             shared = checkpoint_wrapper(shared)
 
         if wrapper_config is not None:
-            # we create a process group of size 1 for the expert params
+            # we create a process group of size >= 1 for the expert params
             # we also need to pass that group as the reduce_scatter group.
-            expert_group = torch.distributed.new_group([group.rank()])
+            expert_group = expert_group or torch.distributed.new_group([group.rank()])
             expert = FullyShardedDataParallel(
                 expert, process_group=expert_group, process_group_reduce_scatter=expert_group, **wrapper_config
             )

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -481,7 +481,7 @@ class TestReduceScatterProcessGroup(DistributedTest):
             return FullyShardedDataParallel(model, group, **config)
 
 
-@pytest.mark.skip(reasone="Recently flaky and not reproducible locally.")
+@pytest.mark.skip(reason="Recently flaky and not reproducible locally.")
 class TestSerialization(DistributedTest):
     @parameterized.expand([[False, False], [True, False], [True, True], [False, True]], name_func=rename_test)
     def test_pickle(self, mixed_precision, cpu_offload):

--- a/tests/nn/data_parallel/test_fsdp.py
+++ b/tests/nn/data_parallel/test_fsdp.py
@@ -774,8 +774,7 @@ class DummyDDP(nn.Module):
 
 
 class MixtureOfExperts(NestedWrappedModule):
-    def __init__(self, group, wrapper_config, checkpoint_act=False, delay_before_free_ms=0,
-                 expert_group=None):
+    def __init__(self, group, wrapper_config, checkpoint_act=False, delay_before_free_ms=0, expert_group=None):
         super().__init__(group, wrapper_config)
         self.group = group
         self.delay_before_free_ms = delay_before_free_ms

--- a/tests/nn/data_parallel/test_fsdp_optimizer_utils.py
+++ b/tests/nn/data_parallel/test_fsdp_optimizer_utils.py
@@ -218,8 +218,6 @@ class TestOptimizerUtils(DistributedTest):
             [v for k, v in shard_sd["param_groups"][0].items()],
             [v for k, v in original_shard_sd["param_groups"][0].items()],
         )
-        shard_state = shard_sd["state"]
-        orig_state = original_shard_sd["state"]
         assert objects_are_equal(shard_sd["state"], original_shard_sd["state"])
         assert objects_are_equal({k: shard_sd[k] for k in original_shard_sd}, original_shard_sd)
 

--- a/tests/nn/data_parallel/test_fsdp_optimizer_utils.py
+++ b/tests/nn/data_parallel/test_fsdp_optimizer_utils.py
@@ -4,7 +4,7 @@
 # LICENSE file in the root directory of this source tree.
 import functools
 from time import time
-
+import unittest
 from parameterized import parameterized
 import torch
 from torch.optim import SGD, Adadelta, Adam  # type: ignore
@@ -12,7 +12,7 @@ from torch.optim import SGD, Adadelta, Adam  # type: ignore
 from fairscale.nn import FullyShardedDataParallel
 from fairscale.nn.data_parallel.fsdp_optim_utils import is_singleton_tensor
 from fairscale.utils.params import recursive_copy_to_device
-from fairscale.utils.testing import objects_are_equal
+from fairscale.utils.testing import objects_are_equal, spawn_for_all_world_sizes, dist_init
 
 from .test_fsdp import (
     DistributedTest,
@@ -37,6 +37,54 @@ def assert_equal(a, b):
     assert a == b, f"{a} != {b}"
 
 
+def spawn_and_init_multiple_groups(fn, args=None, **spawn_kwargs):
+    if args is None:
+        args = ()
+    
+    run_fn = functools.partial(init_and_run, fn, args)
+    spawn_for_all_world_sizes(run_fn, **spawn_kwargs)
+
+def _find_my_group_index(grouped_ranks):
+    my_rank = torch.distributed.get_rank()
+    for i, group in enumerate(grouped_ranks):
+        if my_rank in group:
+            return i
+    raise RuntimeError
+
+def get_moe_group(moe_expert_count=2):
+    if torch.distributed.is_initialized():
+        
+        world_size = torch.distributed.get_world_size()
+
+        # more experts than world size
+        if world_size <= moe_expert_count:
+            assert moe_expert_count % world_size == 0
+            moe_groups = [[i] for i in range(world_size)]
+
+        # larger world than num experts
+        else:
+            assert world_size % moe_expert_count == 0
+            ranks_per_group = world_size // moe_expert_count
+            moe_groups = [
+                [i + j * moe_expert_count for j in range(ranks_per_group)]
+                for i in range(moe_expert_count)
+            ]
+
+        moe_pgs = [torch.distributed.new_group(g) for g in moe_groups]
+
+        my_group_idx = _find_my_group_index(moe_groups)
+        return moe_pgs[my_group_idx]
+    else:
+        return torch.distributed.new_group([torch.distributed.get_rank()])
+
+
+def init_and_run(fn, args, rank, world_size, filename, filename_rpc):
+    dist_init(rank, world_size, filename, filename_rpc)
+    torch.cuda.set_device(rank)
+    group = torch.distributed.new_group()
+    fn(rank, group, *args, expert_group=get_moe_group())
+
+
 class TestOptimizerUtils(DistributedTest):
     @parameterized.expand(
         [[functools.partial(SGD, momentum=0.9), True], [SGD, False], [Adam, False], [Adadelta, True], [Adam, True]],
@@ -50,18 +98,33 @@ class TestOptimizerUtils(DistributedTest):
         )
 
         spawn_and_init(test_fn, world_sizes=[min(torch.cuda.device_count(), 4)])
+    
+    @parameterized.expand(
+        [[SGD, False], [Adam, False]],
+        name_func=rename_test,
+    )
+    def test_consolidate_optimizer_diff_world_size(self, optim_fn, transformer):
+        if torch.cuda.device_count() < 4:
+            raise unittest.SkipTest("This test requires at least 4 GPUs.")
+        config = {"mixed_precision": True, "flatten_parameters": True}
+        config["compute_dtype"] = torch.float32
+        test_fn = functools.partial(
+            self._test_consolidated_optimizer, config, optim_fn=Adam, transformer=transformer
+        )
+        
+        spawn_and_init_multiple_groups(test_fn, world_sizes=[min(torch.cuda.device_count(), 4)])
 
     @classmethod
-    def _test_consolidated_optimizer(self, config, rank, group, optim_fn=torch.optim.SGD, transformer=False):
+    def _test_consolidated_optimizer(self, config, rank, group, optim_fn=torch.optim.SGD, transformer=False, expert_group=None):
         """FSDP.gather_full_optim_state_dict() should return something very similar to optimizer.state_dict()"""
         # Establish reference behavior.
-
         if transformer:
             unwrapped_model = TransformerWithSharedParams(group, wrapper_config=config).cuda()
             fsdp = self.get_wrapped_model(group, config=config).cuda()
         else:
-            unwrapped_model = MixtureOfExperts(group, wrapper_config=None).cuda()
-            fsdp = FullyShardedDataParallel(MixtureOfExperts(group, wrapper_config=config)).cuda()
+            unwrapped_model = MixtureOfExperts(group, wrapper_config=None, expert_group=expert_group).cuda()
+            fsdp = FullyShardedDataParallel(MixtureOfExperts(group, wrapper_config=config,
+                                                             expert_group=expert_group)).cuda()
 
         try:
             fsdp_optim = optim_fn(
@@ -88,9 +151,9 @@ class TestOptimizerUtils(DistributedTest):
             optim_unwrapped.step()
         unwrapped_sd = optim_unwrapped.state_dict()
 
-        if not transformer:
+        if not transformer and not expert_group:
             no_broadcast_children = [x for x in fsdp._fsdp_instances if x.no_broadcast_optim_state]
-            assert len(no_broadcast_children) == 1
+            assert len(no_broadcast_children) == 1, f"Length of non shared params {len(no_broadcast_children)}"
             assert fsdp._fsdp_instances[-1].no_broadcast_optim_state
         torch.cuda.empty_cache()
         cuda_gb_before = torch.cuda.memory_stats(fsdp.rank)["allocated_bytes.all.current"] / 1024 ** 3
@@ -134,14 +197,33 @@ class TestOptimizerUtils(DistributedTest):
         assert_equal(shard_sd.keys(), original_shard_sd.keys())
         original_shard_sd = recursive_copy_to_device(original_shard_sd, non_blocking=False, device="cpu")
         # Before asserting that the dicts are equal, we check keys individually to allow nice tracebacks.
-        assert_equal(
-            [all_tensors_numel_except_for_step(v) for k, v in shard_sd["state"].items()],
-            [all_tensors_numel_except_for_step(v) for k, v in original_shard_sd["state"].items()],
-        )
+        # assert_equal(
+        #     [all_tensors_numel_except_for_step(v) for k, v in shard_sd["state"].items()],
+        #     [all_tensors_numel_except_for_step(v) for k, v in original_shard_sd["state"].items()],
+        # )
         assert_equal(
             [v for k, v in shard_sd["param_groups"][0].items()],
             [v for k, v in original_shard_sd["param_groups"][0].items()],
         )
+        shard_state = shard_sd["state"]
+        orig_state = original_shard_sd["state"]
+        # if torch.distributed.get_rank() == 0:
+        #     for k, v in shard_state.items():
+        #         for v1, v2 in v.items():
+        #             try:
+        #                 print(f"k {k} vk {v1} vv {v2.size()}")
+        #             except AttributeError:
+        #                 print(f"k {k} vk {v1} vv {v2}")
+        #                 continue
+        #     print("Original")
+        #     for k, v in orig_state.items():
+        #         for v1, v2 in v.items():
+        #             try:
+        #                 print(f"k {k} vk {v1} vv {v2.size()}")
+        #             except AttributeError:
+        #                 print(f"k {k} vk {v1} vv {v2}")
+        #                 continue
+        # print(f"shard {shard_state} orig_state {orig_state}")
         assert objects_are_equal(shard_sd["state"], original_shard_sd["state"])
         assert objects_are_equal({k: shard_sd[k] for k in original_shard_sd}, original_shard_sd)
 

--- a/tests/nn/data_parallel/test_fsdp_optimizer_utils.py
+++ b/tests/nn/data_parallel/test_fsdp_optimizer_utils.py
@@ -184,10 +184,10 @@ class TestOptimizerUtils(DistributedTest):
             orig_state = recursive_copy_to_device(unwrapped_sd["state"], non_blocking=False, device="cpu")
 
             assert_equal(len(sd_state.keys()), len(orig_state.keys()))
-            
+
             assert_equal(
-            sum([all_tensors_numel_except_for_step(v) for k, v in sd_state.items()]),
-            sum([all_tensors_numel_except_for_step(v) for k, v in orig_state.items()]),
+                sum([all_tensors_numel_except_for_step(v) for k, v in sd_state.items()]),
+                sum([all_tensors_numel_except_for_step(v) for k, v in orig_state.items()]),
             )
             return
 


### PR DESCRIPTION
## What does this PR do?
This is to enable using expert replicas in MoE models. Previously we were only able to save and load optimizer state for unshared expert state where world size=1. With this change we should be able to aggregate state from nested modules with world sizes different from the parent module.

I've made changes to aggregating optimizer state but let me know if there is something I missed.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
