### PR TITLE
[FSDPv1] Optimize memory usage for optimize_backward_concat=True

### DIFF
--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1767,9 +1767,13 @@ class FullyShardedDataParallel(nn.Module):
             if self.optimize_backward_concat:
                 # Flatten and concat the accumulated fp32 grads
                 # and assign them to param.unsharded_main_grad
-                param.unsharded_main_grad = torch.cat([grad.flatten() for grad in self._fsdp_wrapped_module.fp32_grads])
+                # for idx in range(len(self._fsdp_wrapped_module.fp32_grads)):
+                #     self._fsdp_wrapped_module.fp32_grads[idx] = torch.flatten(self._fsdp_wrapped_module.fp32_grads[idx])
+                # param.unsharded_main_grad = torch.cat([grad for grad in self._fsdp_wrapped_module.fp32_grads])
+                
+                param.unsharded_main_grad = self._fsdp_wrapped_module.fp32_grads
                 # Clean up accumulated grads between data batches
-                self._fsdp_wrapped_module.fp32_grads = []
+                self._fsdp_wrapped_module.fp32_grads = None
             else:
                 if getattr(param, "unsharded_main_grad", None) is None:
                     param.unsharded_main_grad = param.grad.to(torch.float32)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1765,9 +1765,9 @@ class FullyShardedDataParallel(nn.Module):
 
         if self.fp32_reduce_scatter:
             if self.optimize_backward_concat:
-                param.unsharded_main_grad = self._fsdp_wrapped_module.fp32_grads
+                param.unsharded_main_grad = self._fsdp_wrapped_module.fp32_flat_grad
                 # Clean up accumulated grads between data batches
-                self._fsdp_wrapped_module.fp32_grads = None
+                self._fsdp_wrapped_module.fp32_flat_grad = None
             else:
                 if getattr(param, "unsharded_main_grad", None) is None:
                     param.unsharded_main_grad = param.grad.to(torch.float32)

--- a/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
+++ b/fairscale/nn/data_parallel/fully_sharded_data_parallel.py
@@ -1765,12 +1765,6 @@ class FullyShardedDataParallel(nn.Module):
 
         if self.fp32_reduce_scatter:
             if self.optimize_backward_concat:
-                # Flatten and concat the accumulated fp32 grads
-                # and assign them to param.unsharded_main_grad
-                # for idx in range(len(self._fsdp_wrapped_module.fp32_grads)):
-                #     self._fsdp_wrapped_module.fp32_grads[idx] = torch.flatten(self._fsdp_wrapped_module.fp32_grads[idx])
-                # param.unsharded_main_grad = torch.cat([grad for grad in self._fsdp_wrapped_module.fp32_grads])
-                
                 param.unsharded_main_grad = self._fsdp_wrapped_module.fp32_grads
                 # Clean up accumulated grads between data batches
                 self._fsdp_wrapped_module.fp32_grads = None

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -382,10 +382,14 @@ class FlattenParamsWrapper(nn.Module):
     def _grad_accumulation_hook(
         self,
         grad,
-        #param_index,
         start,
         end,
     ):
+        """
+            start: int, the starting index(inclusive) of the grad of this parameter in self.fp32_grads
+            end: int, the ending index(exclusive) of the grad of this parameter in self.fp32_grads
+        """
+
         assert self.fp32_grads is not None
         self.fp32_grads[start:end].add_(grad.flatten())
         return grad
@@ -430,6 +434,7 @@ class FlattenParamsWrapper(nn.Module):
             param_views.append(p)
 
         if self.optimize_backward_concat and self.fp32_grads is None:
+            # Allocate GPU memory for flattened fp32 grad accumulation 
             total_numels = sum([torch.numel(p) for p in param_views])
             self.fp32_grads = torch.zeros(total_numels, dtype=torch.float32, device=torch.cuda.current_device())
 

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -431,7 +431,7 @@ class FlattenParamsWrapper(nn.Module):
 
         if self.optimize_backward_concat and self.fp32_grads is None:
             total_numels = sum([torch.numel(p) for p in param_views])
-            self.fp32_grads = torch.zeros(total_numels, dtype=torch.float32).cuda()
+            self.fp32_grads = torch.zeros(total_numels, dtype=torch.float32, device=torch.cuda.current_device())
 
 
         # Save param views for easy access if anyone still wants to access

--- a/fairscale/nn/misc/flatten_params_wrapper.py
+++ b/fairscale/nn/misc/flatten_params_wrapper.py
@@ -153,7 +153,6 @@ class FlattenParamsWrapper(nn.Module):
             If True, only let backward pass propagate to the corresponding FSDP.params, which will
             invoke the FSDP._post_backward_hook() and concat() op, when _require_backward_grad_sync
             is True (e.g. last microbatch)
-            NOTE: this likely will incur more GPU memory usage
     """
 
     def __init__(


### PR DESCRIPTION
Avoid extra memory usage caused by concat(), directly allocate flattened fp32 grads and perform fp32 grad accumulation for individual parameters on specific slice within the flattened tensor.

# Local test
## Deterministic numerical test

**baseline, optimize_backward_concat=False**
```
 NVTE_TORCH_COMPILE=0 NVTE_DISABLE_NVRTC=1 CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1 torchrun --master_port 1024 --nproc_per_node=8 tra
in.py --dump_dir /tmp/chriscai/xldumps --model_parallel_size 4 --seq_len=8192 --gpu_check_level=-1 --steps=5 --log_all_ste
ps=True --profile_freq=10 --dump_profile_traces=True --model.n_layers=1 --reshard_after_forward=False --batch_size=128 --m
odel.efficient_attn=flash --model.attn_bias_type=causal --model.layer_ckpt=none --model=llama3_kv8 --model.sequence_parall
el=True --mem_snapshot_stop_step 5 --log_all_steps=True --log_freq=1 --model.use_te_layers=True --optim.use_fp32_copy_opti
m=True --use_microbatching=True --optimize_backward_concat=False --mem_snapshot_max_entries=100000 --model.use_fp8=True
```
https://www.internalfb.com/intern/paste/P1404601998/

```
AVG loss: 10.8708400726318359
```

**optimize_backward_concat=True**

https://www.internalfb.com/intern/paste/P1404700768/

```
AVG loss: 10.8708400726318359
```

## memory usage


**baseline, optimize_backward_concat=False**

```
NVTE_TORCH_COMPILE=0 NVTE_DISABLE_NVRTC=1 CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1 PYTHONPATH=~/benchmark/fairscale_repos/fairscale/
torchrun --master_port 1024 --nproc_per_node=8 train.py --dump_dir /tmp/chriscai/xldumps --model_parallel_size 4 --seq_len=1024 --gpu_check_level=-1 --steps=10 --log_all_steps=True --profile_freq=10 --dump_profile_traces=True --model.n_layers=1
 --reshard_after_forward=False --batch_size=128 --model.efficient_attn=flash --model.attn_bias_type=causal --model.layer_ckpt=none --model=llama3_kv8 --model.sequence_parallel=True --mem_snapshot_stop_step 3 --log_all_steps=True --log_freq=1 --
model.use_te_layers=True --optim.use_fp32_copy_optim=True --use_microbatching=True --optimize_backward_concat=False --mem_snapshot_max_entries=500000 --model.use_fp8=False
```

https://www.internalfb.com/intern/paste/P1404611094/

```
torch_cuda_max_reserved: 15.1GB
```

**optimize_backward_concat=True, before optimization**


```
NVTE_TORCH_COMPILE=0 NVTE_DISABLE_NVRTC=1 CRYPTOGRAPHY_OPENSSL_NO_LEGACY=1 PYTHONPATH=~/benchmark/fairscale_repos/fairscale/
torchrun --master_port 1024 --nproc_per_node=8 train.py --dump_dir /tmp/chriscai/xldumps --model_parallel_size 4 --seq_len=1024 --gpu_check_level=-1 --steps=10 --log_all_steps=True --profile_freq=10 --dump_profile_traces=True --model.n_layers=1
 --reshard_after_forward=False --batch_size=128 --model.efficient_attn=flash --model.attn_bias_type=causal --model.layer_ckpt=none --model=llama3_kv8 --model.sequence_parallel=True --mem_snapshot_stop_step 3 --log_all_steps=True --log_freq=1 --
model.use_te_layers=True --optim.use_fp32_copy_optim=True --use_microbatching=True --optimize_backward_concat=True --mem_snapshot_max_entries=500000 --model.use_fp8=False
```


https://www.internalfb.com/intern/paste/P1404620340/


```
torch_cuda_max_reserved: 17.4GB
```



**optimize_backward_concat=True, after optimization**


https://www.internalfb.com/intern/paste/P1404655599/

```
torch_cuda_max_reserved: 15.1GB (-13.2%)

```


# E2E MAST 

**model= llama3_kv8_balance2_ffn12, n_layers = 1, non-PP microbatching, bs = 128, fp8, TP=4, CP = 1, seq_len=1024**



**baseline, optimize_backward_concat=False**
https://www.internalfb.com/mlhub/pipelines/runs/mast/conda-xlformers-c52vf7

<img width="517" alt="Screenshot 2024-06-09 at 5 14 34 PM" src="https://github.com/facebookresearch/fairscale/assets/6046382/1b91995d-c100-4240-b76f-32f506683988">


** tflops/s = ~382**
<img width="377" alt="Screenshot 2024-06-09 at 5 15 31 PM" src="https://github.com/facebookresearch/fairscale/assets/6046382/23a8b122-23e7-4a2c-9fce-ff8a51b0f597">

trace: https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/trace.1149070831916.json.gz&bucket=acadia



**optimize_backward_concat=True before optimization**

https://www.internalfb.com/mlhub/pipelines/runs/mast/conda-xlformers-pdtcx1d5
<img width="517" alt="Screenshot 2024-06-09 at 5 16 54 PM" src="https://github.com/facebookresearch/fairscale/assets/6046382/4b7127b9-b05c-446e-a546-7048108dec55">

https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/trace.24449323379469.json.gz&bucket=acadia

**optimize_backward_concat=True after optimization**

https://www.internalfb.com/mlhub/pipelines/runs/mast/conda-xlformers-ghg1f57z
<img width="507" alt="Screenshot 2024-06-09 at 5 18 28 PM" src="https://github.com/facebookresearch/fairscale/assets/6046382/46e38a0e-ec15-4d13-820b-d8bcc7000ecc">


** tflops/s = ~440 (+15%)**
<img width="368" alt="Screenshot 2024-06-09 at 5 19 03 PM" src="https://github.com/facebookresearch/fairscale/assets/6046382/c40d249f-f79f-4d71-893d-866dc0f7b0df">

trace: https://www.internalfb.com/intern/perfdoctor/trace_view?filepath=tree/traces/trace.17125783820625.json.gz&bucket=acadia







