### PR TITLE
[feat] support a context for loading state_dict for FSDP

### DIFF
--- a/fairscale/nn/data_parallel/__init__.py
+++ b/fairscale/nn/data_parallel/__init__.py
@@ -5,7 +5,7 @@
 
 from typing import List
 
-from .fully_sharded_data_parallel import FullyShardedDataParallel, OffloadConfig, TrainingState, auto_wrap_bn
+from .fully_sharded_data_parallel import FullyShardedDataParallel, OffloadConfig, TrainingState, auto_wrap_bn, no_pre_load_state_dict_hook
 from .sharded_ddp import ShardedDataParallel
 
 __all__: List[str] = []

--- a/fairscale/nn/data_parallel/__init__.py
+++ b/fairscale/nn/data_parallel/__init__.py
@@ -5,7 +5,13 @@
 
 from typing import List
 
-from .fully_sharded_data_parallel import FullyShardedDataParallel, OffloadConfig, TrainingState, auto_wrap_bn, no_pre_load_state_dict_hook
+from .fully_sharded_data_parallel import (
+    FullyShardedDataParallel,
+    OffloadConfig,
+    TrainingState,
+    auto_wrap_bn,
+    no_pre_load_state_dict_hook,
+)
 from .sharded_ddp import ShardedDataParallel
 
 __all__: List[str] = []

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2595,6 +2595,7 @@ def no_pre_load_state_dict_hook() -> Generator:
     yield
     _enable_pre_load_state_dict_hook = bak
 
+
 def _pre_load_state_dict_hook(
     state_dict: Union[Dict[str, torch.Tensor], "OrderedDict[str, torch.Tensor]"], prefix: str, *args: Any
 ) -> None:

--- a/fairscale/nn/misc/__init__.py
+++ b/fairscale/nn/misc/__init__.py
@@ -9,7 +9,7 @@ from typing import List
 # in favor of fairscale.nn.checkpoint.checkpoint_wrapper.
 from fairscale.nn.checkpoint import checkpoint_wrapper
 
-from .flatten_params_wrapper import FlattenParamsWrapper
+from .flatten_params_wrapper import FlattenParamsWrapper, _enable_pre_load_state_dict_hook
 from .param_bucket import GradBucket, ParamBucket
 
 __all__: List[str] = []

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -49,6 +49,8 @@ from fairscale.internal.state_dict import replace_by_prefix_
 if TYPE_CHECKING:
     from collections import OrderedDict  # noqa: F401
 
+# See no_pre_load_state_dict_hook context manager function in FSDP for more details.
+_enable_pre_load_state_dict_hook = True
 
 class FlatParameter(nn.Parameter):
     """A parameter that is initialized from a list of parameters and can be
@@ -543,6 +545,8 @@ def _post_state_dict_hook(
 def _pre_load_state_dict_hook(
     state_dict: Union[Dict[str, Tensor], "OrderedDict[str, Tensor]"], prefix: str, *args: Any
 ) -> None:
+    if not _enable_pre_load_state_dict_hook:
+        return
     # Push everything down to ._fpw_module level.
     replace_by_prefix_(state_dict, prefix, prefix + "_fpw_module.")
     # The flat_param_* keys actually needs to move one level up.

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -52,6 +52,7 @@ if TYPE_CHECKING:
 # See no_pre_load_state_dict_hook context manager function in FSDP for more details.
 _enable_pre_load_state_dict_hook = True
 
+
 class FlatParameter(nn.Parameter):
     """A parameter that is initialized from a list of parameters and can be
     turned into a list of views as needed.


### PR DESCRIPTION
## What does this PR do?
With this context mgr it is possible to load a state_dict for a non-root FSDP wrapped module.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
