### PR TITLE
[fix] a bug in loading flatten state dict

### DIFF
--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -494,8 +494,10 @@ class FlattenParamsWrapper(nn.Module):
         Load a state dict. If necessary, ``unflatten_params`` will be called to
         match the input state_dict.
         """
-        # unflatten the module automatically if the state_dict is non-flat
-        if self.is_flattened and "flat_param_0" not in state_dict:
+        # Unflatten the module automatically if the state_dict is non-flat.
+        # Note, we check the flat_param_ prefix since custom names can be given and flat_param_0 is
+        # not always in the state dict's key list.
+        if self.is_flattened and not any(k.startswith("flat_param_") for k in state_dict.keys()):
             # This object is flatten but state_dict is not. So we unflatten and load.
             with self.unflatten_params():
                 return super().load_state_dict(state_dict, strict)


### PR DESCRIPTION
## What does this PR do?
- Thanks to Alexei for spotting this.
- Added triggering test case.
- enhanced tests with more comments etc.
- I am going to take separate fixes from Alexei's PR and get them in one by one.

@zhaojuanmao, CC you in case this is also an issue in pytorch version. Alexei is still using fairseq, which uses fairscale version of FSDP. He has a few bug fixes that I am going to investigate. Some may be applicable to pytorch version, some may not. We are using fairscale version to experiment a few things around multiple flatten groups for different optimizer settings for different part of the model. I assume pytorch version hasn't supported multiple flatten groups. If I am mistaken please let me know for sure. Thanks!



## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
