### PR TITLE
Remove `torch._six` from `__init__.py`

### DIFF
--- a/stubs/torch/__init__.pyi
+++ b/stubs/torch/__init__.pyi
@@ -3,7 +3,7 @@
 # @generated from torch/__init__.pyi.in
 
 from typing import List, Tuple, Optional, Union, Any, ContextManager, Callable, overload, Iterator, Iterable
-from torch._six import inf
+from torch import inf
 
 import builtins
 


### PR DESCRIPTION
Just use `torch.inf`, as torch._six is gone after https://github.com/pytorch/pytorch/pull/94709
