### PR TITLE
Make sure that tensor is contiguous before gathering across processes

### DIFF
--- a/fairscale/nn/model_parallel/layers.py
+++ b/fairscale/nn/model_parallel/layers.py
@@ -281,7 +281,7 @@ class ColumnParallelLinear(torch.nn.Module):
         )
 
     def get_master_weight(self) -> torch.Tensor:
-        return gather_from_model_parallel_region(self.weight.data.transpose(0, 1)).transpose_(0, 1)
+        return gather_from_model_parallel_region(self.weight.data.transpose(0, 1).contiguous()).transpose_(0, 1)
 
     def forward(self, input_: torch.Tensor) -> torch.Tensor:  # type: ignore
         # Set up backprop all-reduce.


### PR DESCRIPTION
## What does this PR do?

The `get_master_weight()` of the ColumnParallelLinear first applies a transpose to the weights before calling all gather. However all gather requires the tensors to be contiguous. We can ensure this by simply calling it before the all gather. 

Without this PR, I'm often running into:
```
           work = group.allgather([tensor_list], [tensor])
E       ValueError: Tensors must be contiguous
```


## PR review
Anyone in the community is free to review the PR once the tests have passed.
If we didn't discuss your PR in Github issues there's a high chance it will not be merged.
