### PR TITLE
[FSDP] ssd_offload: Support pickling/unpickling of SsdTensorHandle based tensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- FSDP: Add pickle/unpickle support for SsdTensorHandle (and derived classes),
+  verified that FSDP models w/ ssd_offload enabled can correctly call model.state_dict()
+  and model.load_state_dict(...) and thus successfully checkpoint and recover parameters
+  stored as SsdFlatParameters.
+
 ### Fixed
 
 

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -223,7 +223,8 @@ class FlattenParamsWrapper(nn.Module):
             if ssd_offload:
                 assert ssd_directory != ""
                 (handle, fname) = tempfile.mkstemp(dir=ssd_directory, suffix="ssd_buf_param")
-                flat_param = SsdFlatParameter(params=params, filename=fname, requires_grad=params[0].requires_grad)
+                flat_param = SsdFlatParameter.from_tensors(tensors=params)
+                flat_param.set_file_params(fname, 0)
             else:
                 flat_param = FlatParameter(params, params[0].requires_grad)
             flat_param._param_infos = param_infos
@@ -501,7 +502,7 @@ class FlattenParamsWrapper(nn.Module):
 
         return chain(*gens)
 
-    def metadata(self, flat_param_idx: int) -> Tuple[List[str], List[torch.Size], List[int]]:
+    def metadata(self, flat_param_idx: int) -> Tuple[List[str], Sequence[torch.Size], List[int]]:
         """Return metadata for a flat param given its index in the flat_params list."""
         return self.flat_params[flat_param_idx].metadata()
 


### PR DESCRIPTION
## What does this PR do?
Resolves what should be one of the last remaining blockers from making ssd_offload a fully supported feature. I verified that raw SsdTensorHandles (and SsdParameter/SsdFlatParameters) can be torch.saved and torch.loaded successfully (using unit tests in test_ssd_offload.py). In addition, I verified that creating a checkpoint from an FSDP wrapped model using torch.save(model.state_dict()) and then loading it via model.load_state_dict() works correctly (using a unit test in test_fsdp_offload.py).

Do to some intricacies from the flatten params wrapper, the unpickle/pickle methods added not not actually used due to the way state_dict calls summon_full_params. But they are still needed for serializing arbitrary objects containing SsdTensorHandle based tensors.

## Before submitting

- [ X] Did you have fun?
  - Make sure you had fun coding 🙃
- [X ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [X ] N/A
- [ X] Did you make sure to update the docs?
- [X ] Did you write any new necessary tests?
- [X ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
