### PR TITLE
[test] fix circleCI failure due to pyenv versions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,13 +69,11 @@ setup_venv: &setup_venv
   - run:
       name: Setup Virtual Env
       working_directory: ~/
-      shell: /bin/bash
+      shell: /bin/bash -x
       command: |
-        pwd
-        type python
-        which python
+        set -e
+        set -o pipefail
         python -m venv ~/venv
-        exit 0
         echo ". ~/venv/bin/activate" >> $BASH_ENV
         . ~/venv/bin/activate
         python --version
@@ -235,10 +233,11 @@ commands:
        - run:
            name: Setup pyenv
            command: |
-             git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
-             pyenv update
              pyenv install -f <<parameters.version>>
              pyenv global <<parameters.version>>
+             exit 0
+             git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+             pyenv update
 
 # -------------------------------------------------------------------------------------
 # Jobs to run

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,8 @@ setup_venv: &setup_venv
   - run:
       name: Setup Virtual Env
       working_directory: ~/
-      shell: /bin/bash -x
+      # use bash -x for debug early commands executed in .bashrc.
+      shell: /bin/bash
       command: |
         set -e
         set -o pipefail
@@ -232,15 +233,17 @@ commands:
      steps:
        - run:
            name: Setup pyenv
+           # We used to use the following commands to update pyenv.
+           #   git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
+           #   pyenv update
+           # However, it is not deterministic since pyenv is being updated.
+           # It is now fixed to a version. (v2.3.0 is broken since it cause bash to fail when it try to do "eval $(pyenv init -)")
            command: |
              cd /opt/circleci/.pyenv/
              git remote update
              git checkout v2.2.0
              pyenv install -f <<parameters.version>>
              pyenv global <<parameters.version>>
-             exit 0
-             git clone https://github.com/pyenv/pyenv-update.git $(pyenv root)/plugins/pyenv-update
-             pyenv update
 
 # -------------------------------------------------------------------------------------
 # Jobs to run
@@ -466,13 +469,7 @@ jobs:
     steps:
       - checkout
 
-      - run:
-          name: smi
-          shell: /bin/bash -x
-          command: |
-            pwd
-            nvidia-smi
-            echo $PATH
+      - run: nvidia-smi
 
       - setup_pyenv:
           version: 3.9.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,11 @@ setup_venv: &setup_venv
   - run:
       name: Setup Virtual Env
       working_directory: ~/
+      shell: /bin/bash
       command: |
+        pwd
+        type python
+        which python
         python -m venv ~/venv
         echo ". ~/venv/bin/activate" >> $BASH_ENV
         . ~/venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -466,7 +466,13 @@ jobs:
     steps:
       - checkout
 
-      - run: nvidia-smi
+      - run:
+          name: smi
+          shell: /bin/bash -x
+          command: |
+            pwd
+            nvidia-smi
+            echo $PATH
 
       - setup_pyenv:
           version: 3.9.7

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -235,7 +235,7 @@ commands:
            command: |
              cd /opt/circleci/.pyenv/
              git remote update
-             git checkout v2.3.0
+             git checkout v2.2.0
              pyenv install -f <<parameters.version>>
              pyenv global <<parameters.version>>
              exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,9 @@ commands:
        - run:
            name: Setup pyenv
            command: |
+             cd /opt/circleci/.pyenv/
+             git remote update
+             git checkout v2.3.0
              pyenv install -f <<parameters.version>>
              pyenv global <<parameters.version>>
              exit 0

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,6 +75,7 @@ setup_venv: &setup_venv
         type python
         which python
         python -m venv ~/venv
+        exit 0
         echo ". ~/venv/bin/activate" >> $BASH_ENV
         . ~/venv/bin/activate
         python --version


### PR DESCRIPTION
## What does this PR do?

pyenv was moving forward before this fix. Now, it is fixed to v2.2.0. v2.3.0 breaks the circleci's bashrc.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
