### PR TITLE
Fix bibtex entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ If you use FairScale in your publication, please cite it by using the following 
 
 ```BibTeX
 @Misc{FairScale2021,
-  author =       {FairScale authors},
+  author =       {{FairScale authors}},
   title =        {FairScale:  A general purpose modular PyTorch library for high performance and large scale training},
   howpublished = {\url{https://github.com/facebookresearch/fairscale}},
   year =         {2021}


### PR DESCRIPTION
I was using FairScale for a publication and noticed that the bibtex entry leads to a reference like `authors, FairScale` or `authors, F.`. I'm guessing this is not intended and should rather read as `FairScale authors`. For this, the author field needs to be wrapped in an additional pair of braces (so as to be interpreted as one unit by (bib)latex).

This PR simply fixes that.