### PR TITLE
[feat]: add size and names metadata to sha1 store

### DIFF
--- a/fairscale/experimental/wgit/repo.py
+++ b/fairscale/experimental/wgit/repo.py
@@ -21,6 +21,40 @@ from .sha1_store import SHA1_Store
 SHA1_STORE_DIR_NAME = "sha1_store"
 
 
+# These are on-disk keys. Don't modify for backward compatibility.
+SHA1_KEY = "SHA1"
+LAST_MODIFIED_TS_KEY = "last_modified_time_stamp"
+REL_PATH_KEY = "file_path"  # this will be removed from the json since it is redundant.
+
+
+class RepoStatus(Enum):
+    """Collections of Repo Statuses"""
+
+    CLEAN = 1
+    CHANGES_NOT_ADDED = 2
+    CHANGES_ADDED_NOT_COMMITED = 3
+
+
+@dataclass
+class SizeInfo:
+    """Size info for a file or the repo in bytes.
+
+    Deduped size can't be disabled. So it will always be there.
+
+    Both sparsified and gzipped are optional. They are applied in the following
+    order if both are enabled:
+
+        sparsify -> gzip
+
+    Therefore, original >= deduped >= sparsified >= gzipped
+    """
+
+    original: int
+    deduped: int
+    sparsified: int
+    gzipped: int
+
+
 @dataclass
 class _SHA1_Tensor:
     """Representing a tensor using sha1(s) from SHA1 store.
@@ -155,8 +189,18 @@ class Repo:
             sys.stderr.write("fatal: no wgit repo exists!\n")
             sys.exit(1)
 
-    def add(self, in_file_path: str, per_tensor: bool = False, gzip: bool = True) -> None:
+    def add(
+        self,
+        in_file_path: str,
+        per_tensor: bool = False,
+        gzip: bool = True,
+        sparsify: bool = False,
+        sparsify_policy: Any = None,
+    ) -> Optional[Dict[Any, Any]]:
         """Add a file to the wgit repo.
+
+        This could a new file or a modified file. Adding an unmodified, existing file
+        is allowed but it is a noop.
 
         Args:
             in_file_path (str):
@@ -169,26 +213,51 @@ class Repo:
             gzip (bool, optional):
                 Enable gzip based lossless compression on the object being added.
                 Default: True
+            sparsify (bool, optional):
+                Enable sparsify for the tensors, which is going to modify the values
+                for all or some tensors, i.e. lossy compression.
+                Default: False
+            sparsify_policy (Any):
+                TODO (Min): need to add a callback function to control which tensors
+                            and how to sparsify.
+                Default: None
+
+        Returns:
+            (Dict, optional)
+                None if the content is added but not modified with lossy compression.
+                Otherwise, returns a state_dict that contains the modified Tensors to
+                be loaded back into the model, which means the tensors are dense, not
+                SST and DST tensors.
         """
         self._sanity_check()
 
-        # create the corresponding metadata file
+        if sparsify and not per_tensor:
+            raise ValueError("Only support sparsity when per_tensor is true")
+
+        # Create the corresponding metadata file or load it if the file is
+        # not a newly added file.
         file_path = Path(in_file_path)
         rel_file_path = self._rel_file_path(file_path)
         metadata_file = self._process_metadata_file(rel_file_path)
 
-        # add the file to the sha1_store
+        # Add the file to the sha1_store.
+        ret_state_dict = None
+        file_path_or_state_dict: Union[Path, Dict] = file_path
         # TODO (Min): We don't add parent sha1 tracking to sha1 store due to
         #             de-duplication & dependency tracking can create cycles.
         #             We need to figure out a way to handle deletion.
-        sha1_dict = {}
+        # TODO (Min): We don't detect changes and compute delta on a modified file
+        #             yet. Need to figure out a method for delta tracking.
         if per_tensor:
 
             def fn(element: Any) -> Any:
                 """Callback on each leaf object for _recursive_apply_to_elements below."""
                 if isinstance(element, Tensor):
-                    # TODO (Min): here we will optionally do SST/DST and add those
-                    #             tensors with sparsity.
+                    if sparsify:
+                        # TODO (Min): here we will optionally do SST/DST and add those
+                        #             tensors with sparsity.
+                        #             Remember to update ret_state_dict
+                        raise NotImplementedError()
                     sha1 = self._sha1_store.add(element, compress=gzip)
                     return _SHA1_Tensor(is_dense=True, dense_sha1=sha1)
                 else:
@@ -196,13 +265,16 @@ class Repo:
 
             state_dict = torch.load(file_path)
             _recursive_apply_to_elements(state_dict, fn)
-            sha1_dict = {"__sha1_full__": self._sha1_store.add(state_dict)}
-        else:
-            sha1_dict = {"__sha1_full__": self._sha1_store.add(file_path, compress=gzip)}
+            file_path_or_state_dict = state_dict
+
+        # Add this top-level object.
+        sha1 = self._sha1_store.add(file_path_or_state_dict, compress=gzip)
 
         # write metadata to the metadata-file
-        self._write_metadata(metadata_file, file_path, sha1_dict)
+        self._write_metadata(metadata_file, file_path, sha1)
         self._pygit.add()  # add to the .wgit/.git repo
+
+        return ret_state_dict
 
     def commit(self, message: str) -> None:
         """Commits staged changes to the repo.
@@ -217,7 +289,21 @@ class Repo:
         #             LR, sparsity level, etc.
         self._pygit.commit(message)
 
-    def status(self) -> Dict:
+    def size_info(self, path: Optional[str] = None) -> SizeInfo:
+        """Get size info for a file or the whole repo.
+
+        Args:
+            path (str, optional):
+                File path for the query. If None, return whole repo's info.
+                Default: None
+
+        Returns:
+            (SizeInfo):
+                The dataclass that contains the size info.
+        """
+        raise NotImplementedError()
+
+    def status(self) -> Dict[str, RepoStatus]:
         """Show the state of the weigit working tree.
 
         State can be
@@ -226,6 +312,8 @@ class Repo:
           3. clean and tracking files after a change has been committed,
              or clean with with an empty repo.
 
+        TODO (Min): this needs to return repo status and dirty files and untracked
+                    files too.
         Returns:
             (dict):
                 A dict keyed with files and their status.
@@ -273,20 +361,22 @@ class Repo:
                The sha1 hash of the file version to checkout.
         """
         self._sanity_check()
-        raise NotImplementedError
+        raise NotImplementedError()
 
     def checkout_by_steps(self) -> None:
         """Not Implemented: Checkout by step count of the train process"""
         self._sanity_check()
-        raise NotImplementedError
+        raise NotImplementedError()
 
-    def _get_metdata_files(self) -> Dict:
+    def _get_metdata_files(self) -> Dict[str, bool]:
         """Walk the directories that contain the metadata files and check the
         status of those files, whether they have been modified or not.
+
+        Dict[str, bool] is a path in string and whether the file is_modified.
         """
         metadata_d = dict()
         for file in self._dot_wgit_dir_path.iterdir():  # iterate over the .wgit directory
-            # exlude all the .wgit files and directory
+            # exclude all the .wgit files and directory
             if file.name not in {"sha1_store", ".git", ".gitignore"}:
                 # perform a directory walk on the metadata_file directories to find the metadata files
                 for path in file.rglob("*"):
@@ -302,11 +392,7 @@ class Repo:
         try:
             with open(file) as f:
                 metadata = json.load(f)
-            is_metadata = set(metadata.keys()) == {
-                "SHA1",
-                "file_path",
-                "last_modified_time_stamp",
-            }  # TODO: Consider storing the keys as a class attribute, instead of hard coding.
+            is_metadata = set(metadata.keys()) == {SHA1_KEY, LAST_MODIFIED_TS_KEY, REL_PATH_KEY}
         except json.JSONDecodeError:
             return False  # not a json file, so not valid metadata file
         return is_metadata
@@ -320,8 +406,8 @@ class Repo:
         # Get the last modified timestamp recorded by weigit and the current modified
         # timestamp. If not the same, then file has been modified since last weigit
         # updated metadata.
-        last_mod_timestamp = data["last_modified_time_stamp"]
-        curr_mod_timestamp = Path(data["file_path"]).stat().st_mtime
+        last_mod_timestamp = data[LAST_MODIFIED_TS_KEY]
+        curr_mod_timestamp = Path(data[REL_PATH_KEY]).stat().st_mtime
         return not curr_mod_timestamp == last_mod_timestamp
 
     def _process_metadata_file(self, metadata_fname: Path) -> Path:
@@ -339,13 +425,13 @@ class Repo:
                 ref_data = json.load(f)
         return metadata_file
 
-    def _write_metadata(self, metadata_file: Path, file_path: Path, sha1_dict: Dict) -> None:
+    def _write_metadata(self, metadata_file: Path, file_path: Path, sha1: str) -> None:
         """Write metadata to the metadata file"""
         change_time = Path(file_path).stat().st_mtime
         metadata = {
-            "SHA1": sha1_dict,
-            "file_path": str(file_path),
-            "last_modified_time_stamp": change_time,
+            SHA1_KEY: sha1,
+            LAST_MODIFIED_TS_KEY: change_time,
+            REL_PATH_KEY: str(file_path),
         }
         with open(metadata_file, "w", encoding="utf-8") as f:
             json.dump(metadata, f, ensure_ascii=False, indent=4)
@@ -361,11 +447,3 @@ class Repo:
             pass
         # return the relative part (path not common to cwd)
         return Path(*filepath.parts[i:])
-
-
-class RepoStatus(Enum):
-    """Collections of Repo Statuses"""
-
-    CLEAN = 1
-    CHANGES_NOT_ADDED = 2
-    CHANGES_ADDED_NOT_COMMITED = 3

--- a/fairscale/experimental/wgit/repo.py
+++ b/fairscale/experimental/wgit/repo.py
@@ -292,6 +292,15 @@ class Repo:
     def size_info(self, path: Optional[str] = None) -> SizeInfo:
         """Get size info for a file or the whole repo.
 
+        For the whole repo, just call size_info from sha1_store.
+
+        For a file, needs to open the metadata and find the sha1 and then
+        for per_tensor state_dict, collect size_info on all objects.
+
+        TODO (Min): not exactly clear it is easy to compute this with
+                    delta encoding, deduplication between objects, this
+                    is possible to compute precisely.
+
         Args:
             path (str, optional):
                 File path for the query. If None, return whole repo's info.

--- a/tests/experimental/wgit/test_api.py
+++ b/tests/experimental/wgit/test_api.py
@@ -59,10 +59,11 @@ def test_api_init(capsys, repo):
 
 
 @pytest.mark.parametrize("per_tensor", [True, False])
-def test_api_add(capsys, repo, per_tensor):
+@pytest.mark.parametrize("gzip", [True, False])
+def test_api_add(capsys, repo, per_tensor, gzip):
     fnum = random.randint(0, 2)
     chkpt0 = f"checkpoint_{fnum}.pt"
-    repo.add(chkpt0, per_tensor)
+    repo.add(chkpt0, per_tensor=per_tensor, gzip=gzip)
     if per_tensor:
         # TODO (Min): test per_tensor add more.
         return

--- a/tests/experimental/wgit/test_api.py
+++ b/tests/experimental/wgit/test_api.py
@@ -74,7 +74,7 @@ def test_api_add(capsys, repo, per_tensor, gzip):
         json_data = json.load(f)
 
     sha1_dir_0 = f"{sha1_hash[:2]}/" + f"{sha1_hash[2:]}"
-    assert json_data["SHA1"] == {"__sha1_full__": sha1_hash}
+    assert json_data["SHA1"] == sha1_hash
 
 
 def test_api_commit(capsys, repo):

--- a/tests/experimental/wgit/test_cli.py
+++ b/tests/experimental/wgit/test_cli.py
@@ -64,7 +64,7 @@ def test_cli_add(create_test_dir, capsys):
         json_data = json.load(f)
 
     sha1_dir_0 = f"{sha1_hash[:2]}/" + f"{sha1_hash[2:]}"
-    assert json_data["SHA1"] == {"__sha1_full__": sha1_hash}
+    assert json_data["SHA1"] == sha1_hash
 
 
 def test_cli_commit(capsys):

--- a/tests/experimental/wgit/test_sha1_store.py
+++ b/tests/experimental/wgit/test_sha1_store.py
@@ -174,13 +174,13 @@ def test_sha1_delete(sha1_store, compress):
 
 
 @pytest.mark.parametrize("compress", [True, False])
-def test_sha1_size_info(sha1_store, compress):
-    """Testing the size_info() API."""
+def test_sha1_size_info_and_names(sha1_store, compress):
+    """Testing the size_info() and names() APIs."""
     os.chdir(TESTING_STORE_DIR)
 
     # Add once & check.
     tensor = torch.ones(300, 500)
-    sha1 = sha1_store.add(tensor, compress)
+    sha1 = sha1_store.add(tensor, compress=compress, name="name1")
     orig, dedup, gzip = sha1_store.size_info(sha1)
     assert orig == dedup, "no dedup should happen"
     if not compress:
@@ -189,8 +189,14 @@ def test_sha1_size_info(sha1_store, compress):
         assert orig > gzip, "compression should be smaller"
     assert (orig, dedup, gzip) == sha1_store.size_info(), "store and entry sizes should match"
 
+    names = sha1_store.names(sha1)
+    assert names == {"name1": 1}, names
+
     # Add second time & check.
-    sha1 = sha1_store.add(tensor, compress)
+    sha1 = sha1_store.add(tensor, compress=compress, name="name2")
     orig2, dedup2, gzip2 = sha1_store.size_info(sha1)
     assert orig2 == orig * 2 == dedup2 * 2, "dedup not correct"
     assert gzip == gzip2, "compression shouldn't change"
+
+    names = sha1_store.names(sha1)
+    assert names == {"name1": 1, "name2": 1}, names

--- a/tests/experimental/wgit/test_sha1_store.py
+++ b/tests/experimental/wgit/test_sha1_store.py
@@ -19,6 +19,9 @@ from fairscale.internal import torch_version
 # so that we can proper clean it up at any CWD.
 TESTING_STORE_DIR = Path("sha1_store_testing").resolve()
 
+# Used to filter metadata json keys.
+SHA1_KEY_STR_LEN = 40
+
 
 @pytest.fixture(scope="function")
 def sha1_store(request):
@@ -83,7 +86,7 @@ def test_sha1_add_file(sha1_store, compress):
         # torch 1.8 LTS doesn't produce deterministic checkpoint file from fixed tensors/state_dict.
         key = "da3e19590de8f77fcf7a09c888c526b0149863a0"
         assert key in json_dict.keys() and json_dict[key]["ref_count"] == 2, json_dict
-    del json_dict["created_on"]
+    json_dict = dict(filter(lambda item: len(item[0]) == SHA1_KEY_STR_LEN, json_dict.items()))
     assert sorted(map(lambda x: x["ref_count"], json_dict.values())) == [1, 1, 1, 1, 1, 2], json_dict
 
 
@@ -101,7 +104,7 @@ def test_sha1_add_state_dict(sha1_store, compress):
 
     sha1_store._load_json_dict()
     json_dict = sha1_store._json_dict
-    del json_dict["created_on"]
+    json_dict = dict(filter(lambda item: len(item[0]) == SHA1_KEY_STR_LEN, json_dict.items()))
     assert sorted(map(lambda x: x["ref_count"], json_dict.values())) == [1, 1, 1, 2, 2, 2], json_dict
 
 


### PR DESCRIPTION
## What does this PR do?

These commits add original, deduped, gzipped sizes as well as object names to the sha1 store.

Repo class will in the future use the names metadata so that we can get an idea which tensor is which.

Repo class will expose the store/file sizes at some point.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
