### PR TITLE
Fix missing params in unconsolidated models

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2235,9 +2235,10 @@ class FullyShardedDataParallel(nn.Module):
         # of synchronization between shards or that all shards buffers are equivalent).
         if with_module_buffers:
             for buffer_name in shard_metadata[0]["buffer_names"]:
-                if buffer_name not in shard_weights[0] and (not strict):
-                    continue
-                consolidated_weights[buffer_name] = shard_weights[0][buffer_name]
+                if buffer_name in shard_weights[0]:
+                    consolidated_weights[buffer_name] = shard_weights[0][buffer_name]
+                else:
+                    logging.info(f"Missing buffer weights: {buffer_name}")
 
         return consolidated_weights
 


### PR DESCRIPTION
## What does this PR do?
Fixes issue in unconsolidated models where missing key in shared_weights[0] gets accessed. Instead we should only access it if the key exists. Otherwise we skip over it.

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
