### PR TITLE
[minor] Remove false tuples

### DIFF
--- a/tests/experimental/nn/test_ssd_offload.py
+++ b/tests/experimental/nn/test_ssd_offload.py
@@ -33,7 +33,7 @@ def test_write_read():
     _init()
 
     with tempfile.NamedTemporaryFile() as f:
-        ref_tensor = torch.rand((128), dtype=torch.float32)
+        ref_tensor = torch.rand(128, dtype=torch.float32)
         test_tensor = torch.zeros_like(ref_tensor)
         assert not torch.equal(ref_tensor, test_tensor)
         so.write(ref_tensor, f.name)
@@ -45,7 +45,7 @@ def test_ssd_handle_dispatch_fwd():
     _init()
 
     with tempfile.NamedTemporaryFile() as f:
-        orig_tensor = torch.randn((128))
+        orig_tensor = torch.randn(128)
         ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
         ssd_handle.set_file_params(f.name, 0)
         ssd_handle.to_file(release_tensor_after_write=True)
@@ -91,7 +91,7 @@ def test_ssd_handle_dispatch_bwd_hook():
         ssd_handle = so.SsdTensorHandle.from_tensor(orig_tensor)
         ssd_handle.set_file_params(f.name, 0)
         ssd_handle.to_file(release_tensor_after_write=True)
-        one = torch.ones((1), requires_grad=True).cuda()
+        one = torch.ones(1, requires_grad=True).cuda()
 
         orig_copy = ssd_handle.data
         cuda_copy = ssd_handle.to("cuda").detach().requires_grad_(True)
@@ -235,7 +235,7 @@ def test_ssd_flat_parameter_basic():
     with tempfile.NamedTemporaryFile() as f:
         refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
         refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
-        refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32))
+        refc_param = torch.nn.Parameter(torch.rand(128, dtype=torch.float32))
         ssd_flat_param = so.SsdFlatParameter.from_tensors([refa_param, refb_param, refc_param], direct_to_file=False)
         ssd_flat_param.set_file_params(f.name, 0)
 
@@ -261,7 +261,7 @@ def test_ssd_flat_parameter_view_modify():
     with tempfile.NamedTemporaryFile() as f:
         refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=False)
         refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32), requires_grad=False)
-        refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32), requires_grad=False)
+        refc_param = torch.nn.Parameter(torch.rand(128, dtype=torch.float32), requires_grad=False)
         ssd_flat_param = so.SsdFlatParameter.from_tensors([refa_param, refb_param, refc_param], direct_to_file=False)
         ssd_flat_param.set_file_params(f.name, 0)
         ssd_flat_param.flush_on_dirty = False
@@ -300,7 +300,7 @@ def test_ssd_flat_parameter_view_bwd():
             .requires_grad_()
         )
         refc_param = (
-            torch.nn.Parameter(torch.rand((128), dtype=torch.float32), requires_grad=True)
+            torch.nn.Parameter(torch.rand(128, dtype=torch.float32), requires_grad=True)
             .to("cpu")
             .detach()
             .requires_grad_()
@@ -318,7 +318,7 @@ def test_ssd_flat_parameter_view_bwd():
         grad_acc.register_hook(functools.partial(post_backward_hook, "GradAccumulation_orig", hooks_called))
 
         ssd_flat_param.data = cuda_copy
-        one = torch.ones((1), requires_grad=True, device=ssd_flat_param.device)
+        one = torch.ones(1, requires_grad=True, device=ssd_flat_param.device)
         y1 = ssd_flat_param.views[0] + one
         y2 = cuda_copy + 1
 
@@ -412,7 +412,7 @@ def test_ssd_flat_parameter_direct_to_file():
     with tempfile.NamedTemporaryFile() as f:
         refa_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
         refb_param = torch.nn.Parameter(torch.rand((32, 4), dtype=torch.float32))
-        refc_param = torch.nn.Parameter(torch.rand((128), dtype=torch.float32))
+        refc_param = torch.nn.Parameter(torch.rand(128, dtype=torch.float32))
         ssd_flat_param = so.SsdFlatParameter.from_tensors(
             [refa_param, refb_param, refc_param], direct_to_file=True, filename=f.name, offset=0
         )

--- a/tests/nn/data_parallel/test_sharded_ddp_features.py
+++ b/tests/nn/data_parallel/test_sharded_ddp_features.py
@@ -82,7 +82,7 @@ def run_one_step(
 
     # Any model works. Add one different buffer per rank
     model = _get_mlp()
-    model.register_buffer("test_buffer", torch.ones((1)) * rank)
+    model.register_buffer("test_buffer", torch.ones(1) * rank)
     model.to(device)
 
     next(model.parameters()).requires_grad = False  # Test non-trainable parameters

--- a/tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py
+++ b/tests/nn/data_parallel/test_sharded_ddp_pytorch_parity.py
@@ -131,7 +131,7 @@ def run_ddp_parity(
 
     # Any model works. Add one different buffer per rank
     model = _get_mlp_emb(multiple_fw)
-    model.register_buffer("test_buffer", torch.ones((1)) * rank)
+    model.register_buffer("test_buffer", torch.ones(1) * rank)
     model.to(device)
 
     # Make sure that the model starts with non-trainable, so that we check for the buckets to be
@@ -289,7 +289,7 @@ def run_ddp_parity_two_optim(rank, world_size, backend, temp_file_name, reduce_b
     BATCHS = 20
 
     model = _get_mlp_emb()
-    model.register_buffer("test_buffer", torch.ones((1)) * rank)
+    model.register_buffer("test_buffer", torch.ones(1) * rank)
     model.to(device)
     n_half_params = len(list(model.parameters())) // 2
     optim_settings = {"lr": 1e-3, "momentum": 0.99}

--- a/tests/optim/test_oss.py
+++ b/tests/optim/test_oss.py
@@ -146,7 +146,7 @@ class TestSingleRank(unittest.TestCase):
 
         # Move the model to device after OSS was constructed
         x.to(DEVICE)
-        x(torch.zeros((1), device=DEVICE)).backward()
+        x(torch.zeros(1, device=DEVICE)).backward()
 
         # Check that OSS detects that the device changed
         o.step()
@@ -853,7 +853,7 @@ def run_ddp_parity(rank, world_size, backend, temp_file_name, change_train_graph
         trunk = torch.nn.Sequential(
             torch.nn.Linear(in_channels, hidden), torch.nn.Linear(hidden, hidden), torch.nn.Linear(hidden, hidden)
         )
-        trunk.register_buffer("test_buffer", torch.ones((1)) * rank)
+        trunk.register_buffer("test_buffer", torch.ones(1) * rank)
         trunk.to(device)
 
         head = torch.nn.Linear(hidden, out_channels).to(device)

--- a/tests/utils/test_containers.py
+++ b/tests/utils/test_containers.py
@@ -35,7 +35,7 @@ def test_apply_to_tensors(devices):
     def get_a_tensor():
         """Return a random tensor on random device."""
         dev = random.choice(devices)
-        shape = random.choice(((1), (2, 3), (4, 5, 6), (7, 8, 9, 10)))
+        shape = random.choice((1, (2, 3), (4, 5, 6), (7, 8, 9, 10)))
         t = torch.rand(shape).to(dev)
         nonlocal expected
         expected += t.numel()
@@ -45,7 +45,7 @@ def test_apply_to_tensors(devices):
     data = [1, "str"]
     data.append({"key1": get_a_tensor(), "key2": {1: get_a_tensor()}, "key3": 3})
     data.insert(0, set(["x", get_a_tensor(), get_a_tensor()]))
-    data.append(([1], get_a_tensor(), (1), [get_a_tensor()], set((1, 2))))
+    data.append(([1], get_a_tensor(), 1, [get_a_tensor()], set((1, 2))))
     od = OrderedDict()
     od["k"] = "value"
     data.append(od)


### PR DESCRIPTION
## What does this PR do?
This PR removes a number of false tuples, the construction `(X)` does not create a singleton tuple in python, it just resolves to `X`; the presence of false tuples in the code is misleading to readers, and can lead to difficult debugging situations. True singleton tuples can be constructed via `(X,)`; but I've just removed these because (apparently) the tests work with the singleton values.

## Before submitting

- [X] Did you have fun?
  - Make sure you had fun coding 🙃
- [X] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [X] N/A
- [ ] Did you make sure to update the docs?
  - [X] N/A
- [ ] Did you write any new necessary tests?
  - [X] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [X] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
