### PR TITLE
Added reshard hook for frozen params in backward

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1733,7 +1733,7 @@ class FullyShardedDataParallel(nn.Module):
             # Free full params.
             self._free_full_params([param])
 
-        if self.mixed_precision:
+        if self.mixed_precision and (self._require_backward_grad_sync or self.reshard_after_forward):
             # This is a no-op if reshard_after_forward is True, since we already
             # free the param shard when rebuilding the full params in the
             # pre_backward_hook.
@@ -1861,7 +1861,7 @@ class FullyShardedDataParallel(nn.Module):
     def _post_backward_reshard_hook(self, param: Parameter, *unused: Any) -> None:
         if self._should_free_in_backward():
             self._free_full_params([param])
-        if self.mixed_precision:
+        if self.mixed_precision and (self._require_backward_grad_sync or self.reshard_after_forward):
             self._free_fp16_param_shard([param])
         self._use_fp32_param_shard([param])
 
@@ -1937,7 +1937,7 @@ class FullyShardedDataParallel(nn.Module):
                     # For the 1st layer, if the forward inputs did not require
                     # gradient, then we cannot run a reshard hook for it, and
                     # we instead free here.
-                    if p._full_param_padded.untyped_storage().size() > 0:
+                    if p._is_sharded and p._full_param_padded.untyped_storage().size() > 0:
                         fsdp_module._post_backward_reshard_hook(p)
                     continue
 

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -2824,26 +2824,27 @@ def auto_wrap_bn(
         return auto_wrap(module)
 
 
+class Handle(RemovableHandle):
+    handles: Tuple[RemovableHandle, ...]
+
+    def __init__(self, handles: Tuple[RemovableHandle, ...]):
+        self.handles = handles
+
+    def remove(self):
+        for handle in self.handles:
+            handle.remove()
+
+    def __getstate__(self):
+        return self.handles
+
+    def __setstate__(self, state):
+        self.handles = state
+
+
 def register_multi_grad_hook(
     tensors: Sequence[torch.Tensor],
     fn: Callable[[Sequence[Optional[torch.Tensor]]], None]
 ):
-    class Handle(RemovableHandle):
-        handles: Tuple[RemovableHandle, ...]
-
-        def __init__(self, handles: Tuple[RemovableHandle, ...]):
-            self.handles = handles
-
-        def remove(self):
-            for handle in self.handles:
-                handle.remove()
-
-        def __getstate__(self):
-            return self.handles
-
-        def __setstate__(self, state):
-            self.handles = state
-
     count: Dict[int, int] = dict()
     nb_calls = None
     buffer: Dict[int, List[Optional[torch.Tensor]]] = dict()


### PR DESCRIPTION
## What does this PR do?
This PR reshards frozen parameters that got all-gathered in backward. The technical approach follows from https://github.com/pytorch/pytorch/pull/101982/. The idea is that we use a new feature in PyTorch, the multi-grad hook (`register_multi_grad_hook`) to enable us to insert logic that runs after the gradients with respect to a module's inputs have been computed. For modules with frozen parameters, that point is a safe place to reshard the parameters since they have already been used to compute input gradients.

I was not too familiar with the Fairscale testing infra, so I did not use `dist_init()` and set the env vars manually.
```
python -m pytest tests/nn/data_parallel/test_fsdp_freezing_weights.py -s -k test_reshard_frozen_weights
```

While working on this I noticed two possible minor bugs:
1. [Here](https://github.com/awgu/fairscale/blob/08816c804acb700dfd8ba3328a9d0835f69f2a83/fairscale/nn/data_parallel/fully_sharded_data_parallel.py#L1944-L1949), I think we may prefer `if not fsdp_module._require_backward_grad_sync:`. It is not an issue if _every_ FSDP module atomically is under `no_grad` or not.
2. [Here](https://github.com/awgu/fairscale/blob/08816c804acb700dfd8ba3328a9d0835f69f2a83/fairscale/nn/data_parallel/fully_sharded_data_parallel.py#L1959-L1962), we call `_use_fp32_param_shard()` in `_finalize_parameters()` citing the case that the parameters get accidentally gathered after post-backward. I think we _additionally_ need to check if we need to call `_free_full_params()`, or else the optimizer step could update the sharded parameters but the next forward will not re-all-gather the parameters, resulting in a correctness issue.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [ ] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
