### PR TITLE
[testing] Initial fair_dev/fairtest assertion library

### DIFF
--- a/fair_dev/fairtest/__init__.py
+++ b/fair_dev/fairtest/__init__.py
@@ -9,7 +9,7 @@ from fair_dev.fairtest.common_assertions import (
     when_called,
 )
 from fair_dev.fairtest.numeric_assertions import assert_close_to, close_to
-from fair_dev.fairtest.random_utils import with_random_seed
+from fair_dev.fairtest.random_utils import CommonRngState, set_random_seed, with_random_seed
 from fair_dev.fairtest.tensor_assertions import (
     assert_matches_tensor,
     assert_tensor_storage_differs,
@@ -40,6 +40,10 @@ __all__ = [
     # numeric_assertions
     "assert_close_to",
     "close_to",
+    # random_utils
+    "CommonRngState",
+    "set_random_seed",
+    "with_random_seed",
     # tensor_assertions
     "assert_matches_tensor",
     "assert_tensor_storage_differs",
@@ -57,6 +61,4 @@ __all__ = [
     "hide_module_tracebacks",
     # warnings
     "ignore_warnings",
-    # random_utils
-    "with_random_seed",
 ]

--- a/fair_dev/fairtest/__init__.py
+++ b/fair_dev/fairtest/__init__.py
@@ -9,6 +9,7 @@ from fair_dev.fairtest.common_assertions import (
     when_called,
 )
 from fair_dev.fairtest.numeric_assertions import assert_close_to, close_to
+from fair_dev.fairtest.random_utils import with_random_seed
 from fair_dev.fairtest.tensor_assertions import (
     assert_matches_tensor,
     assert_tensor_storage_differs,
@@ -56,4 +57,6 @@ __all__ = [
     "hide_module_tracebacks",
     # warnings
     "ignore_warnings",
+    # random_utils
+    "with_random_seed",
 ]

--- a/fair_dev/fairtest/__init__.py
+++ b/fair_dev/fairtest/__init__.py
@@ -1,0 +1,26 @@
+import hamcrest
+
+from fair_dev.fairtest.common_assertions import (
+    assert_false,
+    assert_match,
+    assert_raises,
+    assert_true,
+    calling_method,
+    when_called,
+)
+from fair_dev.fairtest.numeric_assertions import assert_close_to, close_to
+from fair_dev.fairtest.tracebacks import hide_module_tracebacks
+from fair_dev.fairtest.warnings import ignore_warnings
+
+hide_module_tracebacks(hamcrest.core.base_matcher.__dict__)
+
+__all__ = [
+    "assert_close_to",
+    "assert_match",
+    "assert_raises",
+    "assert_true",
+    "calling_method",
+    "close_to",
+    "hide_module_tracebacks",
+    "when_called",
+]

--- a/fair_dev/fairtest/__init__.py
+++ b/fair_dev/fairtest/__init__.py
@@ -9,18 +9,51 @@ from fair_dev.fairtest.common_assertions import (
     when_called,
 )
 from fair_dev.fairtest.numeric_assertions import assert_close_to, close_to
+from fair_dev.fairtest.tensor_assertions import (
+    assert_matches_tensor,
+    assert_tensor_storage_differs,
+    assert_tensor_structure,
+    assert_tensors_share_storage,
+    different_tensor_storage,
+    matches_tensor,
+    same_tensor_storage,
+    tensor_with_device,
+    tensor_with_dtype,
+    tensor_with_layout,
+    tensor_with_size,
+    tensor_with_structure,
+)
 from fair_dev.fairtest.tracebacks import hide_module_tracebacks
 from fair_dev.fairtest.warnings import ignore_warnings
 
 hide_module_tracebacks(hamcrest.core.base_matcher.__dict__)
 
 __all__ = [
-    "assert_close_to",
+    # common_assertions
+    "assert_false",
     "assert_match",
     "assert_raises",
     "assert_true",
     "calling_method",
-    "close_to",
-    "hide_module_tracebacks",
     "when_called",
+    # numeric_assertions
+    "assert_close_to",
+    "close_to",
+    # tensor_assertions
+    "assert_matches_tensor",
+    "assert_tensor_storage_differs",
+    "assert_tensor_structure",
+    "assert_tensors_share_storage",
+    "different_tensor_storage",
+    "matches_tensor",
+    "same_tensor_storage",
+    "tensor_with_device",
+    "tensor_with_dtype",
+    "tensor_with_layout",
+    "tensor_with_size",
+    "tensor_with_structure",
+    # tracebacks
+    "hide_module_tracebacks",
+    # warnings
+    "ignore_warnings",
 ]

--- a/fair_dev/fairtest/common_assertions.py
+++ b/fair_dev/fairtest/common_assertions.py
@@ -1,0 +1,230 @@
+from dataclasses import dataclass
+import typing
+from typing import Any, Callable, Dict, Optional, Sequence, Tuple, Type
+
+import hamcrest
+from hamcrest.core.assert_that import _assert_bool, _assert_match
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.description import Description
+from hamcrest.core.matcher import Matcher
+
+from fair_dev.fairtest.tracebacks import hide_module_tracebacks
+
+
+def hide_tracebacks(mode: bool = True) -> None:
+    """
+    Hint that some unittest stacks (unittest, pytest) should remove
+    frames from tracebacks that include this module.
+
+    :param mode: optional, the traceback mode.
+    """
+    # globals(), called within the module, grabs the module dict.
+    hide_module_tracebacks(globals(), mode)
+
+
+# default to hiding.
+hide_tracebacks(True)
+
+
+@dataclass
+class WhenCalledMatcher(BaseMatcher[Callable[..., Any]]):
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
+    method: Optional[str] = None
+
+    def __init__(
+        self,
+        args: Sequence[Any],
+        kwargs: Dict[str, Any],
+        matcher: Matcher,
+        method: Optional[str] = None,
+    ) -> None:
+        self.args = tuple(args)
+        self.kwargs = dict(kwargs)
+        self.matcher = matcher
+        self.method = method
+
+    def _matches(self, item: Callable) -> bool:
+        return self.matcher.matches(self._call_item(item))
+
+    def _call_item(self, item: Callable) -> Any:
+        if self.method is None:
+            f = item
+        else:
+            f = getattr(item, self.method)
+
+        return f(*self.args, **self.kwargs)
+
+    def describe_to(self, description: Description) -> None:
+        call_params = ", ".join(
+            tuple([repr(a) for a in self.args] + [f"{k}={repr(v)}" for k, v in self.kwargs.items()])
+        )
+
+        if self.method is None:
+            f = "<callable>"
+        else:
+            f = "<obj>." + self.method
+
+        description.append_text(f"{f}({call_params}) => ")
+        description.append_description_of(self.matcher)
+
+    def describe_mismatch(self, item: Callable, mismatch_description: Description) -> None:
+        val = self._call_item(item)
+        mismatch_description.append_text("was =>").append_description_of(val)
+
+
+@dataclass
+class WhenCalledBuilder:
+    args: Tuple[Any, ...]
+    kwargs: Dict[str, Any]
+    method: Optional[str] = None
+
+    def matches(self, matcher: Any) -> WhenCalledMatcher:
+        return WhenCalledMatcher(
+            args=self.args,
+            kwargs=self.kwargs,
+            matcher=_as_matcher(matcher),
+            method=self.method,
+        )
+
+
+def when_called(*args: Any, **kwargs: Any) -> WhenCalledBuilder:
+    """
+    Build a matcher that asserts that a given callable, when called
+    with the supplied arguments, will yield a result matching the
+    expected matcher.
+
+    Usage:
+
+    >>> def example(a, b, c):
+    >>>     return dict(a=a, b=b, c=c)
+    >>>
+    >>> hamcrest.assert_that(
+    >>>     example,
+    >>>     assertions.when_called(1, 2, c=3) \
+    >>>         .matches(dict(a=1, b=2, c=3))
+    >>> )
+
+    :param args: the arguments to the function.
+    :param kwargs: the keyword arguments to the function.
+    :return: the builder (needs to have `.matches(<Matcher>)` called).
+    """
+    return WhenCalledBuilder(args, kwargs)
+
+
+def calling_method(_method: str, *args: Any, **kwargs: Any) -> WhenCalledBuilder:
+    """
+    Build a matcher that asserts that calling a given method on an object,
+    when called with the supplied arguments, will yield a result matching the
+    expected matcher.
+
+    Usage:
+
+    >>> class Example:
+    >>>   def foo(self, a, b, c):
+    >>>     return dict(a=a, b=b, c=c)
+    >>>
+    >>> hamcrest.assert_that(
+    >>>     Example(),
+    >>>     assertions.calling_method('foo', 1, 2, c=3) \
+    >>>         .matches(dict(a=1, b=2, c=3))
+    >>> )
+
+    :param args: the arguments to the function.
+    :param kwargs: the keyword arguments to the function.
+    :return: the builder (needs to have `.matches(<Matcher>)` called).
+    """
+    return WhenCalledBuilder(args, kwargs, method=_method)
+
+
+def _as_matcher(matcher: Any) -> Matcher:
+    if not isinstance(matcher, Matcher):
+        matcher = hamcrest.is_(matcher)
+
+    return matcher
+
+
+def assert_match(actual: Any, matcher: Any, reason: str = "") -> None:
+    """
+    Asserts that the actual value matches the matcher.
+
+    Similar to hamcrest.assert_that(), but if the matcher is not a Matcher,
+    will fallback to ``hamcrest.is_(matcher)`` rather than boolean matching.
+
+    :param actual: the value to match.
+    :param matcher: a matcher, or a value that will be converted to an ``is_`` matcher.
+    :param reason: Optional explanation to include in failure description.
+    """
+    _assert_match(
+        actual=actual,
+        matcher=_as_matcher(matcher),
+        reason=reason,
+    )
+
+
+def assert_true(actual: Any, reason: str = "") -> None:
+    """
+    Asserts that the actual value is truthy.
+
+    :param actual: the value to match.
+    :param reason: Optional explanation to include in failure description.
+    """
+    _assert_bool(actual, reason=reason)
+
+
+def assert_false(actual: Any, reason: str = "") -> None:
+    """
+    Asserts that the actual value is falsey.
+
+    :param actual: the value to match.
+    :param reason: Optional explanation to include in failure description.
+    """
+    _assert_bool(not actual, reason=reason)
+
+
+def assert_raises(
+    func: Callable[[], Any],
+    exception: Type[Exception],
+    pattern: Optional[str] = None,
+    matching: Any = None,
+) -> None:
+    """
+    Typing utility wrapper for asserting that a lambda throws an expected error.
+
+    Usage:
+
+    >>> def foo():
+    >>>   raise AssertionError("Big time error: 12")
+    >>>
+    >>> assert_raises(
+    >>>   lambda: foo,
+    >>>   AssertionError,
+    >>>   "error: 12",
+    >>> )
+
+    Equivalent to the longer and more annoying:
+
+    >>> hamcrest.assert_that(
+    >>>     # needed to silence mypy
+    >>>     typing.cast(Any, func),
+    >>>     hamcrest.raises(
+    >>>         exception=exception,
+    >>>         pattern=pattern,
+    >>>         matching=matching,
+    >>>     ),
+    >>> )
+
+    :param func: the function to call.
+    :param exception: the exception class to expect.
+    :param pattern: an optional regex to match against the exception message.
+    :param matching: optional Matchers to match against the exception.
+    """
+
+    hamcrest.assert_that(
+        typing.cast(Any, func),
+        hamcrest.raises(
+            exception=exception,
+            pattern=pattern,
+            matching=matching,
+        ),
+    )

--- a/fair_dev/fairtest/common_assertions.py
+++ b/fair_dev/fairtest/common_assertions.py
@@ -57,7 +57,10 @@ class WhenCalledMatcher(BaseMatcher[Callable[..., Any]]):
 
     def describe_to(self, description: Description) -> None:
         call_params = ", ".join(
-            tuple([repr(a) for a in self.args] + [f"{k}={repr(v)}" for k, v in self.kwargs.items()])
+            (
+                *(repr(a) for a in self.args),
+                *(f"{k}={repr(v)}" for k, v in self.kwargs.items()),
+            )
         )
 
         if self.method is None:
@@ -68,7 +71,11 @@ class WhenCalledMatcher(BaseMatcher[Callable[..., Any]]):
         description.append_text(f"{f}({call_params}) => ")
         description.append_description_of(self.matcher)
 
-    def describe_mismatch(self, item: Callable, mismatch_description: Description) -> None:
+    def describe_mismatch(
+        self,
+        item: Callable,
+        mismatch_description: Description,
+    ) -> None:
         val = self._call_item(item)
         mismatch_description.append_text("was =>").append_description_of(val)
 

--- a/fair_dev/fairtest/common_assertions.py
+++ b/fair_dev/fairtest/common_assertions.py
@@ -119,7 +119,7 @@ def when_called(*args: Any, **kwargs: Any) -> WhenCalledBuilder:
     return WhenCalledBuilder(args, kwargs)
 
 
-def calling_method(_method: str, *args: Any, **kwargs: Any) -> WhenCalledBuilder:
+def calling_method(method: str, /, *args: Any, **kwargs: Any) -> WhenCalledBuilder:
     """
     Build a matcher that asserts that calling a given method on an object,
     when called with the supplied arguments, will yield a result matching the
@@ -137,11 +137,12 @@ def calling_method(_method: str, *args: Any, **kwargs: Any) -> WhenCalledBuilder
     >>>         .matches(dict(a=1, b=2, c=3))
     >>> )
 
+    :param method: the method name.
     :param args: the arguments to the function.
     :param kwargs: the keyword arguments to the function.
     :return: the builder (needs to have `.matches(<Matcher>)` called).
     """
-    return WhenCalledBuilder(args, kwargs, method=_method)
+    return WhenCalledBuilder(args, kwargs, method=method)
 
 
 def _as_matcher(matcher: Any) -> Matcher:

--- a/fair_dev/fairtest/common_assertions_test.py
+++ b/fair_dev/fairtest/common_assertions_test.py
@@ -21,11 +21,17 @@ class WhenCalledTest(unittest.TestCase):
         def example(a, b, c):
             return dict(a=a, b=b, c=c)
 
-        hamcrest.assert_that(example, common_assertions.when_called(1, 2, c=3).matches(dict(a=1, b=2, c=3)))
+        hamcrest.assert_that(
+            example,
+            common_assertions.when_called(1, 2, c=3).matches(dict(a=1, b=2, c=3)),
+        )
 
         common_assertions.assert_raises(
             lambda: hamcrest.assert_that(
-                example, common_assertions.when_called(1, 2, c=3).matches(dict(a=1, b=2, c=4))
+                example,
+                common_assertions.when_called(1, 2, c=3).matches(
+                    dict(a=1, b=2, c=4),
+                ),
             ),
             AssertionError,
             (
@@ -40,11 +46,19 @@ class WhenCalledTest(unittest.TestCase):
             def foo(self, a, b, c):
                 return dict(a=a, b=b, c=c)
 
-        hamcrest.assert_that(Example(), common_assertions.calling_method("foo", 1, 2, c=3).matches(dict(a=1, b=2, c=3)))
+        hamcrest.assert_that(
+            Example(),
+            common_assertions.calling_method("foo", 1, 2, c=3).matches(
+                dict(a=1, b=2, c=3),
+            ),
+        )
 
         common_assertions.assert_raises(
             lambda: hamcrest.assert_that(
-                Example(), common_assertions.calling_method("foo", 1, 2, c=3).matches(dict(a=1, b=2, c=4))
+                Example(),
+                common_assertions.calling_method("foo", 1, 2, c=3).matches(
+                    dict(a=1, b=2, c=4),
+                ),
             ),
             AssertionError,
             (
@@ -83,7 +97,10 @@ class AssertTruthTest(unittest.TestCase):
         )
 
         hamcrest.assert_that(
-            typing.cast(Any, lambda: common_assertions.assert_true("", reason="meh")),
+            typing.cast(
+                Any,
+                lambda: common_assertions.assert_true("", reason="meh"),
+            ),
             hamcrest.raises(
                 AssertionError,
                 "meh",
@@ -106,7 +123,10 @@ class AssertFalseTest(unittest.TestCase):
         )
 
         hamcrest.assert_that(
-            typing.cast(Any, lambda: common_assertions.assert_false("abc", reason="meh")),
+            typing.cast(
+                Any,
+                lambda: common_assertions.assert_false("abc", reason="meh"),
+            ),
             hamcrest.raises(
                 AssertionError,
                 "meh",
@@ -121,7 +141,11 @@ class AssertRaisesTest(unittest.TestCase):
             ValueError,
         )
 
-        common_assertions.assert_raises(lambda: _throw(ValueError("abc")), ValueError, "abc")
+        common_assertions.assert_raises(
+            lambda: _throw(ValueError("abc")),
+            ValueError,
+            "abc",
+        )
 
         # No exception.
         hamcrest.assert_that(
@@ -153,7 +177,11 @@ class AssertRaisesTest(unittest.TestCase):
         )
 
     def test_regex(self) -> None:
-        common_assertions.assert_raises(lambda: _throw(ValueError("abc 123")), ValueError, "abc [0-9]+")
+        common_assertions.assert_raises(
+            lambda: _throw(ValueError("abc 123")),
+            ValueError,
+            "abc [0-9]+",
+        )
 
         hamcrest.assert_that(
             typing.cast(

--- a/fair_dev/fairtest/common_assertions_test.py
+++ b/fair_dev/fairtest/common_assertions_test.py
@@ -1,0 +1,197 @@
+import typing
+from typing import Any, NoReturn
+import unittest
+
+import hamcrest
+
+from fair_dev.fairtest import common_assertions
+
+
+def _throw(exception: Exception) -> NoReturn:
+    """
+    Throw an exception, useful inside a lambda.
+
+    :param exception: the exception.
+    """
+    raise exception
+
+
+class WhenCalledTest(unittest.TestCase):
+    def test_when_called(self) -> None:
+        def example(a, b, c):
+            return dict(a=a, b=b, c=c)
+
+        hamcrest.assert_that(example, common_assertions.when_called(1, 2, c=3).matches(dict(a=1, b=2, c=3)))
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                example, common_assertions.when_called(1, 2, c=3).matches(dict(a=1, b=2, c=4))
+            ),
+            AssertionError,
+            (
+                r"Expected: <callable>\(1, 2, c=3\) => <{'a': 1, 'b': 2, 'c': 4}>"
+                r"\s*"
+                r"but: was =><{'a': 1, 'b': 2, 'c': 3}>"
+            ),
+        )
+
+    def test_calling_method(self) -> None:
+        class Example:
+            def foo(self, a, b, c):
+                return dict(a=a, b=b, c=c)
+
+        hamcrest.assert_that(Example(), common_assertions.calling_method("foo", 1, 2, c=3).matches(dict(a=1, b=2, c=3)))
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                Example(), common_assertions.calling_method("foo", 1, 2, c=3).matches(dict(a=1, b=2, c=4))
+            ),
+            AssertionError,
+            (
+                r"Expected: <obj>.foo\(1, 2, c=3\) => <{'a': 1, 'b': 2, 'c': 4}>"
+                r"\s*"
+                r"but: was =><{'a': 1, 'b': 2, 'c': 3}>"
+            ),
+        )
+
+
+class AssertMatchTest(unittest.TestCase):
+    def test(self) -> None:
+        common_assertions.assert_match("abc", "abc")
+
+        hamcrest.assert_that(
+            typing.cast(Any, lambda: common_assertions.assert_match("abc", "xyz")),
+            hamcrest.raises(
+                AssertionError,
+                "Expected: 'xyz'",
+            ),
+        )
+
+
+class AssertTruthTest(unittest.TestCase):
+    def test(self) -> None:
+        common_assertions.assert_true(True)
+        common_assertions.assert_true("abc")
+        common_assertions.assert_true(1)
+        common_assertions.assert_true([1])
+
+        hamcrest.assert_that(
+            typing.cast(Any, lambda: common_assertions.assert_true(False)),
+            hamcrest.raises(
+                AssertionError,
+            ),
+        )
+
+        hamcrest.assert_that(
+            typing.cast(Any, lambda: common_assertions.assert_true("", reason="meh")),
+            hamcrest.raises(
+                AssertionError,
+                "meh",
+            ),
+        )
+
+
+class AssertFalseTest(unittest.TestCase):
+    def test(self) -> None:
+        common_assertions.assert_false(False)
+        common_assertions.assert_false("")
+        common_assertions.assert_false(0)
+        common_assertions.assert_false([])
+
+        hamcrest.assert_that(
+            typing.cast(Any, lambda: common_assertions.assert_false(True)),
+            hamcrest.raises(
+                AssertionError,
+            ),
+        )
+
+        hamcrest.assert_that(
+            typing.cast(Any, lambda: common_assertions.assert_false("abc", reason="meh")),
+            hamcrest.raises(
+                AssertionError,
+                "meh",
+            ),
+        )
+
+
+class AssertRaisesTest(unittest.TestCase):
+    def test_simple(self) -> None:
+        common_assertions.assert_raises(
+            lambda: _throw(ValueError("abc")),
+            ValueError,
+        )
+
+        common_assertions.assert_raises(lambda: _throw(ValueError("abc")), ValueError, "abc")
+
+        # No exception.
+        hamcrest.assert_that(
+            typing.cast(
+                Any,
+                lambda: common_assertions.assert_raises(
+                    lambda: (),
+                    ValueError,
+                ),
+            ),
+            hamcrest.raises(
+                AssertionError,
+                "No exception raised",
+            ),
+        )
+
+        # Wrong exception type.
+        hamcrest.assert_that(
+            typing.cast(
+                Any,
+                lambda: common_assertions.assert_raises(
+                    lambda: _throw(ValueError("abc 123")), IndexError, "abc [0-9]+"
+                ),
+            ),
+            hamcrest.raises(
+                AssertionError,
+                "was raised instead",
+            ),
+        )
+
+    def test_regex(self) -> None:
+        common_assertions.assert_raises(lambda: _throw(ValueError("abc 123")), ValueError, "abc [0-9]+")
+
+        hamcrest.assert_that(
+            typing.cast(
+                Any,
+                lambda: common_assertions.assert_raises(
+                    lambda: _throw(ValueError("abc xyz")), ValueError, "abc [0-9]+"
+                ),
+            ),
+            hamcrest.raises(
+                AssertionError,
+                "the expected pattern .* not found",
+            ),
+        )
+
+    def test_matching(self) -> None:
+        class ExampleException(ValueError):
+            code: int
+
+        e = ExampleException("abc 123")
+        e.code = 123
+
+        common_assertions.assert_raises(
+            lambda: _throw(e),
+            ValueError,
+            matching=hamcrest.has_properties(code=123),
+        )
+
+        hamcrest.assert_that(
+            typing.cast(
+                Any,
+                lambda: common_assertions.assert_raises(
+                    lambda: _throw(e),
+                    ValueError,
+                    matching=hamcrest.has_properties(code=9),
+                ),
+            ),
+            hamcrest.raises(
+                AssertionError,
+                "Correct assertion type .* but an object with .* not found",
+            ),
+        )

--- a/fair_dev/fairtest/common_assertions_test.py
+++ b/fair_dev/fairtest/common_assertions_test.py
@@ -1,5 +1,5 @@
 import typing
-from typing import Any, NoReturn
+from typing import Any, Dict, NoReturn
 import unittest
 
 import hamcrest
@@ -18,7 +18,7 @@ def _throw(exception: Exception) -> NoReturn:
 
 class WhenCalledTest(unittest.TestCase):
     def test_when_called(self) -> None:
-        def example(a, b, c):
+        def example(a: Any, b: Any, c: Any) -> Dict[str, Any]:
             return dict(a=a, b=b, c=c)
 
         hamcrest.assert_that(
@@ -43,7 +43,7 @@ class WhenCalledTest(unittest.TestCase):
 
     def test_calling_method(self) -> None:
         class Example:
-            def foo(self, a, b, c):
+            def foo(self, a: Any, b: Any, c: Any) -> Dict[str, Any]:
                 return dict(a=a, b=b, c=c)
 
         hamcrest.assert_that(

--- a/fair_dev/fairtest/examples_test.py
+++ b/fair_dev/fairtest/examples_test.py
@@ -1,0 +1,27 @@
+import unittest
+
+import hamcrest
+import torch
+
+from fair_dev import fairtest
+
+
+class ExamplesTest(unittest.TestCase):
+    def test_split(self) -> None:
+        a = torch.ones(3)
+        fairtest.assert_match(
+            a.split([1, 2]),
+            hamcrest.contains_exactly(
+                fairtest.tensor_with_structure(size=[1], device="cpu"),
+                fairtest.tensor_with_structure(size=[2], device="cpu"),
+            ),
+        )
+
+    def test_random(self) -> None:
+        with fairtest.with_random_seed(0):
+            a = torch.rand(2, 3)
+
+        with fairtest.with_random_seed(0):
+            b = torch.rand(2, 3)
+
+        fairtest.assert_matches_tensor(a, b)

--- a/fair_dev/fairtest/examples_test.py
+++ b/fair_dev/fairtest/examples_test.py
@@ -1,6 +1,8 @@
+import random
 import unittest
 
 import hamcrest
+import numpy as np
 import torch
 
 from fair_dev import fairtest
@@ -20,8 +22,16 @@ class ExamplesTest(unittest.TestCase):
     def test_random(self) -> None:
         with fairtest.with_random_seed(0):
             a = torch.rand(2, 3)
+            x = np.random.rand(2, 3)
+            m = random.random()
 
         with fairtest.with_random_seed(0):
             b = torch.rand(2, 3)
+            y = np.random.rand(2, 3)
+            n = random.random()
 
         fairtest.assert_matches_tensor(a, b)
+
+        fairtest.assert_true((x == y).all())
+
+        fairtest.assert_match(m, n)

--- a/fair_dev/fairtest/hide_tracebacks_test.py
+++ b/fair_dev/fairtest/hide_tracebacks_test.py
@@ -1,7 +1,7 @@
 from fair_dev.fairtest import common_assertions, tracebacks
 
 
-def test_hide_tracebacks():
+def test_hide_tracebacks() -> None:
     # we can verify the behavior of setting the flags here,
     # but we can't easily trigger the behavior of stripping tracebacks.
 

--- a/fair_dev/fairtest/hide_tracebacks_test.py
+++ b/fair_dev/fairtest/hide_tracebacks_test.py
@@ -1,0 +1,24 @@
+from fair_dev.fairtest import common_assertions, tracebacks
+
+
+def test_hide_tracebacks():
+    # we can verify the behavior of setting the flags here,
+    # but we can't easily trigger the behavior of stripping tracebacks.
+
+    tracebacks.hide_module_tracebacks(globals())
+
+    common_assertions.assert_true(
+        globals()["__unittest"],
+    )
+    common_assertions.assert_true(
+        globals()["__tracebackhide__"],
+    )
+
+    tracebacks.hide_module_tracebacks(globals(), False)
+
+    common_assertions.assert_false(
+        globals()["__unittest"],
+    )
+    common_assertions.assert_false(
+        globals()["__tracebackhide__"],
+    )

--- a/fair_dev/fairtest/numeric_assertions.py
+++ b/fair_dev/fairtest/numeric_assertions.py
@@ -1,0 +1,82 @@
+from typing import Any, Optional, SupportsFloat
+
+import hamcrest
+
+from fair_dev.fairtest import assert_match, hide_module_tracebacks
+
+
+def hide_tracebacks(mode: bool = True) -> None:
+    """
+    Hint that some unittest stacks (unittest, pytest) should remove
+    frames from tracebacks that include this module.
+
+    :param mode: optional, the traceback mode.
+    """
+    # globals(), called within the module, grabs the module dict.
+    hide_module_tracebacks(globals(), mode)
+
+
+# default to hiding.
+hide_tracebacks(True)
+
+
+def close_to(
+    expected: Any,
+    delta: Optional[SupportsFloat] = None,
+    *,
+    rtol: SupportsFloat = 1e-05,
+    atol: SupportsFloat = 1e-08,
+):
+    """
+    `close_to()` variant matcher with a default dynamic delta, based on `numpy.isclose()`,
+
+    This clones the numpy notion of `np.isclose()` pattern, where the default delta is:
+
+    >>> delta = atol + rtol * abs(expected)
+
+    :param expected: the expected value.
+    :param delta: (optional) the tolerance.
+    :param rtol: if delta is None, the relative tolerance.
+    :param atol: if delta is None, the absolute tolerance.
+    :return: a close_to() matcher.
+    """
+
+    if delta is None:
+        # numpy.isclose() pattern:
+        delta = atol + rtol * abs(expected)
+
+    delta = float(delta)
+
+    return hamcrest.close_to(float(expected), delta)
+
+
+def assert_close_to(
+    actual: Any,
+    expected: Any,
+    delta: Optional[SupportsFloat] = None,
+    *,
+    rtol: SupportsFloat = 1e-05,
+    atol: SupportsFloat = 1e-08,
+) -> None:
+    """
+    Asserts that two values are close to each other, with automagic delta selection.
+
+    This clones the numpy notion of `np.isclose()` pattern, where the default delta is:
+
+    >>> delta = atol + rtol * abs(expected)
+
+    :param actual: the actual value.
+    :param expected: the expected value.
+    :param delta: (optional) the tolerance.
+    :param rtol: if delta is None, the relative tolerance.
+    :param atol: if delta is None, the absolute tolerance.
+    """
+    assert_match(
+        actual,
+        close_to(
+            expected=expected,
+            delta=delta,
+            rtol=rtol,
+            atol=atol,
+        ),
+    )

--- a/fair_dev/fairtest/numeric_assertions.py
+++ b/fair_dev/fairtest/numeric_assertions.py
@@ -2,7 +2,8 @@ from typing import Any, Optional, SupportsFloat
 
 import hamcrest
 
-from fair_dev.fairtest import assert_match, hide_module_tracebacks
+from fair_dev.fairtest.common_assertions import assert_match
+from fair_dev.fairtest.tracebacks import hide_module_tracebacks
 
 
 def hide_tracebacks(mode: bool = True) -> None:

--- a/fair_dev/fairtest/numeric_assertions.py
+++ b/fair_dev/fairtest/numeric_assertions.py
@@ -1,6 +1,7 @@
 from typing import Any, Optional, SupportsFloat
 
 import hamcrest
+from hamcrest.core.matcher import Matcher
 
 from fair_dev.fairtest.common_assertions import assert_match
 from fair_dev.fairtest.tracebacks import hide_module_tracebacks
@@ -27,7 +28,7 @@ def close_to(
     *,
     rtol: SupportsFloat = 1e-05,
     atol: SupportsFloat = 1e-08,
-):
+) -> Matcher:
     """
     `close_to()` variant matcher with a default dynamic delta, based on `numpy.isclose()`,
 

--- a/fair_dev/fairtest/numeric_assertions_test.py
+++ b/fair_dev/fairtest/numeric_assertions_test.py
@@ -4,7 +4,7 @@ from fair_dev.fairtest import common_assertions, numeric_assertions
 
 
 class AssertCloseToTest(unittest.TestCase):
-    def test(self):
+    def test(self) -> None:
         numeric_assertions.assert_close_to(
             12.5,
             12.49999,

--- a/fair_dev/fairtest/numeric_assertions_test.py
+++ b/fair_dev/fairtest/numeric_assertions_test.py
@@ -16,5 +16,5 @@ class AssertCloseToTest(unittest.TestCase):
                 12.499,
             ),
             AssertionError,
-            (r"a numeric value within <0.000125> of <12.499>" r"\s*" r"but: <12.5> differed by <0.0009"),
+            r"within <0.000125> of <12.499>\s*but: <12.5> differed by <0.0009",
         )

--- a/fair_dev/fairtest/numeric_assertions_test.py
+++ b/fair_dev/fairtest/numeric_assertions_test.py
@@ -1,0 +1,20 @@
+import unittest
+
+from fair_dev.fairtest import common_assertions, numeric_assertions
+
+
+class AssertCloseToTest(unittest.TestCase):
+    def test(self):
+        numeric_assertions.assert_close_to(
+            12.5,
+            12.49999,
+        )
+
+        common_assertions.assert_raises(
+            lambda: numeric_assertions.assert_close_to(
+                12.5,
+                12.499,
+            ),
+            AssertionError,
+            (r"a numeric value within <0.000125> of <12.499>" r"\s*" r"but: <12.5> differed by <0.0009"),
+        )

--- a/fair_dev/fairtest/random_utils.py
+++ b/fair_dev/fairtest/random_utils.py
@@ -1,24 +1,70 @@
 import contextlib
-from typing import Iterator, Union
+import random
+from typing import Any, Iterator, Optional
 
+import numpy as np
 import torch
 
 
-@contextlib.contextmanager
-def with_random_seed(seed_or_state: Union[int | torch.ByteTensor]) -> Iterator:
+def set_random_seed(
+    seed: int = 0,
+    py_rng_state: Optional[Any] = None,
+    torch_rng_state: Optional[Any] = None,
+    np_rng_state: Optional[Any] = None,
+) -> None:
     """
-    Context manager which resets the global random number generator,
-    and restores it on exit.
+    Sets the python, torch, and numpy global random number generators.
 
-    :param seed_or_state: the seed (an int) or .get_rng_state() (a ByteTensor)
+    :param seed: the seed.
+    :param py_rng_state: (optional) the python rng state.
+    :param torch_rng_state: (optional) the torch rng state.
+    :param np_rng_state: (optional) the numpy rng state.
     """
-    old_state = torch.get_rng_state()
-
-    if isinstance(seed_or_state, torch.Tensor):
-        torch.set_rng_state(seed_or_state)
+    if py_rng_state is not None:
+        random.setstate(py_rng_state)
     else:
-        torch.manual_seed(seed_or_state)
+        random.seed(seed)
+
+    if torch_rng_state is not None:
+        torch.set_rng_state(torch_rng_state)
+    else:
+        torch.manual_seed(seed)
+
+    if np_rng_state is not None:
+        np.random.set_state(np_rng_state)
+    else:
+        np.random.seed(seed)
+
+
+@contextlib.contextmanager
+def with_random_seed(
+    seed: int = 0,
+    py_rng_state: Optional[Any] = None,
+    torch_rng_state: Optional[Any] = None,
+    np_rng_state: Optional[Any] = None,
+) -> Iterator:
+    """
+    Context manager which resets the python, torch, and numpy global random number generators,
+    and restores them on exit.
+
+    :param seed: the seed.
+    :param py_rng_state: (optional) the python rng state.
+    :param torch_rng_state: (optional) the torch rng state.
+    :param np_rng_state: (optional) the numpy rng state.
+    """
+    old_py_state = random.getstate()
+    old_torch_state = torch.get_rng_state()
+    old_np_state = np.random.get_state()
+
+    set_random_seed(
+        seed=seed,
+        py_rng_state=py_rng_state,
+        torch_rng_state=torch_rng_state,
+        np_rng_state=np_rng_state,
+    )
 
     yield
 
-    torch.set_rng_state(old_state)
+    random.setstate(old_py_state)
+    torch.set_rng_state(old_torch_state)
+    np.random.set_state(old_np_state)

--- a/fair_dev/fairtest/random_utils.py
+++ b/fair_dev/fairtest/random_utils.py
@@ -10,7 +10,7 @@ def with_random_seed(seed_or_state: Union[int | torch.ByteTensor]) -> Iterator:
     Context manager which resets the global random number generator,
     and restores it on exit.
 
-    :param seed_or_state: the seed (an int) or .get_rng_state() (a Tensor)
+    :param seed_or_state: the seed (an int) or .get_rng_state() (a ByteTensor)
     """
     old_state = torch.get_rng_state()
 

--- a/fair_dev/fairtest/random_utils.py
+++ b/fair_dev/fairtest/random_utils.py
@@ -1,15 +1,24 @@
 import contextlib
-import typing
+from typing import Iterator, Union
 
 import torch
 
 
 @contextlib.contextmanager
-def reset_generator_seed(seed: int = 3 * 17 * 53 + 1) -> typing.Iterator:
+def with_random_seed(seed_or_state: Union[int | torch.ByteTensor]) -> Iterator:
     """
-    Context manager which resets the `torch.manual_seed()` seed on entry.
+    Context manager which resets the global random number generator,
+    and restores it on exit.
 
-    :param seed: optional seed.
+    :param seed_or_state: the seed (an int) or .get_rng_state() (a Tensor)
     """
-    torch.manual_seed(seed)
+    old_state = torch.get_rng_state()
+
+    if isinstance(seed_or_state, torch.Tensor):
+        torch.set_rng_state(seed_or_state)
+    else:
+        torch.manual_seed(seed_or_state)
+
     yield
+
+    torch.set_rng_state(old_state)

--- a/fair_dev/fairtest/random_utils.py
+++ b/fair_dev/fairtest/random_utils.py
@@ -1,0 +1,15 @@
+import contextlib
+import typing
+
+import torch
+
+
+@contextlib.contextmanager
+def reset_generator_seed(seed: int = 3 * 17 * 53 + 1) -> typing.Iterator:
+    """
+    Context manager which resets the `torch.manual_seed()` seed on entry.
+
+    :param seed: optional seed.
+    """
+    torch.manual_seed(seed)
+    yield

--- a/fair_dev/fairtest/random_utils_test.py
+++ b/fair_dev/fairtest/random_utils_test.py
@@ -15,7 +15,13 @@ class WithRandomSeedTest(unittest.TestCase):
         with random_utils.with_random_seed(0):
             b = torch.rand(2, 3)
 
+        with random_utils.with_random_seed(0):
+            state = torch.get_rng_state()
+        with random_utils.with_random_seed(state):
+            c = torch.rand(2, 3)
+
         tensor_assertions.assert_matches_tensor(a, b)
+        tensor_assertions.assert_matches_tensor(a, c)
 
         tensor_assertions.assert_matches_tensor(
             torch.get_rng_state(),

--- a/fair_dev/fairtest/random_utils_test.py
+++ b/fair_dev/fairtest/random_utils_test.py
@@ -1,29 +1,64 @@
+import random
 import unittest
 
+import numpy as np
 import torch
 
-from fair_dev.fairtest import random_utils, tensor_assertions
+from fair_dev.fairtest import common_assertions, random_utils, tensor_assertions
 
 
 class WithRandomSeedTest(unittest.TestCase):
     def test(self) -> None:
-        expected_state = torch.get_rng_state()
+        expected_py_state = random.getstate()
+        expected_torch_state = torch.get_rng_state()
+        expected_np_state = np.random.get_state()
+
+        # comparing numpy structures is still hard,
+        # capture a side-effect for later.
+        j = np.random.rand(2, 3)
+        np.random.set_state(expected_np_state)
 
         with random_utils.with_random_seed(0):
             a = torch.rand(2, 3)
+            x = np.random.rand(2, 3)
+            m = random.random()
 
         with random_utils.with_random_seed(0):
             b = torch.rand(2, 3)
+            y = np.random.rand(2, 3)
+            n = random.random()
 
         with random_utils.with_random_seed(0):
-            state = torch.get_rng_state()
-        with random_utils.with_random_seed(state):
+            torch_state = torch.get_rng_state()
+            np_state = np.random.get_state()
+
+        with random_utils.with_random_seed(
+            torch_rng_state=torch_state,
+            np_rng_state=np_state,
+        ):
             c = torch.rand(2, 3)
+            z = np.random.rand(2, 3)
+            o = random.random()
 
         tensor_assertions.assert_matches_tensor(a, b)
         tensor_assertions.assert_matches_tensor(a, c)
 
+        common_assertions.assert_true((x == y).all())
+        common_assertions.assert_true((x == z).all())
+
+        common_assertions.assert_match(m, n)
+        common_assertions.assert_match(m, o)
+
+        common_assertions.assert_match(
+            random.getstate(),
+            expected_py_state,
+        )
+
         tensor_assertions.assert_matches_tensor(
             torch.get_rng_state(),
-            expected_state,
+            expected_torch_state,
         )
+
+        # TODO: nice numpy matchers similar to the Tensor matchers.
+        k = np.random.rand(2, 3)
+        common_assertions.assert_true((j == k).all())

--- a/fair_dev/fairtest/random_utils_test.py
+++ b/fair_dev/fairtest/random_utils_test.py
@@ -29,13 +29,9 @@ class WithRandomSeedTest(unittest.TestCase):
             n = random.random()
 
         with random_utils.with_random_seed(0):
-            torch_state = torch.get_rng_state()
-            np_state = np.random.get_state()
+            state = random_utils.CommonRngState.get_state()
 
-        with random_utils.with_random_seed(
-            torch_rng_state=torch_state,
-            np_rng_state=np_state,
-        ):
+        with random_utils.with_random_seed(state=state):
             c = torch.rand(2, 3)
             z = np.random.rand(2, 3)
             o = random.random()

--- a/fair_dev/fairtest/random_utils_test.py
+++ b/fair_dev/fairtest/random_utils_test.py
@@ -1,0 +1,23 @@
+import unittest
+
+import torch
+
+from fair_dev.fairtest import random_utils, tensor_assertions
+
+
+class WithRandomSeedTest(unittest.TestCase):
+    def test(self) -> None:
+        expected_state = torch.get_rng_state()
+
+        with random_utils.with_random_seed(0):
+            a = torch.rand(2, 3)
+
+        with random_utils.with_random_seed(0):
+            b = torch.rand(2, 3)
+
+        tensor_assertions.assert_matches_tensor(a, b)
+
+        tensor_assertions.assert_matches_tensor(
+            torch.get_rng_state(),
+            expected_state,
+        )

--- a/fair_dev/fairtest/tensor_assertions.py
+++ b/fair_dev/fairtest/tensor_assertions.py
@@ -1,0 +1,354 @@
+import numbers
+import typing
+
+import hamcrest
+from hamcrest.core.base_matcher import BaseMatcher
+from hamcrest.core.description import Description
+from hamcrest.core.matcher import Matcher
+import torch
+
+from fair_dev.fairtest import common_assertions, tracebacks
+
+# int is not a Number?
+# https://github.com/python/mypy/issues/3186
+# https://stackoverflow.com/questions/69334475/how-to-hint-at-number-types-i-e-subclasses-of-number-not-numbers-themselv/69383462#69383462kk
+
+NumberLike = typing.Union[numbers.Number, numbers.Complex, typing.SupportsFloat]
+
+TensorConvertable = typing.Any
+
+# TensorConvertable = typing.Union[
+#    torch.Tensor,
+#    NumberLike,
+#    typing.Sequence,
+#    typing.List,
+#    typing.Tuple,
+#    nptyping.NDArray,
+# ]
+"Types which torch.as_tensor(T) can convert."
+
+
+def hide_tracebacks(mode: bool = True) -> None:
+    """
+    Hint that some unittest stacks (unittest, pytest) should remove
+    frames from tracebacks that include this module.
+
+    :param mode: optional, the traceback mode.
+    """
+    # globals(), called within the module, grabs the module dict.
+    tracebacks.hide_module_tracebacks(globals(), mode)
+
+
+# default to hiding.
+hide_tracebacks(True)
+
+
+class TensorStorageMatcher(BaseMatcher[torch.Tensor]):
+    expect_same: bool
+    expected: torch.Tensor
+
+    def __init__(
+        self,
+        expected: torch.Tensor,
+        *,
+        expect_same: bool = True,
+    ) -> None:
+        self.expected = expected
+        self.expect_same = expect_same
+
+    def _data_ptr(self, tensor: torch.Tensor):
+        return tensor.storage().data_ptr()  # type: ignore
+
+    def _matches(self, item: torch.Tensor) -> bool:
+        return self.expect_same == (self._data_ptr(item) == self._data_ptr(self.expected))
+
+    def describe_to(self, description: Description) -> None:
+        if not self.expect_same:
+            description.append_text("not ")
+
+        description.append_text(
+            f"same storage as {self._data_ptr(self.expected)} <{self.expected}>",
+        )
+
+    def describe_mismatch(
+        self,
+        item: torch.Tensor,
+        mismatch_description: Description,
+    ) -> None:
+        mismatch_description.append_text(f"was {self._data_ptr(item)} <{item}>")
+
+
+def same_tensor_storage(expected: torch.Tensor) -> TensorStorageMatcher:
+    return TensorStorageMatcher(expected)
+
+
+def different_tensor_storage(expected: torch.Tensor) -> TensorStorageMatcher:
+    return TensorStorageMatcher(expected, expect_same=False)
+
+
+def assert_tensors_share_storage(actual: torch.Tensor, *views: torch.Tensor) -> None:
+    """
+    Assert that each tensor is a view of the same storage.
+
+    :param views: a series of child Tensors which must all be views of source.
+    """
+    for t in views:
+        common_assertions.assert_match(
+            t,
+            same_tensor_storage(actual),
+        )
+
+
+def assert_tensor_storage_differs(
+    actual: torch.Tensor,
+    reference: torch.Tensor,
+) -> None:
+    """
+    Assert that two tensors are not views of each other, and have different storage.
+
+    :param actual: the tensor.
+    :param reference: the reference tensor.
+    """
+    common_assertions.assert_match(
+        actual,
+        different_tensor_storage(reference),
+    )
+
+
+class TensorStructureMatcher(BaseMatcher):
+    """
+    PyHamcrest matcher for comparing the structure of a tensor to an exemplar.
+
+    Matches:
+      - device
+      - size
+      - dtype
+      - layout
+    """
+
+    expected: torch.Tensor
+
+    def __init__(self, expected: TensorConvertable) -> None:
+        self.expected = torch.as_tensor(expected)
+
+    def _matches(self, item: typing.Any) -> bool:
+        # Todo: structural miss-match that still shows expected tensor.
+
+        try:
+            common_assertions.assert_match(
+                item.device,
+                self.expected.device,
+            )
+            common_assertions.assert_match(
+                item.size(),
+                self.expected.size(),
+            )
+            common_assertions.assert_match(
+                item.dtype,
+                self.expected.dtype,
+            )
+            common_assertions.assert_match(
+                item.layout,
+                self.expected.layout,
+            )
+            return True
+        except AssertionError:
+            return False
+
+    def describe_to(self, description: Description) -> None:
+        description.append_description_of(self.expected)
+
+
+def matches_tensor_structure(
+    expected: TensorConvertable,
+) -> TensorStructureMatcher:
+    """
+    Construct a matcher for comparing the structure of a tensor to an exemplar.
+
+    Matches on:
+      - device
+      - size
+      - dtype
+      - layout
+
+    :return: a matcher.
+    """
+    return TensorStructureMatcher(expected)
+
+
+def assert_tensor_structure(
+    actual: torch.Tensor,
+    expected: TensorConvertable,
+) -> None:
+    """
+    Assert that the `actual` matches the structure (not data) of the `expected`.
+
+    :param actual: a tensor.
+    :param expected: an expected structure.
+    """
+    hamcrest.assert_that(
+        actual,
+        matches_tensor_structure(expected),
+    )
+
+
+class TensorMatcher(TensorStructureMatcher):
+    """
+    PyHamcrest matcher for comparing the structure and data a tensor to an exemplar.
+
+    Matches:
+      - device
+      - size
+      - dtype
+      - layout
+    """
+
+    close: bool = False
+    "Should <close> values be considered identical?"
+
+    def __init__(
+        self,
+        expected: TensorConvertable,
+        *,
+        close: bool = False,
+    ):
+        super().__init__(expected=expected)
+        self.close = close
+
+        if self.expected.is_sparse and not self.expected.is_coalesced():  # type: ignore
+            self.expected = self.expected.coalesce()
+
+    def _matches(self, item: typing.Any) -> bool:
+        if not super()._matches(item):
+            return False
+
+        if self.close:
+            try:
+                torch.testing.assert_close(
+                    item,
+                    self.expected,
+                    equal_nan=True,
+                )
+                return True
+            except AssertionError:
+                return False
+
+        else:
+            if self.expected.is_sparse:  # type: ignore
+                common_assertions.assert_true(item.is_sparse)
+
+                # TODO: it may be necessary to sort the indices and values.
+                if not item.is_coalesced():
+                    item = item.coalesce()
+
+                assert_tensor_equals(
+                    item.indices(),
+                    self.expected.indices(),
+                )
+                assert_tensor_equals(
+                    item.values(),
+                    self.expected.values(),
+                )
+                return True
+            else:
+                # torch.equal(item, self.expected) does not support nan.
+                try:
+                    torch.testing.assert_close(
+                        item,
+                        self.expected,
+                        rtol=0,
+                        atol=0,
+                        equal_nan=True,
+                    )
+                except AssertionError:
+                    return False
+                return True
+
+    def describe_to(self, description: Description) -> None:
+        description.append_text("\n")
+        description.append_description_of(self.expected)
+
+    def describe_match(self, item: typing.Any, match_description: Description) -> None:
+        match_description.append_text("was \n")
+        match_description.append_description_of(item)
+
+    def describe_mismatch(self, item: typing.Any, mismatch_description: Description) -> None:
+        torch.set_printoptions(
+            precision=10,
+        )
+        mismatch_description.append_text("was \n")
+        mismatch_description.append_description_of(item)
+
+
+def matches_tensor(
+    expected: TensorConvertable,
+    close: bool = False,
+) -> TensorMatcher:
+    """
+    Returns a matcher for structure and value of a Tensor.
+
+    :param expected: the expected Tensor.
+    :param close: should *close* values be acceptable?
+    """
+    return TensorMatcher(expected, close=close)
+
+
+def assert_tensor_equals(
+    actual: torch.Tensor,
+    expected: TensorConvertable,
+    *,
+    close: bool = False,
+    view_of: typing.Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """
+    Assert that the `actual` tensor equals the `expected` tensor.
+
+    :param actual: the actual tensor.
+    :param expected: the value (to coerce to a Tensor) to compare to.
+    :param close: should *close* values match?
+    :param view_of: if present, also check that actual is a view of the reference Tensor.
+    :returns: the `actual` value.
+    """
+    hamcrest.assert_that(
+        actual,
+        matches_tensor(
+            expected,
+            close=close,
+        ),
+    )
+    if view_of is not None:
+        assert_tensors_share_storage(view_of, actual)
+
+    return actual
+
+
+def match_tensor_sequence(
+    *expected: TensorConvertable,
+) -> Matcher:
+    """
+    Returns a matcher which expects a sequence that matches the tensors.
+    :param expected: the expected tensors.
+    """
+    return hamcrest.contains_exactly(*[matches_tensor(e) for e in expected])
+
+
+def assert_tensor_sequence_equals(
+    actual: typing.Sequence[torch.Tensor],
+    *expected: TensorConvertable,
+    view_of: typing.Optional[torch.Tensor] = None,
+) -> typing.Sequence[torch.Tensor]:
+    """
+    Assert that the `actual` is a sequence that equals the given `expected` tensor values.
+
+    :param actual: the `actual` to test.
+    :param expected: the expected values.
+    :param view_of: if present, also check that actual is a view of the reference Tensor.
+    :return: the `actual`
+    """
+    hamcrest.assert_that(
+        actual,
+        match_tensor_sequence(*expected),
+    )
+    if view_of is not None:
+        assert_tensors_share_storage(view_of, *actual)
+    return actual

--- a/fair_dev/fairtest/tensor_assertions_test.py
+++ b/fair_dev/fairtest/tensor_assertions_test.py
@@ -1,0 +1,71 @@
+import unittest
+
+import torch
+
+from fair_dev.fairtest import common_assertions, tensor_assertions
+
+
+class SameTensorStorageTest(unittest.TestCase):
+    def test(self):
+        a = torch.ones(2)
+        a_view = a.split([1, 1])[0]
+        b = torch.ones(2)
+
+        common_assertions.assert_match(
+            a,
+            tensor_assertions.same_tensor_storage(a),
+        )
+
+        common_assertions.assert_match(
+            a,
+            tensor_assertions.same_tensor_storage(a_view),
+        )
+
+        common_assertions.assert_raises(
+            lambda: common_assertions.assert_match(
+                a,
+                tensor_assertions.TensorStorageMatcher(b),
+            ),
+            AssertionError,
+            (r"(?ms)same storage as.*but: was"),
+        )
+
+
+class AssertTensorsShareStorageTest(unittest.TestCase):
+    def test(self):
+        a = torch.ones(3, 2)
+        tensor_assertions.assert_tensors_share_storage(
+            a,
+            *a.split([1, 2]),
+        )
+
+        common_assertions.assert_raises(
+            lambda: tensor_assertions.assert_tensors_share_storage(
+                a,
+                torch.tensor([[1.0, 1.0]]),
+                torch.tensor([[1.0, 1.0], [1.0, 1.0]]),
+            ),
+            AssertionError,
+            (r"(?ms)same storage as.*but: was"),
+        )
+
+
+class AssertTensorStorageDiffersTest(unittest.TestCase):
+    def test(self):
+        a = torch.ones(2)
+        a_view = a.split([1, 1])[0]
+        b = torch.ones(2)
+
+        tensor_assertions.assert_tensor_storage_differs(
+            a,
+            b,
+        )
+
+        common_assertions.assert_raises(
+            lambda: tensor_assertions.assert_tensor_storage_differs(
+                a,
+                a_view,
+            ),
+            AssertionError,
+            r"(?ms)not same storage as .* but: was",
+        )

--- a/fair_dev/fairtest/tensor_assertions_test.py
+++ b/fair_dev/fairtest/tensor_assertions_test.py
@@ -1,3 +1,4 @@
+import logging
 import unittest
 
 import hamcrest
@@ -334,6 +335,11 @@ class TensorMatcherTest(unittest.TestCase):
             )
 
     def test_structure_cuda(self) -> None:
+        if not torch.cuda.is_available():
+            # TODO: conditional fixture.
+            logging.info("No torch.cuda.is_available() == False, skipping test")
+            return
+
         # bad device
         a = torch.ones(2)
         b = a.to(device="cuda")

--- a/fair_dev/fairtest/tensor_assertions_test.py
+++ b/fair_dev/fairtest/tensor_assertions_test.py
@@ -7,6 +7,17 @@ import torch
 from fair_dev.fairtest import common_assertions, tensor_assertions
 
 
+def test_example() -> None:
+    a = torch.ones(3)
+    hamcrest.assert_that(
+        a.split([1, 2]),
+        hamcrest.contains_exactly(
+            tensor_assertions.tensor_with_structure(size=[1], device="cpu"),
+            tensor_assertions.tensor_with_structure(size=[2], device="cpu"),
+        ),
+    )
+
+
 class SameTensorStorageTest(unittest.TestCase):
     def test(self) -> None:
         a = torch.ones(2)

--- a/fair_dev/fairtest/tensor_assertions_test.py
+++ b/fair_dev/fairtest/tensor_assertions_test.py
@@ -1,12 +1,13 @@
 import unittest
 
+import hamcrest
 import torch
 
 from fair_dev.fairtest import common_assertions, tensor_assertions
 
 
 class SameTensorStorageTest(unittest.TestCase):
-    def test(self):
+    def test(self) -> None:
         a = torch.ones(2)
         a_view = a.split([1, 1])[0]
         b = torch.ones(2)
@@ -32,7 +33,7 @@ class SameTensorStorageTest(unittest.TestCase):
 
 
 class AssertTensorsShareStorageTest(unittest.TestCase):
-    def test(self):
+    def test(self) -> None:
         a = torch.ones(3, 2)
         tensor_assertions.assert_tensors_share_storage(
             a,
@@ -51,7 +52,7 @@ class AssertTensorsShareStorageTest(unittest.TestCase):
 
 
 class AssertTensorStorageDiffersTest(unittest.TestCase):
-    def test(self):
+    def test(self) -> None:
         a = torch.ones(2)
         a_view = a.split([1, 1])[0]
         b = torch.ones(2)
@@ -68,4 +69,211 @@ class AssertTensorStorageDiffersTest(unittest.TestCase):
             ),
             AssertionError,
             r"(?ms)not same storage as .* but: was",
+        )
+
+
+class MatchesTensorStructureTest(unittest.TestCase):
+    def test_bad_type(self) -> None:
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                7,
+                tensor_assertions.tensor_with_structure(
+                    size=(5, 3),
+                ),
+            ),
+            AssertionError,
+            "(?ms)Expected: an instance of Tensor.* but: was <7>",
+        )
+
+    def test_size(self) -> None:
+        a = torch.ones(2, 3)
+
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                size=(2, 3),
+            ),
+        )
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_size((2, 3)),
+        )
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                size=torch.Size((2, 3)),
+            ),
+        )
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_structure(
+                    size=(5, 3),
+                ),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(size=\(5, 3\)\).*but: tensor\(\[size=\(2, 3\)\]\)",
+        )
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_size((5, 3)),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(size=\(5, 3\)\).*but: tensor\(\[size=\(2, 3\)\]\)",
+        )
+
+    def test_dtype(self) -> None:
+        a = torch.ones(2, 3, dtype=torch.int64)
+
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                dtype=torch.int64,
+            ),
+        )
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_dtype(torch.int64),
+        )
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_structure(
+                    dtype=torch.float16,
+                ),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(dtype=torch.float16\).*but: tensor\(\[dtype=torch.int64\]\)",
+        )
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_dtype(torch.float16),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(dtype=torch.float16\).*but: tensor\(\[dtype=torch.int64\]\)",
+        )
+
+    def test_device(self) -> None:
+        a = torch.ones(2, 3)
+
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                device="cpu",
+            ),
+        )
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_device("cpu"),
+        )
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                device=torch.device("cpu"),
+            ),
+        )
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_structure(
+                    device="cuda",
+                ),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(device='cuda'\).*but: tensor\(\[device='cpu'\]\)",
+        )
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_device("cuda"),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(device='cuda'\).*but: tensor\(\[device='cpu'\]\)",
+        )
+
+    def test_layout(self) -> None:
+        a = torch.ones(2, 3)
+
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                layout=torch.strided,
+            ),
+        )
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_layout(torch.strided),
+        )
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_structure(
+                    layout=torch.sparse_coo,  # type: ignore
+                ),
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(layout=torch.sparse_coo\).*but: tensor\(\[layout=torch.strided\]\)",
+        )
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_layout(torch.sparse_coo),  # type: ignore
+            ),
+            AssertionError,
+            r"(?ms)Expected: tensor\(layout=torch.sparse_coo\).*but: tensor\(\[layout=torch.strided\]\)",
+        )
+
+    def test_everything(self) -> None:
+        a = torch.ones(2, 3, dtype=torch.int64)
+
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                size=(2, 3),
+                dtype=torch.int64,
+                device="cpu",
+                layout=torch.strided,
+            ),
+        )
+
+        tensor_assertions.assert_tensor_structure(
+            a,
+            size=(2, 3),
+            dtype=torch.int64,
+            device="cpu",
+            layout=torch.strided,
+        )
+
+        hamcrest.assert_that(
+            a,
+            tensor_assertions.tensor_with_structure(
+                size=torch.Size((2, 3)),
+                dtype=torch.int64,
+                device=torch.device("cpu"),
+                layout=torch.strided,
+            ),
+        )
+
+        common_assertions.assert_raises(
+            lambda: hamcrest.assert_that(
+                a,
+                tensor_assertions.tensor_with_structure(
+                    size=(5, 3),  # mismatch
+                    dtype=torch.float16,  # mismatch
+                    device="cpu",
+                    layout=torch.strided,
+                ),
+            ),
+            AssertionError,
+            (
+                r"(?ms)Expected: tensor\(size=\(5, 3\), dtype=torch.float16, device='cpu', layout=torch.strided\)"
+                + r".*"
+                + r"but: tensor\(\[size=\(2, 3\)\], \[dtype=torch.int64\], device='cpu', layout=torch.strided\)"
+            ),
         )

--- a/fair_dev/fairtest/tensor_assertions_test.py
+++ b/fair_dev/fairtest/tensor_assertions_test.py
@@ -8,17 +8,6 @@ import torch
 from fair_dev.fairtest import common_assertions, tensor_assertions
 
 
-def test_example() -> None:
-    a = torch.ones(3)
-    hamcrest.assert_that(
-        a.split([1, 2]),
-        hamcrest.contains_exactly(
-            tensor_assertions.tensor_with_structure(size=[1], device="cpu"),
-            tensor_assertions.tensor_with_structure(size=[2], device="cpu"),
-        ),
-    )
-
-
 class SameTensorStorageTest(unittest.TestCase):
     def test(self) -> None:
         a = torch.ones(2)

--- a/fair_dev/fairtest/tracebacks.py
+++ b/fair_dev/fairtest/tracebacks.py
@@ -1,0 +1,48 @@
+import typing
+
+_TRACEBACK_SENSE_FLAGS = [
+    # unittest integration; hide these frames from tracebacks
+    "__unittest",
+    # py.test integration; hide these frames from tracebacks
+    "__tracebackhide__",
+]
+
+
+def hide_module_tracebacks(module: typing.Any, mode: bool = True) -> None:
+    """
+    Set traceback behavior flags on a module.
+
+    Various python testing tools will pay attention to certain sense flags
+    in stack frames, and selectively remove stack frames they are present in.
+
+    This is useful to strip the stack frames from a unittesting library out
+    of the error reports; because we generally assume the library is correct,
+    and the error should be attributed to the user's call site, and not
+    the unittest library.
+
+    When _developing_ a unittest library, this isn't true.
+
+    This machinery lets us toggle those flags for a given module.
+
+    Suggested usage in a test library:
+
+    >>> from fair_dev.fairtest import hide_module_tracebacks
+    >>>
+    >>> def hide_tracebacks(mode: bool = True) -> None:
+    >>>     '''
+    >>>     Hint that some unittest stacks (unittest, pytest) should remove
+    >>>     frames from tracebacks that include this module.
+    >>>
+    >>>     :param mode: optional, the traceback mode.
+    >>>     '''
+    >>>     # globals(), called within the module, grabs the module dict.
+    >>>     hide_module_tracebacks(globals(), mode)
+    >>>
+    >>> # default to hiding.
+    >>> hide_tracebacks(True)
+
+    :param module: the module to toggle.
+    :param mode: (Optional) the mode; defaults to True.
+    """
+    for flag in _TRACEBACK_SENSE_FLAGS:
+        module[flag] = mode

--- a/fair_dev/fairtest/warnings.py
+++ b/fair_dev/fairtest/warnings.py
@@ -1,0 +1,28 @@
+import contextlib
+from typing import Generator
+import warnings
+
+
+@contextlib.contextmanager
+def ignore_warnings() -> Generator[None, None, None]:
+    """
+    This is a general context manager to suppress all python warnings.
+
+    The use case is that, when testing an API, sometimes it is valuable
+    to call that API in an incorrect way, to verify that error handling
+    behaves as excepted.
+
+    There is equally a desire to not spam unittest results with warnings,
+    so sometimes we avoid writing those tests.
+
+    This permits tests (such as `assert_raises()`) to be written which
+    trigger warnings, without escalating those warnings to the test environment.
+
+    Usage:
+
+    >>> with ignore_warnings():
+    >>>   # something that will warn ...
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        yield

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,6 +19,7 @@ pytest-cov == 3.0.0
 pytest-timeout == 2.1.0
 remote-pdb >= 2.1.0
 parameterized >= 0.8.1
+pyhamcrest >= 2.0.3
 
 # Tools for testing docs
 docutils == 0.17

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,14 @@ disallow_untyped_decorators = true
 disallow_incomplete_defs = true
 warn_unused_ignores = true
 
+[mypy-fair_dev.*]
+check_untyped_defs = true
+disallow_untyped_defs = true
+disallow_untyped_calls = true
+disallow_untyped_decorators = true
+disallow_incomplete_defs = true
+warn_unused_ignores = true
+
 [mypy-fairscale.experimental.nn.distributed_pipeline.trace]
 ignore_errors = True
 


### PR DESCRIPTION
## What does this PR do?
Iterates on #1003

This lands a first layer of pyhamcrest fluent test matchers for pytorch Tensors.

This permits saying nested things like:
```
a = torch.ones(3)
hamcrest.assert_that(
    a.split([1, 2]),
    hamcrest.contains_exactly(
        fairtest.tensor_with_structure(size=[1], device="cpu"),
        fairtest.tensor_with_structure(size=[2], device="cpu"),
    ),
)
```

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [x] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [x] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [x] N/A

## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
