### PR TITLE
[FSDP] ssd_offload fixing backward path (grad_fn) for SsdFlatParameter and SsdFlatParameterView

### DIFF
--- a/fairscale/experimental/nn/ssd_offload.py
+++ b/fairscale/experimental/nn/ssd_offload.py
@@ -11,7 +11,7 @@ import io
 import os
 import pickle
 from types import TracebackType
-from typing import IO, Any, BinaryIO, Iterator, List, Optional, Sequence, Tuple, Type, Union
+from typing import IO, Any, BinaryIO, Callable, Dict, Iterator, List, Optional, Sequence, Tuple, Type, Union
 
 import numpy as np
 import torch
@@ -82,7 +82,8 @@ class StorageState(Enum):
 
     UNALLOCATED = auto()
     ON_DISK = auto()
-    ON_CPU = auto()
+    ON_CPU_CLEAN = auto()
+    ON_CPU_DIRTY = auto()
 
 
 class SsdTensorHandle(torch.Tensor):
@@ -109,12 +110,18 @@ class SsdTensorHandle(torch.Tensor):
 
     @staticmethod
     def __new__(
-        cls: Type[SsdTensorHandle], shape: torch.Size, dtype: torch.dtype, requires_grad: bool = False
+        cls: Type[SsdTensorHandle],
+        shape: torch.Size,
+        dtype: torch.dtype,
+        requires_grad: bool = False,
+        device: torch.device = torch.device("cpu"),
     ) -> SsdTensorHandle:
-        r = super(SsdTensorHandle, cls)._make_wrapper_subclass(cls, shape, dtype=dtype, requires_grad=requires_grad)  # type: ignore
+        r = super(SsdTensorHandle, cls)._make_wrapper_subclass(cls, shape, dtype=dtype, requires_grad=requires_grad, device=device)  # type: ignore
         return r
 
-    def __init__(self, shape: torch.Size, dtype: torch.dtype, requires_grad: bool) -> None:
+    def __init__(
+        self, shape: torch.Size, dtype: torch.dtype, requires_grad: bool, device: torch.device = torch.device("cpu")
+    ) -> None:
         self._unpickle_f: Optional[Union[BinaryIO, IO[bytes]]] = None
 
         self._shape = shape
@@ -128,8 +135,14 @@ class SsdTensorHandle(torch.Tensor):
         self.offset = -1
         # valid if loaded to memory
         self.tensor: Optional[torch.Tensor] = None
-        self.requires_grad = requires_grad
         self.storage_state = StorageState.UNALLOCATED
+
+    def mark_dirty(self) -> None:
+        assert self.tensor is not None
+        assert self.storage_state in [StorageState.ON_CPU_CLEAN, StorageState.ON_CPU_DIRTY]
+        self.storage_state = StorageState.ON_CPU_DIRTY
+        # hack to force write on mark_dirty
+        self.to_file()
 
     @classmethod
     def from_file(
@@ -143,7 +156,7 @@ class SsdTensorHandle(torch.Tensor):
     @classmethod
     def from_tensor(cls: Type[SsdTensorHandle], tensor: torch.Tensor) -> SsdTensorHandle:
         """Returns a new SsdTensorHandle from a tensor."""
-        handle = cls(shape=tensor.shape, dtype=tensor.dtype, requires_grad=tensor.requires_grad)
+        handle = cls(shape=tensor.shape, dtype=tensor.dtype, requires_grad=tensor.requires_grad, device=tensor.device)
         handle.point_to_tensor(tensor)
         return handle
 
@@ -168,7 +181,7 @@ class SsdTensorHandle(torch.Tensor):
         assert self._shape == tensor.shape
         assert self._dtype == tensor.dtype
         self.tensor = tensor
-        self.storage_state = StorageState.ON_CPU
+        self.storage_state = StorageState.ON_CPU_DIRTY
 
     # if resizing a handle that is part of an ssd buffer, care must be taken that the new size
     # doesn't conflict with adjacent handles!
@@ -185,21 +198,33 @@ class SsdTensorHandle(torch.Tensor):
         if self.tensor is not None:
             return self.tensor
         else:
+            if self.device != torch.device("cpu"):
+                raise RuntimeError(
+                    f"to_tensor called on an SsdTensorHandle when the tensor has been offloaded to disk. self.device = {self.device}, it should be {torch.device('cpu')}. Some unexpected .data override has occured!!"
+                )
             result_tensor = torch.empty(size=self._shape, dtype=self._dtype, requires_grad=self.requires_grad)
             self.copy_into_tensor(result_tensor)
             self.tensor = result_tensor
-            self.storage_state = StorageState.ON_CPU
+            self.storage_state = StorageState.ON_CPU_CLEAN
             return self.tensor
 
     def to_file(self, permit_when_tensor_none: bool = False, release_tensor_after_write: bool = True) -> None:
         """Saves the tensor to disk and releases memory if specified."""
         assert self.tensor is not None or permit_when_tensor_none
 
+        # if it's available in Memory but not modified, no need to write-back
         if self.tensor is not None:
-            write(self.tensor, self.filename, self.offset * self.tensor.element_size())
+            if self.storage_state is StorageState.ON_CPU_DIRTY:
+                if self.device != torch.device("cpu"):
+                    raise RuntimeError(
+                        f"to_file called on an SsdTensorHandle when self.device = {self.device}, it should be {torch.device('cpu')}. Some unexpected .data override has occured!!"
+                    )
+                write(self.tensor, self.filename, self.offset * self.tensor.element_size())
             if release_tensor_after_write:
                 self.tensor = None
                 self.storage_state = StorageState.ON_DISK
+            else:
+                self.storage_state = StorageState.ON_CPU_CLEAN
 
     def copy_into_tensor(self, tensor: torch.Tensor) -> None:
         """Copies SsdTensorHandle's data into the given tensor.
@@ -229,24 +254,43 @@ class SsdTensorHandle(torch.Tensor):
         versions to track if modifications have been made. If we detect changes to the
         tensor, we write it to the file maintained by the Handle.
         """
+        func_name = func.overloadpacket.__name__
         ssd_tensor_handles = []
 
         def unwrap(e: Any) -> torch.Tensor:
             if isinstance(e, SsdTensorHandle):
                 t = e.to_tensor()
-                ssd_tensor_handles.append((e, t._version))  # type: ignore
+                ssd_tensor_handles.append(e)
                 return t
             else:
                 return e
 
         r = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
 
-        for e, saved_version in ssd_tensor_handles:
-            inplace_is_this_tensor = func.__name__[-1] == "_" and e is args[0]
+        for e in ssd_tensor_handles:
+            inplace_is_this_tensor = (
+                (func_name.endswith("_") and not func_name.endswith("__")) or func_name.startswith("__i")
+            ) and e is args[0]
             out_is_this_tensor = False if "out" not in kwargs else e is kwargs["out"]
             if inplace_is_this_tensor or out_is_this_tensor:
-                e.to_file()
+                e.mark_dirty()
         return r
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name == "data":
+            assert isinstance(value, torch.Tensor)
+            # Respect .data changes, and the user better know what they are doing!
+            if self.storage_state == StorageState.ON_CPU_DIRTY:
+                raise RuntimeError("Attempting to override tensor when the existing tensor is dirty, this is an error!")
+            if value.shape != self.shape:
+                raise RuntimeError(
+                    f"Attempting to override tensor metadata using .data to change shape of tensor. Orig shape: {self.shape} New shape: {value.shape}"
+                )
+            if value.requires_grad != self.requires_grad:
+                pass
+                # raise RuntimeError(f"Attempting to override tensor metadata using .data to change requires_grad. Orig value: {self.requires_grad} New value: {value.requires_grad}")
+            self.tensor = value
+        super(SsdTensorHandle, self).__setattr__(name, value)
 
     @classmethod
     def __unpickle__(
@@ -264,7 +308,7 @@ class SsdTensorHandle(torch.Tensor):
             head, tail = os.path.split(self.filename)
             filename = os.path.join(self.override_directory_path, tail)
         if self.is_available():
-            byte_iter = iter(TensorChunkingIterator(self.tensor))
+            byte_iter = iter(TensorChunkingIterator(self.tensor))  # ignore: type
         else:
             byte_iter = iter(
                 FileChunkingIterator(self.filename, expected_size_bytes=self.numel() * self.element_size())
@@ -358,19 +402,29 @@ class TorchSaver:
 class SsdParameter(SsdTensorHandle, torch.nn.Parameter):
     @classmethod
     def from_tensor(cls: Type[SsdParameter], tensor: SsdTensorHandle) -> SsdParameter:  # type: ignore
-        r = cls(tensor.shape, tensor.dtype, tensor.requires_grad)
+        r = cls(tensor.shape, tensor.dtype, tensor.requires_grad, device=tensor.device)
         r.point_to_tensor(tensor)
         return r
 
     @staticmethod
     def __new__(
-        cls: Type[SsdParameter], shape: torch.Size, dtype: torch.dtype, requires_grad: bool = True
+        cls: Type[SsdParameter],
+        shape: torch.Size,
+        dtype: torch.dtype,
+        requires_grad: bool = True,
+        device: torch.device = torch.device("cpu"),
     ) -> SsdParameter:
-        r = super(SsdParameter, cls).__new__(cls, shape, dtype=dtype, requires_grad=requires_grad)
+        r = super(SsdParameter, cls).__new__(cls, shape=shape, dtype=dtype, requires_grad=requires_grad, device=device)
         return r  # type: ignore
 
-    def __init__(self, shape: torch.Size, dtype: torch.dtype, requires_grad: bool = True) -> None:
-        super(SsdParameter, self).__init__(shape, dtype, requires_grad)
+    def __init__(
+        self,
+        shape: torch.Size,
+        dtype: torch.dtype,
+        requires_grad: bool = True,
+        device: torch.device = torch.device("cpu"),
+    ) -> None:
+        super(SsdParameter, self).__init__(shape=shape, dtype=dtype, requires_grad=requires_grad, device=device)
 
 
 class SsdFlatParameter(SsdParameter):
@@ -381,7 +435,11 @@ class SsdFlatParameter(SsdParameter):
     """
 
     def __new__(
-        cls: Type[SsdFlatParameter], shapes: Sequence[torch.Size], dtype: torch.dtype, requires_grad: bool = True
+        cls: Type[SsdFlatParameter],
+        shapes: Sequence[torch.Size],
+        dtype: torch.dtype,
+        requires_grad: bool = True,
+        device: torch.device = torch.device("cpu"),
     ) -> SsdFlatParameter:
         """Make an object using the parent's __new__ function."""
 
@@ -390,10 +448,18 @@ class SsdFlatParameter(SsdParameter):
             raise ValueError("An non-empty list or tuple argument is needed")
 
         size = sum([np.prod(s) for s in shapes])
-        r = super(SsdFlatParameter, cls).__new__(cls, torch.Size((size,)), dtype=dtype, requires_grad=requires_grad)
+        r = super(SsdFlatParameter, cls).__new__(
+            cls, torch.Size((size,)), dtype=dtype, requires_grad=requires_grad, device=device
+        )
         return r  # type: ignore
 
-    def __init__(self, shapes: Sequence[torch.Size], dtype: torch.dtype, requires_grad: bool = True):
+    def __init__(
+        self,
+        shapes: Sequence[torch.Size],
+        dtype: torch.dtype,
+        requires_grad: bool = True,
+        device: torch.device = torch.device("cpu"),
+    ):
         """Initialize the _param_numels and _param_shapes lists."""
         self._param_shapes = shapes
         self._param_numels = [np.prod(s) for s in shapes]
@@ -402,6 +468,7 @@ class SsdFlatParameter(SsdParameter):
             self.numel() <= total_numels
         ), f"Something wrong with __new__ method, {self.numel()} vs. {sum(self._param_numels)}"
 
+        self.views: List[SsdFlatParameterView] = []
         # These are set by FPW class below, not by this class itself.
         self._param_infos: List[Tuple[str, torch.nn.Module, str]] = []
         self._shared_param_infos: List[Tuple[str, str, torch.nn.Module, str, torch.nn.Module, str]] = []
@@ -409,6 +476,22 @@ class SsdFlatParameter(SsdParameter):
         super(SsdFlatParameter, self).__init__(
             shape=torch.Size((total_numels,)), dtype=dtype, requires_grad=requires_grad
         )
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        super(SsdFlatParameter, self).__setattr__(name, value)
+        if name == "data":
+            self._refresh_views()
+
+    def _invalidate_views(self) -> None:
+        for v in self.views:
+            v.tensor = None
+
+    @torch.enable_grad()
+    def _refresh_views(self) -> None:
+        print(
+            f" _refresh_views self.shape: {self.shape} self.tensor.shape: {self.tensor.shape} param_numels: {self._param_numels}, param_shapes: {self._param_shapes}"
+        )
+        self.views = [s.view(v) for s, v in zip(self.split(self._param_numels), self._param_shapes)]  # type: ignore
 
     def get_param_views(self, external_data: Optional[torch.Tensor] = None) -> Iterator[torch.Tensor]:
         """Return a generator of views that map to the original parameters."""
@@ -425,7 +508,8 @@ class SsdFlatParameter(SsdParameter):
                 )
             return (t.view(s) for (t, s) in zip(external_data.split(self._param_numels), self._param_shapes))
         else:
-            return (t.view(s) for (t, s) in zip(self.split(self._param_numels), self._param_shapes))
+            # this needs to return SsdFlatParameterViews
+            return (v for v in self.views)
 
     def metadata(self) -> Tuple[List[str], Sequence[torch.Size], List[int]]:
         """Return tuple of (names, shapes, numels) metadata for this flat parameter."""
@@ -434,7 +518,11 @@ class SsdFlatParameter(SsdParameter):
 
     @classmethod
     def from_tensors(
-        cls: Type[SsdFlatParameter], tensors: Sequence[torch.Tensor], direct_to_file: bool = False
+        cls: Type[SsdFlatParameter],
+        tensors: Sequence[torch.Tensor],
+        direct_to_file: bool = False,
+        filename: str = "",
+        offset: int = 0,
     ) -> "SsdFlatParameter":
         """Returns a new SsdFlatParameter from a sequence of tensors."""
         assert (
@@ -449,16 +537,79 @@ class SsdFlatParameter(SsdParameter):
         if any(isinstance(t, SsdFlatParameter) for t in tensors):
             raise ValueError("Nesting SsdFlatParameter is not supported")
 
-        handle = cls(shapes=[t.size() for t in tensors], dtype=tensors[0].dtype, requires_grad=tensors[0].requires_grad)
+        requires_grad = tensors[0].requires_grad
+        dtype = tensors[0].dtype
+        device = tensors[0].device
+        for t in tensors:
+            if t.requires_grad != requires_grad:
+                raise RuntimeError("Not all tensors have identical requires_grad option")
+            if t.dtype != dtype:
+                raise RuntimeError("Not all tensors have identical dtype option")
+            if t.device != device:
+                raise RuntimeError("Not all tensors have identical device option")
+        handle = cls(
+            shapes=[t.size() for t in tensors],
+            dtype=tensors[0].dtype,
+            requires_grad=tensors[0].requires_grad,
+            device=device,
+        )
         if direct_to_file:
-            assert False, "direct_to_file not implemented yet"
-            pass
+            assert filename != ""
+            handle.set_file_params(filename, offset)
+            offset = offset
+            for t in tensors:
+                write(t, handle.filename, offset)
+                offset += t.numel() * t.element_size()
+
+            handle.storage_state = StorageState.ON_DISK
         else:
             tensor = torch.cat(
-                [t.detach().reshape(-1) if isinstance(t, torch.nn.Parameter) else t.reshape(-1) for t in tensors], 0
-            )
+                [t.reshape(-1) if isinstance(t, torch.nn.Parameter) else t.reshape(-1) for t in tensors],
+                0,
+            ).detach()
+            tensor.requires_grad_()
             handle.point_to_tensor(tensor)
         return handle
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore
+        func_name = func.overloadpacket.__name__
+        value_before = 0.0
+        if func_name == "add_":
+            value_before = args[0][0].item()
+        r = super(SsdFlatParameter, cls).__torch_dispatch__(func, types, args, kwargs)  # type: ignore
+        if func_name == "add_":
+            value_after = args[0][0].item()
+        if func_name.startswith("split"):
+            assert isinstance(args[0], SsdFlatParameter)
+            parent = args[0]
+            return [SsdFlatParameterView(parent, t, idx) for idx, t in enumerate(r)]
+        else:
+            return r
+
+    # need to subclass these methods to support Views
+    def point_to_tensor(self, tensor: torch.Tensor) -> None:
+        super(SsdFlatParameter, self).point_to_tensor(tensor)
+        self._refresh_views()
+
+    def point_to_file(self, filename: str, offset: int) -> None:
+        super(SsdFlatParameter, self).point_to_file(filename, offset)
+        self._invalidate_views()
+
+    def to_tensor(self) -> torch.Tensor:
+        call_refresh_views = False
+        if self.tensor is None:
+            call_refresh_views = True
+        result = super(SsdFlatParameter, self).to_tensor()
+        if call_refresh_views:
+            self._refresh_views()
+        return result
+
+    def to_file(self, permit_when_tensor_none: bool = False, release_tensor_after_write: bool = True) -> None:
+        super(SsdFlatParameter, self).to_file(permit_when_tensor_none, release_tensor_after_write)
+        self._invalidate_views()
 
     @classmethod
     def __unpickle_SFP__(
@@ -492,6 +643,176 @@ class SsdFlatParameter(SsdParameter):
             None,
             byte_iter,
         )
+
+
+class SsdFlatParameterView(torch.Tensor):
+    """
+    Represents a view into an SsdFlatParameter
+    """
+
+    def __new__(
+        cls: Type[SsdFlatParameterView], parent: SsdFlatParameter, tensor: torch.Tensor, id: int
+    ) -> SsdFlatParameterView:
+        r = super(SsdFlatParameterView, cls)._make_wrapper_subclass(cls, tensor.shape, dtype=tensor.dtype, requires_grad=tensor.requires_grad, device=tensor.device)  # type: ignore
+        return r
+
+    def __init__(self: SsdFlatParameterView, parent: SsdFlatParameter, tensor: torch.Tensor, id: int) -> None:
+        self.parent = parent
+        self.tensor: Optional[torch.Tensor] = tensor
+        self.id = id
+
+    __torch_function__ = torch._C._disabled_torch_function_impl
+
+    @classmethod
+    def __torch_dispatch__(cls, func, types, args=(), kwargs=None):  # type: ignore
+        """Intercepts all operations performed on this handle object.
+
+        Before any operation, the tensor attribute is unwrapped from the handle
+        and used in the operation. We maintain a refernce to the tensor and its current
+        versions to track if modifications have been made. If we detect changes to the
+        tensor, we write it to the file maintained by the Handle.
+        """
+        func_name = func.overloadpacket.__name__
+        ssd_tensor_handles = []
+
+        def unwrap(e: Any) -> torch.Tensor:
+            if isinstance(e, SsdFlatParameterView):
+                if not e.parent.is_available():
+                    print("to_tensor called, UH OH")
+                    e.parent.to_tensor()
+                # e.parent will ensure that e.tensor is valid and points to tensor view
+                t = e.tensor
+                ssd_tensor_handles.append(e)
+                return t
+            else:
+                return e
+
+        r = func(*tree_map(unwrap, args), **tree_map(unwrap, kwargs))
+
+        for e in ssd_tensor_handles:
+            inplace_is_this_tensor = (
+                (func_name.endswith("_") and not func_name.endswith("__")) or func_name.startswith("__i")
+            ) and e is args[0]
+            out_is_this_tensor = False if "out" not in kwargs else e is kwargs["out"]
+            if inplace_is_this_tensor or out_is_this_tensor:
+                e.parent.mark_dirty()
+
+        if func_name.startswith("view"):
+            assert isinstance(args[0], SsdFlatParameterView)
+            flat_view = args[0]
+            return SsdFlatParameterView(flat_view.parent, r, flat_view.id)
+        return r
+
+
+# ###################################
+# ### BEGIN OVERRIDE_PROPERTY FNs ###
+# ###################################
+def _inject_new_class(module: torch.nn.Module) -> None:
+    r"""Sets up a module to be parametrized.
+
+    This works by substituting the class of the module by a class
+    that extends it to be able to inject a property
+
+    Args:
+        module (nn.Module): module into which to inject the property
+    """
+    cls = module.__class__
+
+    def getstate(self):  # type: ignore
+        raise RuntimeError(
+            "Serialization of parametrized modules is only "
+            "supported through state_dict(). See:\n"
+            "https://pytorch.org/tutorials/beginner/saving_loading_models.html"
+            "#saving-loading-a-general-checkpoint-for-inference-and-or-resuming-training"
+        )
+
+    param_cls = type(
+        f"Parametrized{cls.__name__}",
+        (cls,),
+        {
+            "__getstate__": getstate,
+        },
+    )
+
+    module.__class__ = param_cls
+    module.override_properties: Dict[str, Callable[[], torch.Tensor]] = {}  # type: ignore
+    # setattr(module, "override_properties", {})
+
+
+def _inject_property(module: torch.nn.Module, property_name: str) -> None:
+    r"""Injects a property into module[property_name].
+
+    It assumes that the class in the module has already been modified from its
+    original one using _inject_new_class and that the tensor under :attr:`property_name`
+    has already been moved out
+
+    Args:
+        module (nn.Module): module into which to inject the property
+        property_name (str): name of the name of the property to create
+    """
+
+    def get_parametrized(self: torch.nn.Module) -> torch.Tensor:
+        prop: Callable[[], torch.Tensor] = self.override_properties[property_name]  # type: ignore
+        # If caching is not active, this function just evaluates the parameterization
+        return prop()
+
+    def set_original(self: torch.nn.Module, value: Callable[[], torch.Tensor]) -> None:
+        self.override_properties[property_name] = value  # type: ignore
+
+    def del_fn(self: torch.nn.Module) -> None:
+        _remove_property(self, property_name)
+
+    setattr(module.__class__, property_name, property(get_parametrized, set_original, del_fn))
+
+
+def _register_property(module: torch.nn.Module, property_name: str, property_value: Callable[[], torch.Tensor]) -> None:
+    has_injected_class = hasattr(module, "override_properties")
+    if not has_injected_class:
+        _inject_new_class(module)
+        if hasattr(module, property_name):
+            delattr(module, property_name)
+    module.override_properties[property_name] = property_value  # type: ignore
+    _inject_property(module, property_name)
+
+
+def _remove_property(module: torch.nn.Module, property_name: str, new_property_value: Optional[Any] = None) -> None:
+    delattr(module.__class__, property_name)
+    del module.override_properties[property_name]  # type: ignore
+
+    # Roll back the parametrized class if no other buffer or parameter
+    # is currently parametrized in this class
+    if len(module.override_properties) == 0:  # type: ignore
+        delattr(module, "override_properties")
+        # Restore class
+        orig_cls = module.__class__.__bases__[0]
+        module.__class__ = orig_cls
+    if new_property_value is not None:
+        setattr(module.__class__, property_name, new_property_value)
+
+
+# #################################
+# ### END OVERRIDE_PROPERTY FNs ###
+# #################################
+
+
+class SsdFlatParameterViewProperty:
+    def __init__(self, parent: SsdFlatParameter, view_id: int) -> None:
+        super().__init__()
+        self.parent = parent
+        self.view_id = view_id
+
+    def __call__(self) -> SsdFlatParameterView:
+        return self.parent.views[self.view_id]
+
+
+class SsdFlatParameterViewParameterization(torch.nn.Module):
+    def __init__(self, parent: SsdFlatParameter, view_id: int) -> None:
+        super().__init__()
+        self.parent = parent
+        self.view_id = view_id
+
+    def forward(self, *args: Any, **kwargs: Any) -> SsdFlatParameterView:
+        return self.parent.views[self.view_id]
 
 
 class DisableMemoizationPicklerModule:

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -230,6 +230,7 @@ class FlattenParamsWrapper(nn.Module):
                 assert ssd_directory != ""
                 (handle, fname) = tempfile.mkstemp(dir=ssd_directory, suffix="ssd_buf_param")
                 flat_param = SsdFlatParameter.from_tensors(tensors=params)
+                flat_param.allow_unsafe_changes = True
                 flat_param.set_file_params(fname, 0)
             else:
                 flat_param = FlatParameter(params, params[0].requires_grad)

--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -16,11 +16,12 @@ import numpy as np
 import pytest
 import torch
 
-import fairscale.experimental.nn.ssd_offload as so
-from fairscale.utils import torch_version
-
-# Note: We need the nightly version for SSD offload to work. Hence I am checking for the next PyTorch release.
-pytestmark = pytest.mark.skipif(torch_version() < (1, 11, 0), reason="requires torch version >= 1.11.0")
+try:
+    import fairscale.experimental.nn.ssd_offload as so
+except ImportError as ie:
+    # Note: We need the nightly version for SSD offload to work. Hence I am checking for the next PyTorch release.
+    pytestmark = pytest.mark.skipif(True, reason=ie.msg)
+    pass
 
 
 def _init():
@@ -104,9 +105,6 @@ def test_ssd_handle_dispatch_bwd_hook():
 
 
 def test_ssd_handle_train_simple():
-    if torch_version() >= (1, 12, 0):
-        pytest.skip("to be fixed")
-
     _init()
 
     with tempfile.NamedTemporaryFile() as f:
@@ -196,9 +194,6 @@ def test_torch_save_load_ssd_flat_param_on_mem():
 
 
 def test_ssd_param_train_simple():
-    if torch_version() >= (1, 12, 0):
-        pytest.skip("to be fixed")
-
     _init()
     with tempfile.NamedTemporaryFile() as f:
         orig_tensor = torch.randn((4, 4))

--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -93,7 +93,7 @@ def test_ssd_handle_dispatch_bwd_hook():
         one = torch.ones((1), requires_grad=True).cuda()
 
         orig_copy = ssd_handle.data
-        cuda_copy = ssd_handle.to("cuda").detach()
+        cuda_copy = ssd_handle.to("cuda").detach().requires_grad_(True)
         ssd_handle.data = cuda_copy
 
         ssd_handle.register_hook(functools.partial(post_backward_hook, "ssd_handle"))

--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -8,6 +8,7 @@ Testing SsdFlatParameter and SsdTensorHandle modules.
 """
 
 import filecmp
+import functools
 import os
 import tempfile
 
@@ -77,6 +78,34 @@ def test_ssd_handle_dispatch_bwd():
         assert torch.equal(ssd_handle.grad, orig_copy.grad)
 
 
+def test_ssd_handle_dispatch_bwd_hook():
+    _init()
+
+    def post_backward_hook(name, grad):
+        print(f"BACKWARD HOOK for tensor {name} CALLED")
+
+    with tempfile.NamedTemporaryFile() as f:
+        orig_tensor = torch.randn((4, 4), requires_grad=True)
+        orig_copy = orig_tensor.clone().detach().requires_grad_(True)
+        ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
+        ssd_handle.set_file_params(f.name, 0)
+        ssd_handle.to_file(release_tensor_after_write=True)
+        one = torch.ones((1), requires_grad=True).cuda()
+
+        import pdb
+
+        pdb.set_trace()
+        orig_copy = ssd_handle.data
+        cuda_copy = ssd_handle.to("cuda").detach()
+        ssd_handle.data = cuda_copy
+
+        ssd_handle.register_hook(functools.partial(post_backward_hook, "ssd_handle"))
+        one.register_hook(functools.partial(post_backward_hook, "one"))
+
+        y1 = ssd_handle + one
+        y1.sum().backward()
+
+
 def test_ssd_handle_train_simple():
     if torch_version() >= (1, 12, 0):
         pytest.skip("to be fixed")
@@ -102,15 +131,15 @@ def test_ssd_handle_train_simple():
         y1 = ssd_handle + 1
         optimizer_ssd.zero_grad()
         y1.sum().backward()
+        assert ssd_handle.storage_state is so.StorageState.ON_CPU_CLEAN
         optimizer_ssd.step()
+        assert ssd_handle.storage_state is so.StorageState.ON_CPU_DIRTY
 
         y2 = orig_copy + 1
         optimizer_orig.zero_grad()
         y2.sum().backward()
         optimizer_orig.step()
 
-        # make sure we are using the file version not the cached tensor
-        ssd_handle.point_to_file(f.name, 0)
         assert torch.equal(ssd_handle.to_tensor(), orig_copy)
 
 
@@ -193,15 +222,17 @@ def test_ssd_param_train_simple():
         y1 = ssd_param + 1
         optimizer_ssd.zero_grad()
         y1.sum().backward()
+        # Test to see if Dirty is being calculated correctly when optimizer modifies
+        # ssd_param
+        assert ssd_param.storage_state is so.StorageState.ON_CPU_CLEAN
         optimizer_ssd.step()
+        assert ssd_param.storage_state is so.StorageState.ON_CPU_DIRTY
 
         y2 = param + 1
         optimizer_orig.zero_grad()
         y2.sum().backward()
         optimizer_orig.step()
 
-        # make sure we are using the file version not the cached tensor
-        ssd_param.point_to_file(f.name, 0)
         assert torch.equal(ssd_param.to_tensor(), param)
 
 
@@ -211,7 +242,7 @@ def test_ssd_flat_parameter_basic():
         refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
         refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
         refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32))
-        ssd_flat_param = so.SsdFlatParameter.from_tensors([refa_param, refb_param, refc_param], False)
+        ssd_flat_param = so.SsdFlatParameter.from_tensors([refa_param, refb_param, refc_param], direct_to_file=False)
         ssd_flat_param.set_file_params(f.name, 0)
 
         param_views = list(ssd_flat_param.get_param_views())
@@ -224,3 +255,200 @@ def test_ssd_flat_parameter_basic():
         assert torch.equal(refb_param, param_views[1])
         assert torch.equal(refc_param, param_views[2])
         ssd_flat_param.to_file()
+
+        assert not ssd_flat_param.is_available()
+        first_value = param_views[0][0][0].item()
+        assert ssd_flat_param.is_available()
+        assert first_value == refa_param[0][0].item()
+
+
+def test_ssd_flat_parameter_view_modify():
+    _init()
+    with tempfile.NamedTemporaryFile() as f:
+        refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=False)
+        refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=False)
+        refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32), requires_grad=False)
+        ssd_flat_param = so.SsdFlatParameter.from_tensors([refa_param, refb_param, refc_param], direct_to_file=False)
+        ssd_flat_param.set_file_params(f.name, 0)
+
+        param_views = list(ssd_flat_param.get_param_views())
+
+        assert ssd_flat_param.storage_state == so.StorageState.ON_CPU_DIRTY
+        ssd_flat_param.to_file()
+        assert ssd_flat_param.storage_state == so.StorageState.ON_DISK
+        assert param_views[0].tensor is None
+
+        param_views[0] += 0.1
+        assert ssd_flat_param.storage_state == so.StorageState.ON_CPU_DIRTY
+
+
+def test_ssd_tensor_handle_grad_fn():
+    _init()
+
+    with tempfile.NamedTemporaryFile() as f:
+        orig_tensor = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=True)
+        view_tensor = orig_tensor.view(-1)
+        assert view_tensor.grad_fn is not None
+        import pdb
+
+        pdb.set_trace()
+        ssd_handle = so.SsdTensorHandle.from_tensor(view_tensor)
+        assert ssd_handle.grad_fn is not None  # fails because grad_fn isn't used by dispatch
+
+
+def test_ssd_flat_parameter_view_bwd():
+    _init()
+
+    hooks_called = []
+
+    def post_backward_hook(name, hooks_called, *grads):
+        print(f"BACKWARD HOOK for tensor {name} CALLED")
+        hooks_called.append(name)
+
+    with tempfile.NamedTemporaryFile() as f:
+        refa_param = (
+            torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=True)
+            .to("cpu")
+            .detach()
+            .requires_grad_()
+        )
+        refb_param = (
+            torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=True)
+            .to("cpu")
+            .detach()
+            .requires_grad_()
+        )
+        refc_param = (
+            torch.nn.Parameter(torch.rand((128), dtype=torch.float32), requires_grad=True)
+            .to("cpu")
+            .detach()
+            .requires_grad_()
+        )
+        ssd_flat_param = so.SsdFlatParameter.from_tensors(
+            [refa_param, refb_param, refc_param], direct_to_file=True, filename=f.name, offset=0
+        )
+        orig_copy = ssd_flat_param.data
+        cuda_copy = ssd_flat_param.to("cuda").detach().requires_grad_()
+        cpu_copy = ssd_flat_param.to("cpu").detach().requires_grad_()
+
+        p_tmp = ssd_flat_param.expand_as(ssd_flat_param)  # Get a grad_fn on p_tmp.
+        assert p_tmp.grad_fn is not None
+        grad_acc = p_tmp.grad_fn.next_functions[0][0]  # Gets its GradAccumulation object.
+        grad_acc.register_hook(functools.partial(post_backward_hook, "GradAccumulation_orig", hooks_called))
+
+        ssd_flat_param.data = cuda_copy
+        one = torch.ones((1), requires_grad=True, device=ssd_flat_param.device)
+        y1 = ssd_flat_param.views[0] + one
+        y2 = cuda_copy + 1
+
+        # ssd_flat_param.to_file()
+        # ssd_flat_param.data = orig_copy
+
+        p_tmp = ssd_flat_param.expand_as(ssd_flat_param)  # Get a grad_fn on p_tmp.
+        assert p_tmp.grad_fn is not None
+        grad_acc = p_tmp.grad_fn.next_functions[0][0]  # Gets its GradAccumulation object.
+        grad_acc.register_hook(functools.partial(post_backward_hook, "GradAccumulation_cuda", hooks_called))
+        ssd_flat_param.views[0].register_hook(
+            functools.partial(post_backward_hook, "ssd_flat_param.views[0]", hooks_called)
+        )
+        ssd_flat_param.register_hook(functools.partial(post_backward_hook, "ssd_flat_param", hooks_called))
+        one.register_hook(functools.partial(post_backward_hook, "one", hooks_called))
+
+        y1.sum().backward()
+        y2.sum().backward()
+
+        assert "GradAccumulation_cuda" in hooks_called
+        assert "ssd_flat_param" in hooks_called
+        assert "one" in hooks_called
+
+
+def test_ssd_flat_parameter_view_bwd_parameterization():
+    _init()
+
+    hooks_called = []
+
+    def post_backward_hook(name, hooks_called, *grads):
+        print(f"BACKWARD HOOK for tensor {name} CALLED")
+        hooks_called.append(name)
+
+    with tempfile.NamedTemporaryFile() as f:
+        layer1 = torch.nn.Linear(32, 4, bias=False)
+        layer2 = torch.nn.Linear(32, 4, bias=False)
+        layer3 = torch.nn.Linear(128, 1, bias=False)
+        ssd_flat_param = so.SsdFlatParameter.from_tensors(
+            [layer1.weight, layer2.weight, layer3.weight], direct_to_file=False, filename=f.name, offset=0
+        )
+        torch.nn.utils.parametrize.register_parametrization(
+            layer1, "weight", so.SsdFlatParameterViewParameterization(ssd_flat_param, 0)
+        )
+        torch.nn.utils.parametrize.register_parametrization(
+            layer2, "weight", so.SsdFlatParameterViewParameterization(ssd_flat_param, 1)
+        )
+        torch.nn.utils.parametrize.register_parametrization(
+            layer3, "weight", so.SsdFlatParameterViewParameterization(ssd_flat_param, 2)
+        )
+
+        orig_copy = ssd_flat_param.data
+        cuda_copy = ssd_flat_param.to("cuda").detach().requires_grad_()
+        cpu_copy = ssd_flat_param.to("cpu").detach().requires_grad_()
+
+        p_tmp = ssd_flat_param.expand_as(ssd_flat_param)  # Get a grad_fn on p_tmp.
+        assert p_tmp.grad_fn is not None
+        grad_acc = p_tmp.grad_fn.next_functions[0][0]  # Gets its GradAccumulation object.
+        grad_acc.register_hook(functools.partial(post_backward_hook, "GradAccumulation_orig", hooks_called))
+
+        ssd_flat_param.data = cuda_copy
+        one = torch.ones(layer1.weight.shape, requires_grad=True, device=ssd_flat_param.device)
+        y1 = layer1.forward(one)
+        y2 = cuda_copy + 1
+
+        # ssd_flat_param.to_file()
+        # ssd_flat_param.data = orig_copy
+
+        p_tmp = ssd_flat_param.expand_as(ssd_flat_param)  # Get a grad_fn on p_tmp.
+        assert p_tmp.grad_fn is not None
+        grad_acc = p_tmp.grad_fn.next_functions[0][0]  # Gets its GradAccumulation object.
+        grad_acc.register_hook(functools.partial(post_backward_hook, "GradAccumulation_cuda", hooks_called))
+        ssd_flat_param.views[0].register_hook(
+            functools.partial(post_backward_hook, "ssd_flat_param.views[0]", hooks_called)
+        )
+        ssd_flat_param.register_hook(functools.partial(post_backward_hook, "ssd_flat_param", hooks_called))
+        one.register_hook(functools.partial(post_backward_hook, "one", hooks_called))
+
+        y1.sum().backward()
+        y2.sum().backward()
+
+        assert "GradAccumulation_cuda" in hooks_called
+        assert "ssd_flat_param.views[0]" in hooks_called
+        assert "ssd_flat_param" in hooks_called
+        assert "one" in hooks_called
+
+
+def test_ssd_flat_parameter_direct_to_file():
+    _init()
+    with tempfile.NamedTemporaryFile() as f:
+        refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
+        refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
+        refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32))
+        ssd_flat_param = so.SsdFlatParameter.from_tensors(
+            [refa_param, refb_param, refc_param], direct_to_file=True, filename=f.name, offset=0
+        )
+
+        param_views = list(ssd_flat_param.get_param_views())
+
+        assert refa_param.shape == param_views[0].shape
+        assert refb_param.shape == param_views[1].shape
+        assert refc_param.shape == param_views[2].shape
+
+        for p in param_views:
+            assert p.tensor is None
+
+        assert torch.equal(refa_param, param_views[0])
+        assert torch.equal(refb_param, param_views[1])
+        assert torch.equal(refc_param, param_views[2])
+        ssd_flat_param.to_file()
+
+        assert not ssd_flat_param.is_available()
+        first_value = param_views[0][0][0].item()
+        assert ssd_flat_param.is_available()
+        assert first_value == refa_param[0][0].item()

--- a/tests/nn/data_parallel/test_fsdp_offload.py
+++ b/tests/nn/data_parallel/test_fsdp_offload.py
@@ -16,16 +16,16 @@ import torch
 from torch import nn
 import torch.distributed
 
-import fairscale.experimental.nn.ssd_offload as so
+try:
+    import fairscale.experimental.nn.ssd_offload as so
+except ImportError as ie:
+    # Note: We need the nightly version for SSD offload to work. Hence I am checking for the next PyTorch release.
+    pytestmark = pytest.mark.skipif(True, reason=ie.msg)
+    pass
+
 from fairscale.nn.checkpoint.checkpoint_activations import checkpoint_wrapper
 from fairscale.nn.data_parallel import FullyShardedDataParallel, OffloadConfig, TrainingState
-from fairscale.utils import torch_version
 from fairscale.utils.testing import dist_init, spawn_for_all_world_sizes
-
-# Note: We need the nightly version for SSD offload to work. Hence I am checking for the next PyTorch release.
-print(f"torch version {torch_version()}")
-pytestmark = pytest.mark.skipif(torch_version() < (1, 11, 0), reason="requires torch version >= 1.11.0")
-
 
 # How to use remote-pdb: https://gist.github.com/sshleifer/9d43351957179c13606e015b072927d4
 # All helper functions called by spawn must be either @classmethod, @staticmethod
@@ -137,8 +137,6 @@ def rename_test(testcase_func, param_num, param):
 
 class TestSsdMemory(DistributedTest):
     def test_memory_benchmark(self):
-        if torch_version() >= (1, 12, 0):
-            pytest.skip("to be fixed")
 
         test_fn = functools.partial(self._test_memory_benchmark, config={})
         spawn_and_init(test_fn)
@@ -218,8 +216,6 @@ class TimeKeeper:
 class TestModuleProperties(DistributedTest):
     @parameterized.expand(CONFIG, name_func=rename_test)
     def test_named_parameters(self, config):
-        if torch_version() >= (1, 12, 0):
-            pytest.skip("to be fixed")
 
         test_fn = functools.partial(self._test_named_params, config=config)
         spawn_and_init(test_fn)
@@ -264,23 +260,17 @@ class TestModuleProperties(DistributedTest):
 class TestSsdLoading(DistributedTest):
     @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
     def test_ssd_offloading_eval(self, config):
-        if torch_version() >= (1, 12, 0):
-            pytest.skip("to be fixed")
 
         test_fn = functools.partial(self._test_ssd_offload_eval, config=config)
         spawn_and_init(test_fn)
 
     @parameterized.expand(CONFIG, name_func=rename_test)
     def test_transformer_parameterized(self, config):
-        if torch_version() >= (1, 12, 0):
-            pytest.skip("to be fixed")
 
         spawn_and_init(functools.partial(self._test_identical_outputs_eval, TransformerWithSharedParams, config))
 
     @parameterized.expand(CONFIG_OPTIONS, name_func=rename_test)
     def test_ssd_offloading_train_flatten_params_wrapper(self, config):
-        if torch_version() >= (1, 12, 0):
-            pytest.skip("to be fixed")
 
         test_fn = functools.partial(self._test_ssd_offloading_train_flatten_params_wrapper, config=config)
         spawn_and_init(test_fn)

--- a/tests/nn/data_parallel/test_fsdp_offload.py
+++ b/tests/nn/data_parallel/test_fsdp_offload.py
@@ -288,6 +288,8 @@ class TestSsdLoading(DistributedTest):
     @classmethod
     def _test_ssd_offloading_train_flatten_params_wrapper(self, rank, group, config):
         SIZE = 16 * 16
+        LR = 0.01
+        MOMENTUM = 0.1
         model = SimpleLinear(group, input_size=SIZE, output_size=SIZE, layers=4)
 
         with tempfile.TemporaryDirectory() as current_tempdir:
@@ -305,7 +307,7 @@ class TestSsdLoading(DistributedTest):
                 model = FullyShardedDataParallel(model, **config)
             model_device = torch.device("cuda")
             model.train()
-            optim = torch.optim.SGD(model.parameters(), lr=1.0, momentum=0.1)
+            optim = torch.optim.SGD(model.parameters(), lr=LR, momentum=MOMENTUM)
 
             checkpoint_file = tempfile.NamedTemporaryFile()
             checkpoint_load_directory = tempfile.TemporaryDirectory(prefix="checkpoint_dir")
@@ -322,8 +324,11 @@ class TestSsdLoading(DistributedTest):
                     input = model.get_input(torch.device("cuda"))
                     output = model(*input)
                     pre_checkpoint_last_output = output
-                    # print(f"pre_checkpoint value: {output[0][0].item()}")
-                    print(f"i={i} pre_checkpoint model.flat_params[0][0].item() = {model.flat_params[0][0].item()}")
+                    """
+                    param_itr = iter(model.named_parameters())
+                    p_name, p_val = next(param_itr)
+                    print(f"i={i} pre_checkpoint {p_name} = {p_val[0].item()}")
+                    """
                     loss = model.module.get_loss(input, output).to(model_device)
                     assert loss.dtype == torch.float32
                     model.module.run_backward(loss)
@@ -333,20 +338,23 @@ class TestSsdLoading(DistributedTest):
                             # so.torch_saver.save({"model": model.state_dict(), "optim": optim.state_dict()}, checkpoint_file.name)
                             torch.save({"model": model.state_dict()}, checkpoint_file.name)
                         # reset momentum just after checkpoint save
-                        optim = torch.optim.SGD(model.parameters(), lr=1.0, momentum=0.1)
+                        optim = torch.optim.SGD(model.parameters(), lr=LR, momentum=MOMENTUM)
 
                 checkpoint = torch.load(checkpoint_file.name)
                 model.load_state_dict(checkpoint["model"])
                 # reset momentum just after checkpoint load
-                optim = torch.optim.SGD(model.parameters(), lr=1.0, momentum=0.1)
+                optim = torch.optim.SGD(model.parameters(), lr=LR, momentum=MOMENTUM)
                 # do more iterations after loading checkpoint
                 for i in range(ITERATIONS - 1):
                     optim.zero_grad()
                     input = model.get_input(torch.device("cuda"))
                     output = model(*input)
                     post_checkpoint_last_output = output
-                    # print(f"post_checkpoint value: {output[0][0].item()}")
-                    print(f"i={i} post_checkpoint model.flat_params[0][0].item() = {model.flat_params[0][0].item()}")
+                    """
+                    param_itr = iter(model.named_parameters())
+                    p_name, p_val = next(param_itr)
+                    print(f"i={i} post_checkpoint {p_name} = {p_val[0].item()}")
+                    """
                     loss = model.module.get_loss(input, output).to(model_device)
                     assert loss.dtype == torch.float32
 
@@ -504,7 +512,7 @@ def spawn_and_init(fn, args=None, **spawn_kwargs):
     # _, filename_rpc = tempfile.mkstemp()
     # run_fn(0, 1, filename, filename_rpc)
 
-    spawn_for_all_world_sizes(run_fn, **spawn_kwargs, world_sizes=[2])
+    spawn_for_all_world_sizes(run_fn, **spawn_kwargs)
 
 
 def init_and_run(fn, args, rank, world_size, filename, filename_rpc):


### PR DESCRIPTION
## Resolved some issues discovered that the backward path for SsdFlatParameter/View wasn't working properly due to the .data assignment. There was an issue inside of pytorch core where assigning .data would reset the flag that allowed for __torch_dispatch__ to be called on a tensor subclass. As a result, it effectively reverted back to a normal tensor stored on the CPU. I got pytorch to correct this issue on pytorch master, and then went through the effort of getting ssd_offload to work properly with the fix.

Fixes # (issue).

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
