### PR TITLE
Fix _free_full_params()

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2096,6 +2096,8 @@ class FullyShardedDataParallel(nn.Module):
         """Free up storage for full parameters."""
         if params is None:
             params = self.params
+        if not self.has_full_params:
+            return
         self.has_full_params = False
         current_stream = torch.cuda.current_stream()
         for p in params:


### PR DESCRIPTION
I've been getting `AttributeError: 'FlatParameter' object has no attribute '_full_param_padded'` triggered by `p._full_param_padded.record_stream(current_stream)`

Adding a check to not free full params if none have been added.

## What does this PR do?
Fixes bug

## Before submitting

- [ ] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
