### PR TITLE
Implmentation of dense_sst_to_dst and sst_dst_to_dense

### DIFF
--- a/fairscale/experimental/wgit/signal_sparsity.py
+++ b/fairscale/experimental/wgit/signal_sparsity.py
@@ -271,7 +271,7 @@ class SignalSparsity:
         return _scatter_topk_to_sparse_tensor(delta.abs(), delta, k, dim=self._dst_top_k_dim)
 
     def sst_dst_to_dense(self, sst: Tensor, dst: Optional[Tensor] = None) -> Tensor:
-        """From SST and DST returns a dense reconstruction RT. When argument dst=None, simply returns
+        """From SST and DST returns a dense reconstructed tensor (RT). When argument dst=None, simply returns
         the inverse transform of the SST tensor.
 
         Args:
@@ -284,10 +284,10 @@ class SignalSparsity:
             (Tensor):
                 A dense tensor in real number domain from the SST.
         """
-        dense_recons = torch.real(self._inverse_transform(sst))
+        dense_rt = torch.real(self._inverse_transform(sst))
         if dst is not None:
-            dense_recons += dst
-        return dense_recons
+            dense_rt += dst
+        return dense_rt
 
 
 # We could separate have helper functions that work on state_dict instead of a tensor.

--- a/fairscale/experimental/wgit/signal_sparsity.py
+++ b/fairscale/experimental/wgit/signal_sparsity.py
@@ -248,7 +248,7 @@ class SignalSparsity:
         return _scatter_topk_to_sparse_tensor(real_dense_freq, dense_freq, k, dim=self._sst_top_k_dim)
 
     def dense_sst_to_dst(self, dense: Tensor, sst: Tensor) -> Tensor:
-        """Calculates DST from input dense and SST tensors. The steps are as follows:
+        """Calculates DST from input dense and SST tensors.
 
         dense - ifft(sst)[using sst_dst_to_dense method] -> top-k -> dst
 

--- a/fairscale/experimental/wgit/signal_sparsity.py
+++ b/fairscale/experimental/wgit/signal_sparsity.py
@@ -268,7 +268,7 @@ class SignalSparsity:
         return _scatter_topk_to_sparse_tensor(delta.abs(), delta, k, dim=self._dst_top_k_dim)
 
     def sst_dst_to_dense(self, sst: Tensor, dst: Optional[Tensor] = None) -> Tensor:
-        """From SST and DST returns a dense reconstruction. When argument dst = None, simply returns
+        """From SST and DST returns a dense reconstruction. When argument dst=None, simply returns
         the inverse transform of the SST tensor.
 
         Args:

--- a/fairscale/experimental/wgit/signal_sparsity.py
+++ b/fairscale/experimental/wgit/signal_sparsity.py
@@ -169,8 +169,7 @@ class SignalSparsity:
 
         self._validate_conf()
         # TODO (Min): Type checking for the following
-        self._transform = torch.fft.fft if algo is Algo.FFT else _dct_transform  # type: ignore
-        self._inverse_transform = torch.fft.ifft if algo is Algo.FFT else _inverse_dct_transform  # type: ignore
+        self._transform, self._inverse_transform = (torch.fft.fft, torch.fft.ifft) if algo is Algo.FFT else (_dct_transform, _inverse_dct_transform)  # type: ignore
 
     def _validate_conf(self) -> None:
         """Validating if the config is valid.

--- a/fairscale/experimental/wgit/signal_sparsity.py
+++ b/fairscale/experimental/wgit/signal_sparsity.py
@@ -248,9 +248,7 @@ class SignalSparsity:
         return _scatter_topk_to_sparse_tensor(real_dense_freq, dense_freq, k, dim=self._sst_top_k_dim)
 
     def dense_sst_to_dst(self, dense: Tensor, sst: Tensor) -> Tensor:
-        """Calculates DST from input dense and SST tensors. This utilizes the sst_dst_to_dense
-        method with the parameter dst=None to get the inverse transform of the SST. The steps are
-        as follows:
+        """Calculates DST from input dense and SST tensors. The steps are as follows:
 
         dense - ifft(sst)[using sst_dst_to_dense method] -> top-k -> dst
 
@@ -269,14 +267,14 @@ class SignalSparsity:
         k = _get_k_for_topk(self._dst_top_k_percent, self._dst_top_k_element, top_k_total_size)
         return _scatter_topk_to_sparse_tensor(delta.abs(), delta, k, dim=self._dst_top_k_dim)
 
-    def sst_dst_to_dense(self, sst: Tensor, dst: Tensor = None) -> Tensor:
+    def sst_dst_to_dense(self, sst: Tensor, dst: Optional[Tensor] = None) -> Tensor:
         """From SST and DST returns a dense reconstruction. When argument dst = None, simply returns
         the iFFT of the SST tensor.
 
         Args:
             sst (Tensor):
                 Singal sparse tensor. Required argument.
-            dst (Tensor, optinoal):
+            dst (Tensor, optional):
                 Delta sparse tensor, optional.
 
         Returns:

--- a/fairscale/experimental/wgit/signal_sparsity.py
+++ b/fairscale/experimental/wgit/signal_sparsity.py
@@ -250,7 +250,7 @@ class SignalSparsity:
     def dense_sst_to_dst(self, dense: Tensor, sst: Tensor) -> Tensor:
         """Calculates DST from input dense and SST tensors.
 
-        dense - ifft(sst)[using sst_dst_to_dense method] -> top-k -> dst
+        dense - inverse_transform(sst)[using sst_dst_to_dense method] -> top-k -> dst
 
         Args:
             dense (Tensor):
@@ -262,14 +262,14 @@ class SignalSparsity:
             (Tensor):
                 Same shaped tensor, still dense format but has zeros. Non-zeros are top-k delta values.
         """
-        delta = dense - self.sst_dst_to_dense(sst)  # sst_dst_to_dense(sst) returns the IFFT in this case
+        delta = dense - self.sst_dst_to_dense(sst)  # sst_dst_to_dense(sst) returns the inverse transform here
         top_k_total_size = _top_k_total_size(dense, self._dst_top_k_dim)
         k = _get_k_for_topk(self._dst_top_k_percent, self._dst_top_k_element, top_k_total_size)
         return _scatter_topk_to_sparse_tensor(delta.abs(), delta, k, dim=self._dst_top_k_dim)
 
     def sst_dst_to_dense(self, sst: Tensor, dst: Optional[Tensor] = None) -> Tensor:
         """From SST and DST returns a dense reconstruction. When argument dst = None, simply returns
-        the iFFT of the SST tensor.
+        the inverse transform of the SST tensor.
 
         Args:
             sst (Tensor):

--- a/tests/experimental/wgit/test_signal_sparsity.py
+++ b/tests/experimental/wgit/test_signal_sparsity.py
@@ -12,14 +12,15 @@ from fairscale.experimental.wgit.signal_sparsity import SignalSparsity
 
 def get_test_params():
     """Helper function to create and return a list of tuples of the form:
-    (in_tensor, expected_tensor, dim, percent, top_k_element) to be used as parameters for tests.
+    (dense, expected_sst, expected_dst, expected_weight_reconstruction, dim, percent, top_k_element)
+    to be used as parameters for tests.
     """
     # input in_tensors
     tensor_4x3 = torch.arange(12).reshape(4, 3)
     tensor_2x2x3 = torch.arange(12).reshape(3, 2, 2)
 
     # Expected SST output tensors for 4x3 tensor of ascending ints
-    expected_4x3_None = torch.tensor(
+    expd_sst_4x3_None = torch.tensor(
         [
             [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],  # with dim=None, top-2
             [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
@@ -29,7 +30,11 @@ def get_test_params():
         dtype=torch.complex64,
     )
 
-    expected_4x3_0 = torch.tensor(
+    expd_dst_4x3_None = torch.tensor([[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+
+    expd_wr_4x3_None = torch.tensor([[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [7.0, 7.0, 7.0], [10.0, 10.0, 10.0]])
+
+    expd_sst_4x3_0 = torch.tensor(
         [
             [0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j],  # with dim=0, top-2
             [0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j],
@@ -39,7 +44,11 @@ def get_test_params():
         dtype=torch.complex64,
     )
 
-    expected_4x3_1 = torch.tensor(
+    expd_dst_4x3_0 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+
+    expd_wr_4x3_0 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]])
+
+    expd_sst_4x3_1 = torch.tensor(
         [
             [3.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, 0.0000000 + 0.0000000j],  # with dim=1, top-2
             [12.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, 0.0000000 + 0.0000000j],
@@ -49,20 +58,36 @@ def get_test_params():
         dtype=torch.complex64,
     )
 
-    expected_2x2x3_1 = torch.tensor(
+    expd_dst_4x3_1 = torch.tensor(
+        [[-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000]]
+    )
+
+    expd_wr_4x3_1 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]])
+
+    expd_sst_2x2x3_1 = torch.tensor(
         [
-            [[1.0 + 0.0j, -1.0 + 0.0j], [5.0 + 0.0j, -1.0 + 0.0j]],  # with dim=1, top-2
-            [[9.0 + 0.0j, -1.0 + 0.0j], [13.0 + 0.0j, -1.0 + 0.0j]],
-            [[17.0 + 0.0j, -1.0 + 0.0j], [21.0 + 0.0j, -1.0 + 0.0j]],
+            [[0.0 + 0.0j, -1.0 + 0.0j], [5.0 + 0.0j, 0.0 + 0.0j]],  # with dim=1, top-1
+            [[0.0 + 0.0j, -1.0 + 0.0j], [13.0 + 0.0j, 0.0 + 0.0j]],
+            [[0.0 + 0.0j, -1.0 + 0.0j], [21.0 + 0.0j, 0.0 + 0.0j]],
         ],
         dtype=torch.complex64,
     )
 
+    expd_dst_2x2x3_1 = torch.tensor(
+        [
+            [[0.5000, 0.5000], [0.0000, 0.0000]],  # with dim=1, top-1
+            [[4.5000, 4.5000], [0.0000, 0.0000]],
+            [[8.5000, 8.5000], [0.0000, 0.0000]],
+        ]
+    )
+
+    expd_wr_2x2x3_1 = torch.tensor([[[0.0, 1.0, 2.0], [4.0, 4.0, 4.0]], [[6.0, 7.0, 8.0], [10.0, 10.0, 10.0]]])
+
     return [
-        (tensor_4x3, expected_4x3_None, None, 20, 2),
-        (tensor_4x3, expected_4x3_0, 0, 50, 2),
-        (tensor_4x3, expected_4x3_1, 1, 70, 2),
-        (tensor_2x2x3, expected_2x2x3_1, 1, 100, 2),
+        (tensor_4x3, expd_sst_4x3_None, expd_dst_4x3_None, expd_wr_4x3_None, None, 20, 2),
+        (tensor_4x3, expd_sst_4x3_0, expd_dst_4x3_0, expd_wr_4x3_0, 0, 50, 2),
+        (tensor_4x3, expd_sst_4x3_1, expd_dst_4x3_1, expd_wr_4x3_1, 1, 70, 2),
+        (tensor_2x2x3, expd_sst_2x2x3_1, expd_dst_2x2x3_1, expd_wr_2x2x3_1, 1, 50, 1),
     ]
 
 
@@ -128,16 +153,16 @@ def test_dense_to_sst_perfect_recons(tensor, dim):
     assert all((sparser_2d.dense_to_sst(tensor) == torch.fft.fft(tensor)).flatten())
 
 
-@pytest.mark.parametrize("tensor, expected, dim, percent, k", get_test_params())
-def test_dense_to_sst_fixed(tensor, expected, dim, percent, k):
-    """Tests for fixed input dense tensor and fixed expected output SST tensor for top-2 elements."""
+@pytest.mark.parametrize("tensor, expd_sst, expd_dst, expd_wr, dim, percent, k", get_test_params())
+def test_dense_to_sst_fixed(tensor, expd_sst, expd_dst, expd_wr, dim, percent, k):
+    """Tests for fixed input dense tensor and fixed expected output SST tensor."""
     sparser_2d = SignalSparsity(sst_top_k_percent=None, sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_percent=100)
     sst = sparser_2d.dense_to_sst(tensor)
-    objects_are_equal(sst, expected, raise_exception=True)
+    objects_are_equal(sst, expd_sst, raise_exception=True)
 
 
-@pytest.mark.parametrize("tensor, expected, dim, percent, k", get_test_params())
-def test_percent_element(tensor, expected, dim, percent, k):
+@pytest.mark.parametrize("tensor, expd_sst, expd_dst, expd_wr, dim, percent, k", get_test_params())
+def test_percent_element(tensor, expd_sst, expd_dst, expd_wr, dim, percent, k):
     """Tests whether comparative values for top_k_element and top_k_percent returns same outputs"""
     sparser_2d = SignalSparsity(sst_top_k_percent=None, sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_percent=100)
     sst_element = sparser_2d.dense_to_sst(tensor)
@@ -147,3 +172,42 @@ def test_percent_element(tensor, expected, dim, percent, k):
     )
     sst_percent = sparser_2d.dense_to_sst(tensor)
     objects_are_equal(sst_element, sst_percent, raise_exception=True)
+
+
+@pytest.mark.parametrize("tensor, sst, expd_dst, expd_wr, dim, percent, k", get_test_params())
+def test_dense_sst_to_dst(tensor, sst, expd_dst, expd_wr, dim, percent, k):
+    """Tests fixed expected output DST tensor with fixed input dense and SST tensors."""
+    sparser_2d = SignalSparsity(sst_top_k_percent=None, sst_top_k_element=k, dst_top_k_element=k, dst_top_k_dim=dim)
+    dst = sparser_2d.dense_sst_to_dst(tensor, sst)
+    objects_are_equal(dst, expd_dst, raise_exception=True)
+
+
+@pytest.mark.parametrize(
+    "dense, k, dim",
+    [
+        (torch.arange(12).reshape(4, 3), 12, None),  # top-12, dim=None
+        (torch.arange(12).reshape(4, 3), 4, 0),  # top-4, dim=0
+        (torch.arange(12).reshape(4, 3), 3, 1),  # top-3, dim=1
+        (torch.arange(60).reshape(10, 6), 60, None),  # top-60, dim=None
+        (torch.arange(60).reshape(10, 6), 10, 0),  # top-10, dim=0
+        (torch.arange(60).reshape(10, 6), 6, 1),  # top-6, dim=1
+        (torch.arange(60).reshape(2, 5, 6), 5, 1),  # top-5, dim=1
+    ],
+)
+def test_sst_dst_to_dense_reconstruction(dense, k, dim):
+    """Tests whether perfect reconstruction of input dense tensor is generated when top-k matches the numel
+    across some dimension dim for both SST and DST.
+    """
+    sparser = SignalSparsity(sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_element=k, dst_top_k_dim=dim)
+    sst = sparser.dense_to_sst(dense)
+    dst = sparser.dense_sst_to_dst(dense, sst)
+    dense_recons = sparser.sst_dst_to_dense(sst, dst)
+    objects_are_equal(dense, dense_recons)
+
+
+@pytest.mark.parametrize("tensor, sst, dst, expd_wr, dim, percent, k", get_test_params())
+def test_sst_dst_to_dense(tensor, sst, dst, expd_wr, dim, percent, k):
+    """Tests the correct expected reconstruction from frozen sst and dst tensors."""
+    sparser = SignalSparsity(sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_element=k, dst_top_k_dim=dim)
+    dense_recons = sparser.sst_dst_to_dense(sst, dst)
+    objects_are_equal(dense_recons, expd_wr)

--- a/tests/experimental/wgit/test_signal_sparsity.py
+++ b/tests/experimental/wgit/test_signal_sparsity.py
@@ -16,8 +16,8 @@ def get_test_params():
     to be used as parameters for tests.
     """
     # input in_tensors
-    tensor_4x3 = torch.arange(12).reshape(4, 3)
-    tensor_2x2x3 = torch.arange(12).reshape(3, 2, 2)
+    tensor_4x3 = torch.arange(12).reshape(4, 3).float()
+    tensor_2x2x3 = torch.arange(12).reshape(3, 2, 2).float()
 
     # Expected SST output tensors for 4x3 tensor of ascending ints
     expd_sst_4x3_None = torch.tensor(
@@ -30,9 +30,13 @@ def get_test_params():
         dtype=torch.complex64,
     )
 
-    expd_dst_4x3_None = torch.tensor([[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    expd_dst_4x3_None = torch.tensor(
+        [[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float32
+    )  # with dim=None, top-2
 
-    expd_wr_4x3_None = torch.tensor([[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [7.0, 7.0, 7.0], [10.0, 10.0, 10.0]])
+    expd_wr_4x3_None = torch.tensor(
+        [[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [7.0, 7.0, 7.0], [10.0, 10.0, 10.0]], dtype=torch.float32
+    )
 
     expd_sst_4x3_0 = torch.tensor(
         [
@@ -44,9 +48,13 @@ def get_test_params():
         dtype=torch.complex64,
     )
 
-    expd_dst_4x3_0 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]])
+    expd_dst_4x3_0 = torch.tensor(
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float32
+    )  # with dim=0, top-2
 
-    expd_wr_4x3_0 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]])
+    expd_wr_4x3_0 = torch.tensor(
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]], dtype=torch.float32
+    )
 
     expd_sst_4x3_1 = torch.tensor(
         [
@@ -59,10 +67,13 @@ def get_test_params():
     )
 
     expd_dst_4x3_1 = torch.tensor(
-        [[-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000]]
+        [[-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000]],
+        dtype=torch.float32,  # with dim=1, top-2
     )
 
-    expd_wr_4x3_1 = torch.tensor([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]])
+    expd_wr_4x3_1 = torch.tensor(
+        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]], dtype=torch.float32
+    )
 
     expd_sst_2x2x3_1 = torch.tensor(
         [
@@ -78,10 +89,18 @@ def get_test_params():
             [[0.5000, 0.5000], [0.0000, 0.0000]],  # with dim=1, top-1
             [[4.5000, 4.5000], [0.0000, 0.0000]],
             [[8.5000, 8.5000], [0.0000, 0.0000]],
-        ]
+        ],
+        dtype=torch.float32,
     )
 
-    expd_wr_2x2x3_1 = torch.tensor([[[0.0, 1.0, 2.0], [4.0, 4.0, 4.0]], [[6.0, 7.0, 8.0], [10.0, 10.0, 10.0]]])
+    expd_wr_2x2x3_1 = torch.tensor(
+        [
+            [[0.0000, 1.0000], [2.5000, 2.5000]],
+            [[4.0000, 5.0000], [6.5000, 6.5000]],
+            [[8.0000, 9.0000], [10.5000, 10.5000]],
+        ],
+        dtype=torch.float32,
+    )
 
     return [
         (tensor_4x3, expd_sst_4x3_None, expd_dst_4x3_None, expd_wr_4x3_None, None, 20, 2),
@@ -185,13 +204,13 @@ def test_dense_sst_to_dst(tensor, sst, expd_dst, expd_wr, dim, percent, k):
 @pytest.mark.parametrize(
     "dense, k, dim",
     [
-        (torch.arange(12).reshape(4, 3), 12, None),  # top-12, dim=None
-        (torch.arange(12).reshape(4, 3), 4, 0),  # top-4, dim=0
-        (torch.arange(12).reshape(4, 3), 3, 1),  # top-3, dim=1
-        (torch.arange(60).reshape(10, 6), 60, None),  # top-60, dim=None
-        (torch.arange(60).reshape(10, 6), 10, 0),  # top-10, dim=0
-        (torch.arange(60).reshape(10, 6), 6, 1),  # top-6, dim=1
-        (torch.arange(60).reshape(2, 5, 6), 5, 1),  # top-5, dim=1
+        (torch.arange(12).float().reshape(4, 3), 12, None),  # top-12, dim=None
+        (torch.arange(12).float().reshape(4, 3), 4, 0),  # top-4, dim=0
+        (torch.arange(12).float().reshape(4, 3), 3, 1),  # top-3, dim=1
+        (torch.arange(60).float().reshape(10, 6), 60, None),  # top-60, dim=None
+        (torch.arange(60).float().reshape(10, 6), 10, 0),  # top-10, dim=0
+        (torch.arange(60).float().reshape(10, 6), 6, 1),  # top-6, dim=1
+        (torch.arange(60).float().reshape(2, 5, 6), 5, 1),  # top-5, dim=1
     ],
 )
 def test_sst_dst_to_dense_reconstruction(dense, k, dim):
@@ -202,7 +221,7 @@ def test_sst_dst_to_dense_reconstruction(dense, k, dim):
     sst = sparser.dense_to_sst(dense)
     dst = sparser.dense_sst_to_dst(dense, sst)
     dense_recons = sparser.sst_dst_to_dense(sst, dst)
-    objects_are_equal(dense, dense_recons)
+    objects_are_equal(dense, dense_recons, raise_exception=True)
 
 
 @pytest.mark.parametrize("tensor, sst, dst, expd_wr, dim, percent, k", get_test_params())
@@ -210,4 +229,4 @@ def test_sst_dst_to_dense(tensor, sst, dst, expd_wr, dim, percent, k):
     """Tests the correct expected reconstruction from frozen sst and dst tensors."""
     sparser = SignalSparsity(sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_element=k, dst_top_k_dim=dim)
     dense_recons = sparser.sst_dst_to_dense(sst, dst)
-    objects_are_equal(dense_recons, expd_wr)
+    objects_are_equal(dense_recons, expd_wr, raise_exception=True)

--- a/tests/experimental/wgit/test_signal_sparsity.py
+++ b/tests/experimental/wgit/test_signal_sparsity.py
@@ -37,7 +37,7 @@ def get_test_params():
         [[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float32
     )
 
-    # with dim=None, top-2 for both sst and dst
+    # expected_reconstructed_tensor with dim=None and top-2 for both sst and dst
     expd_rt_4x3_None = torch.tensor(
         [[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [7.0, 7.0, 7.0], [10.0, 10.0, 10.0]], dtype=torch.float32
     )
@@ -58,7 +58,7 @@ def get_test_params():
         [[0.5000, 0.5100, 0.5200], [0.5400, 0.5400, 0.5400], [0.0000, 0.0000, 0.0000], [0.0000, 0.0000, 0.0000]]
     )
 
-    # with dim=0, top-2 for both sst and dst
+    # expected_reconstructed_tensor with dim=0 and top-2 for both sst and dst
     expd_rt_4x3_0 = torch.tensor(
         [[0.5000, 0.5100, 0.5200], [0.5300, 0.5400, 0.5500], [0.5700, 0.5700, 0.5700], [0.5900, 0.6000, 0.6100]]
     )
@@ -82,7 +82,7 @@ def get_test_params():
         ]
     )
 
-    # with dim=1, top-2 for both sst and dst
+    # expected_reconstructed_tensor with dim=1 and top-2 for both sst and dst
     expd_rt_3x3_1 = torch.tensor([[-5.0000, -3.7500, -2.5000], [-1.2500, 0.0000, 1.2500], [2.5000, 3.7500, 5.0000]])
 
     # with dim=1, top-1
@@ -105,7 +105,7 @@ def get_test_params():
         dtype=torch.float32,
     )
 
-    # with dim=1, top-1 for both sst and dst
+    # expected_reconstructed_tensor with dim=1 and top-1 for both sst and dst
     expd_rt_2x2x3_1 = torch.tensor(
         [
             [[0.0000, 1.0000], [2.5000, 2.5000]],
@@ -237,9 +237,9 @@ def test_sst_dst_to_perfect_dense_reconstruction(dense, k, dim):
     objects_are_equal(dense, dense_recons, raise_exception=True)
 
 
-@pytest.mark.parametrize("unused1, sst, dst, expd_wr, dim, unused2, k", get_test_params())
-def test_sst_dst_to_dense(unused1, sst, dst, expd_wr, dim, unused2, k):
+@pytest.mark.parametrize("unused1, sst, dst, expd_rt, dim, unused2, k", get_test_params())
+def test_sst_dst_to_dense(unused1, sst, dst, expd_rt, dim, unused2, k):
     """Tests the correct expected reconstruction from frozen sst and dst tensors."""
     sparser = SignalSparsity(sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_element=k, dst_top_k_dim=dim)
     dense_recons = sparser.sst_dst_to_dense(sst, dst)
-    objects_are_equal(dense_recons, expd_wr, raise_exception=True)
+    objects_are_equal(dense_recons, expd_rt, raise_exception=True)

--- a/tests/experimental/wgit/test_signal_sparsity.py
+++ b/tests/experimental/wgit/test_signal_sparsity.py
@@ -12,17 +12,19 @@ from fairscale.experimental.wgit.signal_sparsity import SignalSparsity
 
 def get_test_params():
     """Helper function to create and return a list of tuples of the form:
-    (dense, expected_sst, expected_dst, expected_weight_reconstruction, dim, percent, top_k_element)
+    (dense, expected_sst, expected_dst, expected_reconstructed_tensor (RT), dim, percent, top_k_element)
     to be used as parameters for tests.
     """
     # input in_tensors
-    tensor_4x3 = torch.arange(12).reshape(4, 3).float()
+    tensor_4x3_None = torch.arange(12).reshape(4, 3).float()
+    tensor_4x3_0 = torch.arange(50, 62).reshape(4, 3) / 100
+    tensor_3x3_1 = torch.linspace(-5, 5, 9).reshape(3, 3)
     tensor_2x2x3 = torch.arange(12).reshape(3, 2, 2).float()
 
-    # Expected SST output tensors for 4x3 tensor of ascending ints
+    # with dim=None, top-2
     expd_sst_4x3_None = torch.tensor(
         [
-            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],  # with dim=None, top-2
+            [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
             [0.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
             [21.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
             [30.0 + 0.0j, 0.0 + 0.0j, 0.0 + 0.0j],
@@ -30,70 +32,81 @@ def get_test_params():
         dtype=torch.complex64,
     )
 
+    # with dim=None, top-2
     expd_dst_4x3_None = torch.tensor(
         [[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float32
-    )  # with dim=None, top-2
+    )
 
-    expd_wr_4x3_None = torch.tensor(
+    # with dim=None, top-2 for both sst and dst
+    expd_rt_4x3_None = torch.tensor(
         [[0.0, 0.0, 0.0], [0.0, 4.0, 5.0], [7.0, 7.0, 7.0], [10.0, 10.0, 10.0]], dtype=torch.float32
     )
 
+    # with dim=0, top-2
     expd_sst_4x3_0 = torch.tensor(
         [
-            [0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j],  # with dim=0, top-2
-            [0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j, 0.0000000 + 0.0000000j],
-            [21.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, -1.5000000 - 0.8660254j],
-            [30.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, -1.5000000 - 0.8660254j],
+            [0.0000000000 + 0.0000000000j, 0.0000000000 + 0.0000000000j, 0.0000000000 + 0.0000000000j],
+            [0.0000000000 + 0.0000000000j, -0.0150000453 + 0.0086602457j, -0.0150000453 - 0.0086602457j],
+            [1.7100000381 + 0.0000000000j, 0.0000000000 + 0.0000000000j, 0.0000000000 + 0.0000000000j],
+            [1.7999999523 + 0.0000000000j, -0.0150000453 + 0.0086602457j, -0.0150000453 - 0.0086602457j],
         ],
         dtype=torch.complex64,
     )
 
+    # with dim=0, top-2
     expd_dst_4x3_0 = torch.tensor(
-        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0]], dtype=torch.float32
-    )  # with dim=0, top-2
-
-    expd_wr_4x3_0 = torch.tensor(
-        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]], dtype=torch.float32
+        [[0.5000, 0.5100, 0.5200], [0.5400, 0.5400, 0.5400], [0.0000, 0.0000, 0.0000], [0.0000, 0.0000, 0.0000]]
     )
 
-    expd_sst_4x3_1 = torch.tensor(
+    # with dim=0, top-2 for both sst and dst
+    expd_rt_4x3_0 = torch.tensor(
+        [[0.5000, 0.5100, 0.5200], [0.5300, 0.5400, 0.5500], [0.5700, 0.5700, 0.5700], [0.5900, 0.6000, 0.6100]]
+    )
+
+    # with dim=1, top-2
+    expd_sst_3x3_1 = torch.tensor(
         [
-            [3.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, 0.0000000 + 0.0000000j],  # with dim=1, top-2
-            [12.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, 0.0000000 + 0.0000000j],
-            [21.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, 0.0000000 + 0.0000000j],
-            [30.0000000 + 0.0000000j, -1.5000000 + 0.8660254j, 0.0000000 + 0.0000000j],
+            [-11.2500000000 + 0.0000000000j, -1.8750000000 + 1.0825316906j, 0.0000000000 + 0.0000000000j],
+            [0.0000000000 + 0.0000000000j, -1.8750000000 + 1.0825316906j, -1.8750000000 - 1.0825316906j],
+            [11.2500000000 + 0.0000000000j, -1.8750000000 + 1.0825316906j, 0.0000000000 + 0.0000000000j],
         ],
         dtype=torch.complex64,
     )
 
-    expd_dst_4x3_1 = torch.tensor(
-        [[-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000], [-0.5000, 0.0000, 0.5000]],
-        dtype=torch.float32,  # with dim=1, top-2
+    # with dim=1, top-2
+    expd_dst_3x3_1 = torch.tensor(
+        [
+            [-6.2500000000e-01, 0.0000000000e00, 6.2500000000e-01],
+            [0.0000000000e00, -4.8244856998e-08, 0.0000000000e00],
+            [-6.2500000000e-01, 0.0000000000e00, 6.2500000000e-01],
+        ]
     )
 
-    expd_wr_4x3_1 = torch.tensor(
-        [[0.0, 1.0, 2.0], [3.0, 4.0, 5.0], [6.0, 7.0, 8.0], [9.0, 10.0, 11.0]], dtype=torch.float32
-    )
+    # with dim=1, top-2 for both sst and dst
+    expd_rt_3x3_1 = torch.tensor([[-5.0000, -3.7500, -2.5000], [-1.2500, 0.0000, 1.2500], [2.5000, 3.7500, 5.0000]])
 
+    # with dim=1, top-1
     expd_sst_2x2x3_1 = torch.tensor(
         [
-            [[0.0 + 0.0j, -1.0 + 0.0j], [5.0 + 0.0j, 0.0 + 0.0j]],  # with dim=1, top-1
+            [[0.0 + 0.0j, -1.0 + 0.0j], [5.0 + 0.0j, 0.0 + 0.0j]],
             [[0.0 + 0.0j, -1.0 + 0.0j], [13.0 + 0.0j, 0.0 + 0.0j]],
             [[0.0 + 0.0j, -1.0 + 0.0j], [21.0 + 0.0j, 0.0 + 0.0j]],
         ],
         dtype=torch.complex64,
     )
 
+    # with dim=1, top-1
     expd_dst_2x2x3_1 = torch.tensor(
         [
-            [[0.5000, 0.5000], [0.0000, 0.0000]],  # with dim=1, top-1
+            [[0.5000, 0.5000], [0.0000, 0.0000]],
             [[4.5000, 4.5000], [0.0000, 0.0000]],
             [[8.5000, 8.5000], [0.0000, 0.0000]],
         ],
         dtype=torch.float32,
     )
 
-    expd_wr_2x2x3_1 = torch.tensor(
+    # with dim=1, top-1 for both sst and dst
+    expd_rt_2x2x3_1 = torch.tensor(
         [
             [[0.0000, 1.0000], [2.5000, 2.5000]],
             [[4.0000, 5.0000], [6.5000, 6.5000]],
@@ -103,10 +116,10 @@ def get_test_params():
     )
 
     return [
-        (tensor_4x3, expd_sst_4x3_None, expd_dst_4x3_None, expd_wr_4x3_None, None, 20, 2),
-        (tensor_4x3, expd_sst_4x3_0, expd_dst_4x3_0, expd_wr_4x3_0, 0, 50, 2),
-        (tensor_4x3, expd_sst_4x3_1, expd_dst_4x3_1, expd_wr_4x3_1, 1, 70, 2),
-        (tensor_2x2x3, expd_sst_2x2x3_1, expd_dst_2x2x3_1, expd_wr_2x2x3_1, 1, 50, 1),
+        (tensor_4x3_None, expd_sst_4x3_None, expd_dst_4x3_None, expd_rt_4x3_None, None, 20, 2),
+        (tensor_4x3_0, expd_sst_4x3_0, expd_dst_4x3_0, expd_rt_4x3_0, 0, 50, 2),
+        (tensor_3x3_1, expd_sst_3x3_1, expd_dst_3x3_1, expd_rt_3x3_1, 1, 70, 2),
+        (tensor_2x2x3, expd_sst_2x2x3_1, expd_dst_2x2x3_1, expd_rt_2x2x3_1, 1, 50, 1),
     ]
 
 
@@ -172,16 +185,16 @@ def test_dense_to_sst_perfect_recons(tensor, dim):
     assert all((sparser_2d.dense_to_sst(tensor) == torch.fft.fft(tensor)).flatten())
 
 
-@pytest.mark.parametrize("tensor, expd_sst, expd_dst, expd_wr, dim, percent, k", get_test_params())
-def test_dense_to_sst_fixed(tensor, expd_sst, expd_dst, expd_wr, dim, percent, k):
+@pytest.mark.parametrize("tensor, expd_sst, unused1, unused2, dim, unused3, k", get_test_params())
+def test_dense_to_sst_fixed(tensor, expd_sst, unused1, unused2, dim, unused3, k):
     """Tests for fixed input dense tensor and fixed expected output SST tensor."""
     sparser_2d = SignalSparsity(sst_top_k_percent=None, sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_percent=100)
     sst = sparser_2d.dense_to_sst(tensor)
     objects_are_equal(sst, expd_sst, raise_exception=True)
 
 
-@pytest.mark.parametrize("tensor, expd_sst, expd_dst, expd_wr, dim, percent, k", get_test_params())
-def test_percent_element(tensor, expd_sst, expd_dst, expd_wr, dim, percent, k):
+@pytest.mark.parametrize("tensor, unused1, unused2, unused3, dim, percent, k", get_test_params())
+def test_percent_element(tensor, unused1, unused2, unused3, dim, percent, k):
     """Tests whether comparative values for top_k_element and top_k_percent returns same outputs"""
     sparser_2d = SignalSparsity(sst_top_k_percent=None, sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_percent=100)
     sst_element = sparser_2d.dense_to_sst(tensor)
@@ -193,8 +206,8 @@ def test_percent_element(tensor, expd_sst, expd_dst, expd_wr, dim, percent, k):
     objects_are_equal(sst_element, sst_percent, raise_exception=True)
 
 
-@pytest.mark.parametrize("tensor, sst, expd_dst, expd_wr, dim, percent, k", get_test_params())
-def test_dense_sst_to_dst(tensor, sst, expd_dst, expd_wr, dim, percent, k):
+@pytest.mark.parametrize("tensor, sst, expd_dst, unused1, dim, unused2, k", get_test_params())
+def test_dense_sst_to_dst(tensor, sst, expd_dst, unused1, dim, unused2, k):
     """Tests fixed expected output DST tensor with fixed input dense and SST tensors."""
     sparser_2d = SignalSparsity(sst_top_k_percent=None, sst_top_k_element=k, dst_top_k_element=k, dst_top_k_dim=dim)
     dst = sparser_2d.dense_sst_to_dst(tensor, sst)
@@ -204,16 +217,16 @@ def test_dense_sst_to_dst(tensor, sst, expd_dst, expd_wr, dim, percent, k):
 @pytest.mark.parametrize(
     "dense, k, dim",
     [
-        (torch.arange(12).float().reshape(4, 3), 12, None),  # top-12, dim=None
-        (torch.arange(12).float().reshape(4, 3), 4, 0),  # top-4, dim=0
-        (torch.arange(12).float().reshape(4, 3), 3, 1),  # top-3, dim=1
+        (torch.linspace(0.01, 0.06, 40).reshape(5, 8), 40, None),  # top-40, dim=None
+        (torch.linspace(0.1, 0.6, 30).reshape(5, 6), 5, 0),  # top-5, dim=0
+        (torch.linspace(-0.1, 0.6, 35).reshape(7, 5), 5, 1),  # top-5, dim=1
         (torch.arange(60).float().reshape(10, 6), 60, None),  # top-60, dim=None
         (torch.arange(60).float().reshape(10, 6), 10, 0),  # top-10, dim=0
         (torch.arange(60).float().reshape(10, 6), 6, 1),  # top-6, dim=1
         (torch.arange(60).float().reshape(2, 5, 6), 5, 1),  # top-5, dim=1
     ],
 )
-def test_sst_dst_to_dense_reconstruction(dense, k, dim):
+def test_sst_dst_to_perfect_dense_reconstruction(dense, k, dim):
     """Tests whether perfect reconstruction of input dense tensor is generated when top-k matches the numel
     across some dimension dim for both SST and DST.
     """
@@ -224,8 +237,8 @@ def test_sst_dst_to_dense_reconstruction(dense, k, dim):
     objects_are_equal(dense, dense_recons, raise_exception=True)
 
 
-@pytest.mark.parametrize("tensor, sst, dst, expd_wr, dim, percent, k", get_test_params())
-def test_sst_dst_to_dense(tensor, sst, dst, expd_wr, dim, percent, k):
+@pytest.mark.parametrize("unused1, sst, dst, expd_wr, dim, unused2, k", get_test_params())
+def test_sst_dst_to_dense(unused1, sst, dst, expd_wr, dim, unused2, k):
     """Tests the correct expected reconstruction from frozen sst and dst tensors."""
     sparser = SignalSparsity(sst_top_k_element=k, sst_top_k_dim=dim, dst_top_k_element=k, dst_top_k_dim=dim)
     dense_recons = sparser.sst_dst_to_dense(sst, dst)


### PR DESCRIPTION
## What does this PR do?
1. Implements the dense_sst_to_dst and sst_dst_to_dense method.
2. Adds tests for perfect reconstruction with all top-k across different dims.
3. Adds tests for the two new methods.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
