### PR TITLE
Adding ELI5 video to Fairscale

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ FairScale was designed with the following values in mind:
 
 * **Performance** - FairScale APIs provide the best performance in terms of scaling and efficiency.
 
+## Watch Introductory Video
+
+[![Explain Like I’m 5: FairScale](https://img.youtube.com/vi/oDt7ebOwWIc/0.jpg)](https://www.youtube.com/watch?v=oDt7ebOwWIc)
+
 ## What's New:
 
 * January 2022 [fairscale 0.4.5 was released](https://github.com/facebookresearch/fairscale/releases/tag/v0.4.5).


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible called ELI5s. We have also been working on React Labs series that we would like to add to the site. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Jest](https://jestjs.io/), [React Native](https://reactnative.dev/),[Hydra](https://hydra.cc/), and over 20 other projects.
