### PR TITLE
Added requires_grad check for params_with_grad method

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -687,7 +687,7 @@ class FullyShardedDataParallel(nn.Module):
     @property
     def params_with_grad(self) -> List[Parameter]:
         """[p for p in self.parameters() if p.grad is not None]"""
-        return [p for p in self.parameters() if (p.grad is not None or p.main_grad is not None)]
+        return [p for p in self.parameters() if (p.requires_grad and (p.grad is not None or p.main_grad is not None))]
 
     @torch.no_grad()
     def clip_grad_norm_(


### PR DESCRIPTION
## What does this PR do?
This PR fixes the silent errors of `params_with_grad` when `param.requires_grad=False`.

Before the fix, if we have params with `requires_grad=False`, when we call `params_with_grad` method (e.g., from gradient clipping:
- the original code first checks that `p.grad is not None` is evaluated to False
- then it tries to evaluate `p.main_grad is not None`. Since p doesn't have the main_grad attribute, this line of code will error out. When the outside caller doesn't catch this exception properly, this will lead to potential bugs.

For the fix, we added `requires_grad` check before the rest of the code.

## Before submitting

- [x] Did you have fun?
  - Make sure you had fun coding 🙃
- [x] Did you read the [contributor guideline](https://github.com/facebookresearch/fairscale/blob/main/CONTRIBUTING.md)?
- [ ] Was this discussed/approved via a Github issue? (no need for typos, doc improvements)
  - [ ] N/A
- [ ] Did you make sure to update the docs?
  - [ ] N/A
- [ ] Did you write any new necessary tests?
  - [ ] N/A
- [ ] Did you update the [changelog](https://github.com/facebookresearch/fairscale/blob/main/CHANGELOG.md)? (if needed)
  - [ ] N/A


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
