### PR TITLE
Fix typo in argument ParallelEmbedding argument assignment

### DIFF
--- a/fairscale/nn/model_parallel/layers.py
+++ b/fairscale/nn/model_parallel/layers.py
@@ -178,7 +178,7 @@ class ParallelEmbedding(torch.nn.Module):
         self.embedding_dim = embedding_dim
         self.padding_idx = padding_idx
         self.max_norm = max_norm
-        self.norm_type = scale_grad_by_freq
+        self.norm_type = norm_type
         self.scale_grad_by_freq = scale_grad_by_freq
         self.sparse = sparse
         self._weight = None


### PR DESCRIPTION
## What does this PR do?
This fixes a small typo in ParallelEmbedding where `scale_grad_by_freq` was assigned to `self.norm_type`.
