### PR TITLE
Fix the parameter in ParallelEmbedding

### DIFF
--- a/fairscale/nn/model_parallel/layers.py
+++ b/fairscale/nn/model_parallel/layers.py
@@ -178,7 +178,7 @@ class ParallelEmbedding(torch.nn.Module):
         self.embedding_dim = embedding_dim
         self.padding_idx = padding_idx
         self.max_norm = max_norm
-        self.norm_type = scale_grad_by_freq
+        self.norm_type = norm_type
         self.scale_grad_by_freq = scale_grad_by_freq
         self.sparse = sparse
         self._weight = None


### PR DESCRIPTION
The parameter passing is wrong in ParallelEmbedding. It should be the same as that in class VocabParallelEmbedding. https://github.com/facebookresearch/fairscale/blob/164cc0f3170b4a3951dd84dda29c3e1504ac4d6e/fairscale/nn/model_parallel/layers.py#L111 This may be a typo error.

cc @ezyang @likethesky @myleott @froody @Celebio