### PR TITLE
Add support for `torch.set_default_device` when initializing model parameters

### DIFF
--- a/fairscale/nn/model_parallel/layers.py
+++ b/fairscale/nn/model_parallel/layers.py
@@ -120,7 +120,7 @@ class VocabParallelEmbedding(torch.nn.Module):
         self.num_embeddings_per_partition = self.vocab_end_index - self.vocab_start_index
 
         # Allocate weights.
-        self.weight = Parameter(torch.Tensor(self.num_embeddings_per_partition, self.embedding_dim))
+        self.weight = Parameter(torch.empty(self.num_embeddings_per_partition, self.embedding_dim))
         # And initialize.
         _initialize_affine_weight(
             self.weight, self.num_embeddings, self.embedding_dim, self.num_embeddings_per_partition, 0, init_method
@@ -187,7 +187,7 @@ class ParallelEmbedding(torch.nn.Module):
         self.embedding_dim_per_partition = divide_and_check_no_remainder(self.embedding_dim, world_size)
 
         # Allocate weights.
-        self.weight = Parameter(torch.Tensor(self.num_embeddings, self.embedding_dim_per_partition))
+        self.weight = Parameter(torch.empty(self.num_embeddings, self.embedding_dim_per_partition))
         # And initialize.
         _initialize_affine_weight(
             self.weight,
@@ -259,9 +259,9 @@ class ColumnParallelLinear(torch.nn.Module):
         # Parameters.
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
         # we allocate the transpose.
-        self.weight = Parameter(torch.Tensor(self.output_size_per_partition, self.in_features))
+        self.weight = Parameter(torch.empty(self.output_size_per_partition, self.in_features))
         if bias:
-            self.bias = Parameter(torch.Tensor(self.output_size_per_partition))
+            self.bias = Parameter(torch.empty(self.output_size_per_partition))
             # Always initialize bias to zero.
             with torch.no_grad():
                 self.bias.zero_()
@@ -346,9 +346,9 @@ class RowParallelLinear(torch.nn.Module):
         # Parameters.
         # Note: torch.nn.functional.linear performs XA^T + b and as a result
         # we allocate the transpose.
-        self.weight = Parameter(torch.Tensor(self.out_features, self.input_size_per_partition))
+        self.weight = Parameter(torch.empty(self.out_features, self.input_size_per_partition))
         if bias:
-            self.bias = Parameter(torch.Tensor(self.out_features))
+            self.bias = Parameter(torch.empty(self.out_features))
             # Always initialize bias to zero.
             with torch.no_grad():
                 self.bias.zero_()


### PR DESCRIPTION
## What does this PR do?
Replace `torch.Tensor` with `torch.empty` when initializing model parameters.

The reason is that `torch.empty` is compatible with `torch.set_default_device` (but `torch.Tensor` is not), thus enable one to efficiently initialize a large ML model with specified GPUs.

(An example is that initialize a Llama2 model with the default `torch.nn.init.xavier_normal_` method is extremely slow on CPUs, but very fast on GPUs.)

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [x] N/A
- [ ] Did you make sure to update the docs?
  - [x] N/A
- [ ] Did you write any new necessary tests?
  - [x] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [x] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
