### PR TITLE
Added fns for manual free, reduce-scatter; removed stream sync if event sync

### DIFF
--- a/fairscale/utils/reduce_scatter_bucketer.py
+++ b/fairscale/utils/reduce_scatter_bucketer.py
@@ -145,7 +145,8 @@ class ReduceScatterBucketer:
                     self._reduce_scatter_free_event_queue._dequeue()
                 event = self._reduce_scatter_free_event_queue.dequeue_if_needed()
                 if event:
-                    event.synchronize()
+                    with torch.profiler.record_function(f"FSDP reduce-scatter sync"):
+                        event.synchronize()
 
             # TODO: investigate how to avoid using torch.cat (because it seems to be slow for CPU tensors)
             # input is too big to fit in the bucket, reduce-scatter directly


### PR DESCRIPTION
This PR:
1. Adds `_run_all_post_backward_hooks()` to run `_post_backward_hook()` on all parameters of all FSDP modules in the calling module's `.modules()`.
    - This is used for manually reduce-scattering gradients after PP send/recv for input gradients.
2. Adds `_free_all_full_params()` to run `_free_full_params()` on all parameters of all FSDP modules in the calling module's `.modules()`.
    - This is used for freeing parameters (and hence blocking the CPU thread if using CUDA stream synchronization) before PP send/recv for input gradients.
3. Disables the CUDA stream synchronization in `_free_full_params()` if both `limit_all_gather_events=True` and `limit_reduce_scatter_events=True` (requiring both just to be conservative).
    - On the first order, we do not need the CUDA stream synchronization if using the CUDA event synchronization. This change allows us to delay the CPU blocking until later when truly needed.
4. Adds profiler `record_function()` calls for the all-gather CPU sync and reduce-scatter CPU sync.